### PR TITLE
Add unit testing for scaling & non scaling filters

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,9 @@ bloomfilter = "1.0.13"
 lazy_static = "1.4.0"
 libc = "0.2"
 
+[dev-dependencies]
+rand = "0.8"
+
 [lib]
 crate-type = ["cdylib"]
 name = "valkey_bloom"

--- a/src/bloom/command_handler.rs
+++ b/src/bloom/command_handler.rs
@@ -394,7 +394,7 @@ pub fn bloom_filter_info(ctx: &Context, input_args: &[ValkeyString]) -> ValkeyRe
                 .as_str()
             {
                 "CAPACITY" => Ok(ValkeyValue::Integer(val.capacity())),
-                "SIZE" => Ok(ValkeyValue::Integer(val.get_memory_usage() as i64)),
+                "SIZE" => Ok(ValkeyValue::Integer(val.memory_usage() as i64)),
                 "FILTERS" => Ok(ValkeyValue::Integer(val.filters.len() as i64)),
                 "ITEMS" => Ok(ValkeyValue::Integer(val.cardinality())),
                 "EXPANSION" => {
@@ -411,7 +411,7 @@ pub fn bloom_filter_info(ctx: &Context, input_args: &[ValkeyString]) -> ValkeyRe
                 ValkeyValue::SimpleStringStatic("Capacity"),
                 ValkeyValue::Integer(val.capacity()),
                 ValkeyValue::SimpleStringStatic("Size"),
-                ValkeyValue::Integer(val.get_memory_usage() as i64),
+                ValkeyValue::Integer(val.memory_usage() as i64),
                 ValkeyValue::SimpleStringStatic("Number of filters"),
                 ValkeyValue::Integer(val.filters.len() as i64),
                 ValkeyValue::SimpleStringStatic("Number of items inserted"),

--- a/src/configs.rs
+++ b/src/configs.rs
@@ -20,5 +20,5 @@ lazy_static! {
 }
 
 /// Constants
-pub const TIGHTENING_RATIO: f32 = 0.8515625;
+pub const TIGHTENING_RATIO: f32 = 0.5;
 pub const MAX_FILTERS_PER_OBJ: i32 = i32::MAX;

--- a/src/wrapper/bloom_callback.rs
+++ b/src/wrapper/bloom_callback.rs
@@ -69,7 +69,7 @@ pub unsafe extern "C" fn bloom_free(value: *mut c_void) {
 /// Compute the memory usage for a bloom object.
 pub unsafe extern "C" fn bloom_mem_usage(value: *const c_void) -> usize {
     let item = &*value.cast::<BloomFilterType>();
-    item.get_memory_usage()
+    item.memory_usage()
 }
 
 /// # Safety


### PR DESCRIPTION
PR to add unit testing of the BloomFilter structure's behavior in case of scaling and non scaling filter and also to test for false positive rate correctness. Non scaling and scaling filters are created at scale to filled with items to capacity and exists operations are used to validate fp_rate correctness. 

