### PR TITLE
add bf.load to support bloom filter aofrewrite.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,9 +15,11 @@ homepage = "https://github.com/valkey-io/valkey-bloom"
 valkey-module = "0.1.2"
 valkey-module-macros = "0"
 linkme = "0"
-bloomfilter = "1.0.13"
+bloomfilter = { version = "1.0.13", features = ["serde"] }
 lazy_static = "1.4.0"
 libc = "0.2"
+serde = { version = "1.0", features = ["derive"] }
+bincode = "1.3"
 
 [dev-dependencies]
 rand = "0.8"

--- a/README.md
+++ b/README.md
@@ -16,6 +16,8 @@ BF.CARD
 BF.RESERVE
 BF.INFO
 BF.INSERT
+BF.LOAD
+BF.DUMP
 ```
 
 Build instructions for Linux.

--- a/README.md
+++ b/README.md
@@ -17,7 +17,6 @@ BF.RESERVE
 BF.INFO
 BF.INSERT
 BF.LOAD
-BF.DUMP
 ```
 
 Build instructions for Linux.

--- a/src/bloom/command_handler.rs
+++ b/src/bloom/command_handler.rs
@@ -490,3 +490,79 @@ pub fn bloom_filter_info(ctx: &Context, input_args: &[ValkeyString]) -> ValkeyRe
         _ => Err(ValkeyError::Str(utils::NOT_FOUND)),
     }
 }
+
+pub fn bloom_filter_load(ctx: &Context, input_args: &[ValkeyString]) -> ValkeyResult {
+    let argc = input_args.len();
+    if argc != 3 {
+        return Err(ValkeyError::WrongArity);
+    }
+    let mut idx = 1;
+    let filter_name = &input_args[idx];
+    idx += 1;
+    let value = &input_args[idx];
+    // find filter
+    let filter_key = ctx.open_key_writable(filter_name);
+
+    let filter = match filter_key.get_value::<BloomFilterType>(&BLOOM_FILTER_TYPE) {
+        Ok(v) => v,
+        Err(_) => {
+            // error
+            return Err(ValkeyError::Str(utils::ERROR));
+        }
+    };
+    match filter {
+        Some(_) => {
+            // if bloom exists, return exists error.
+            Err(ValkeyError::Str(utils::KEY_EXISTS))
+        }
+        None => {
+            // if filter not exists, create it.
+            let hex = value.to_vec();
+            let bf = match BloomFilterType::decoder_bloom_filter(&hex) {
+                Ok(v) => v,
+                Err(_) => {
+                    return Err(ValkeyError::Str(utils::ERROR));
+                }
+            };
+            match filter_key.set_value(&BLOOM_FILTER_TYPE, bf) {
+                Ok(_) => {
+                    replicate_and_notify_events(ctx, filter_name, false, true);
+                    VALKEY_OK
+                }
+                Err(_) => Err(ValkeyError::Str(utils::ERROR)),
+            }
+        }
+    }
+}
+
+pub fn bloom_filter_dump(ctx: &Context, input_args: &[ValkeyString]) -> ValkeyResult {
+    let argc = input_args.len();
+    if argc != 2 {
+        return Err(ValkeyError::WrongArity);
+    }
+    let idx = 1;
+    let filter_name = &input_args[idx];
+    // find filter
+    let filter_key = ctx.open_key_writable(filter_name);
+
+    let value = match filter_key.get_value::<BloomFilterType>(&BLOOM_FILTER_TYPE) {
+        Ok(v) => v,
+        Err(_) => {
+            // not found return error
+            return Err(ValkeyError::Str(utils::INVALID_ARGUMENT));
+        }
+    };
+    match value {
+        Some(bf) => {
+            let hex = match bf.encoder_bloom_filter() {
+                Ok(val) => val,
+                Err(err) => {
+                    println!("encode bloom filter failed. {err}");
+                    return Err(ValkeyError::Str(utils::ERROR));
+                }
+            };
+            Ok(ValkeyValue::StringBuffer(hex))
+        }
+        None => Ok(ValkeyValue::Null),
+    }
+}

--- a/src/bloom/command_handler.rs
+++ b/src/bloom/command_handler.rs
@@ -518,10 +518,11 @@ pub fn bloom_filter_load(ctx: &Context, input_args: &[ValkeyString]) -> ValkeyRe
         None => {
             // if filter not exists, create it.
             let hex = value.to_vec();
-            let bf = match BloomFilterType::decode_bloom_filter(&hex) {
+            let validate_size_limit = !ctx.get_flags().contains(ContextFlags::REPLICATED);
+            let bf = match BloomFilterType::decode_bloom_filter(&hex, validate_size_limit) {
                 Ok(v) => v,
-                Err(_) => {
-                    return Err(ValkeyError::Str(utils::ERROR));
+                Err(err) => {
+                    return Err(ValkeyError::Str(err.as_str()));
                 }
             };
             match filter_key.set_value(&BLOOM_FILTER_TYPE, bf) {

--- a/src/bloom/command_handler.rs
+++ b/src/bloom/command_handler.rs
@@ -518,7 +518,7 @@ pub fn bloom_filter_load(ctx: &Context, input_args: &[ValkeyString]) -> ValkeyRe
         None => {
             // if filter not exists, create it.
             let hex = value.to_vec();
-            let bf = match BloomFilterType::decoder_bloom_filter(&hex) {
+            let bf = match BloomFilterType::decode_bloom_filter(&hex) {
                 Ok(v) => v,
                 Err(_) => {
                     return Err(ValkeyError::Str(utils::ERROR));
@@ -532,37 +532,5 @@ pub fn bloom_filter_load(ctx: &Context, input_args: &[ValkeyString]) -> ValkeyRe
                 Err(_) => Err(ValkeyError::Str(utils::ERROR)),
             }
         }
-    }
-}
-
-pub fn bloom_filter_dump(ctx: &Context, input_args: &[ValkeyString]) -> ValkeyResult {
-    let argc = input_args.len();
-    if argc != 2 {
-        return Err(ValkeyError::WrongArity);
-    }
-    let idx = 1;
-    let filter_name = &input_args[idx];
-    // find filter
-    let filter_key = ctx.open_key_writable(filter_name);
-
-    let value = match filter_key.get_value::<BloomFilterType>(&BLOOM_FILTER_TYPE) {
-        Ok(v) => v,
-        Err(_) => {
-            // not found return error
-            return Err(ValkeyError::Str(utils::INVALID_ARGUMENT));
-        }
-    };
-    match value {
-        Some(bf) => {
-            let hex = match bf.encoder_bloom_filter() {
-                Ok(val) => val,
-                Err(err) => {
-                    println!("encode bloom filter failed. {err}");
-                    return Err(ValkeyError::Str(utils::ERROR));
-                }
-            };
-            Ok(ValkeyValue::StringBuffer(hex))
-        }
-        None => Ok(ValkeyValue::Null),
     }
 }

--- a/src/bloom/data_type.rs
+++ b/src/bloom/data_type.rs
@@ -12,9 +12,9 @@ use std::os::raw::c_int;
 use valkey_module::native_types::ValkeyType;
 use valkey_module::{logging, raw};
 
-use super::utils::BLOOM_TYPE_VERSION;
-
-use super::utils::BLOOM_TYPE_VERSION;
+/// Use for decode an encode `BloomFilterType`.
+/// This value must increased when `BloomFilterType` struct change.
+pub const BLOOM_TYPE_VERSION: u8 = 1;
 
 const BLOOM_FILTER_TYPE_ENCODING_VERSION: i32 = 1;
 

--- a/src/bloom/data_type.rs
+++ b/src/bloom/data_type.rs
@@ -12,7 +12,7 @@ use std::os::raw::c_int;
 use valkey_module::native_types::ValkeyType;
 use valkey_module::{logging, raw};
 
-/// Use for decode an encode `BloomFilterType`.
+/// Used for decoding and encoding `BloomFilterType`. Currently used in AOF Rewrite.
 /// This value must increased when `BloomFilterType` struct change.
 pub const BLOOM_TYPE_VERSION: u8 = 1;
 
@@ -25,7 +25,6 @@ pub static BLOOM_FILTER_TYPE: ValkeyType = ValkeyType::new(
         version: raw::REDISMODULE_TYPE_METHOD_VERSION as u64,
         rdb_load: Some(bloom_callback::bloom_rdb_load),
         rdb_save: Some(bloom_callback::bloom_rdb_save),
-        // TODO
         aof_rewrite: Some(bloom_callback::bloom_aof_rewrite),
 
         mem_usage: Some(bloom_callback::bloom_mem_usage),

--- a/src/bloom/data_type.rs
+++ b/src/bloom/data_type.rs
@@ -12,6 +12,10 @@ use std::os::raw::c_int;
 use valkey_module::native_types::ValkeyType;
 use valkey_module::{logging, raw};
 
+use super::utils::BLOOM_TYPE_VERSION;
+
+use super::utils::BLOOM_TYPE_VERSION;
+
 const BLOOM_FILTER_TYPE_ENCODING_VERSION: i32 = 1;
 
 pub static BLOOM_FILTER_TYPE: ValkeyType = ValkeyType::new(
@@ -22,7 +26,7 @@ pub static BLOOM_FILTER_TYPE: ValkeyType = ValkeyType::new(
         rdb_load: Some(bloom_callback::bloom_rdb_load),
         rdb_save: Some(bloom_callback::bloom_rdb_save),
         // TODO
-        aof_rewrite: None,
+        aof_rewrite: Some(bloom_callback::bloom_aof_rewrite),
 
         mem_usage: Some(bloom_callback::bloom_mem_usage),
         // TODO
@@ -117,6 +121,7 @@ impl ValkeyDataType for BloomFilterType {
         );
         BLOOM_NUM_OBJECTS.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
         let item = BloomFilterType {
+            version: BLOOM_TYPE_VERSION,
             expansion: expansion as u32,
             fp_rate,
             filters,

--- a/src/bloom/data_type.rs
+++ b/src/bloom/data_type.rs
@@ -121,7 +121,6 @@ impl ValkeyDataType for BloomFilterType {
         );
         BLOOM_NUM_OBJECTS.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
         let item = BloomFilterType {
-            version: BLOOM_TYPE_VERSION,
             expansion: expansion as u32,
             fp_rate,
             filters,

--- a/src/bloom/utils.rs
+++ b/src/bloom/utils.rs
@@ -809,7 +809,6 @@ mod tests {
         let _ = bf.add_item(key.as_bytes(), true);
         let origin_expansion = bf.expansion;
         let origin_fp_rate = bf.fp_rate;
-        let origin_size = configs::BLOOM_MEMORY_LIMIT_PER_FILTER.load(Ordering::SeqCst);
         // unsupoort expansion
         bf.expansion = 0;
 
@@ -837,14 +836,14 @@ mod tests {
         );
         bf.fp_rate = origin_fp_rate;
 
-        // 3. unsupport filter size:
-        configs::BLOOM_MEMORY_LIMIT_PER_FILTER.store(1, Ordering::SeqCst);
-        let vec = bf.encode_bloom_filter().unwrap();
+        // 3. build a larger than 64mb filter
+        let extra_large_filter =
+            BloomFilterType::new_reserved(0.01_f64, 57000000, 2, false).unwrap();
+        let vec = extra_large_filter.encode_bloom_filter().unwrap();
         // should return error
         assert_eq!(
             BloomFilterType::decode_bloom_filter(&vec, true).err(),
             Some(BloomError::ExceedsMaxBloomSize)
         );
-        configs::BLOOM_MEMORY_LIMIT_PER_FILTER.store(origin_size, Ordering::SeqCst);
     }
 }

--- a/src/bloom/utils.rs
+++ b/src/bloom/utils.rs
@@ -1,5 +1,6 @@
 use crate::{configs, metrics};
 use bloomfilter;
+use serde::{Deserialize, Serialize};
 use std::{mem, sync::atomic::Ordering};
 
 /// KeySpace Notification Events
@@ -21,6 +22,10 @@ pub const MAX_NUM_SCALING_FILTERS: &str = "ERR bloom object reached max number o
 pub const UNKNOWN_ARGUMENT: &str = "ERR unknown argument received";
 pub const EXCEEDS_MAX_BLOOM_SIZE: &str =
     "ERR operation results in filter allocation exceeding size limit";
+pub const INVALID_ARGUMENT: &str = "ERR invalid argument received";
+pub const KEY_EXISTS: &str = "-BUSYKEY Target key name already exists.";
+
+pub const BLOOM_TYPE_VERSION: u8 = 1;
 
 #[derive(Debug, PartialEq)]
 pub enum BloomError {
@@ -42,7 +47,9 @@ impl BloomError {
 /// The BloomFilterType structure. 40 bytes.
 /// Can contain one or more filters.
 /// This is a generic top level structure which is not coupled to any bloom crate.
+#[derive(Serialize, Deserialize)]
 pub struct BloomFilterType {
+    pub version: u8,
     pub expansion: u32,
     pub fp_rate: f64,
     pub filters: Vec<BloomFilter>,
@@ -71,6 +78,7 @@ impl BloomFilterType {
         let bloom = BloomFilter::new(fp_rate, capacity);
         let filters = vec![bloom];
         let bloom = BloomFilterType {
+            version: BLOOM_TYPE_VERSION,
             expansion,
             fp_rate,
             filters,
@@ -91,6 +99,7 @@ impl BloomFilterType {
             filters.push(new_filter);
         }
         BloomFilterType {
+            version: BLOOM_TYPE_VERSION,
             expansion: from_bf.expansion,
             fp_rate: from_bf.fp_rate,
             filters,
@@ -188,6 +197,41 @@ impl BloomFilterType {
         }
         Ok(0)
     }
+
+    pub fn encoder_bloom_filter(&self) -> Result<Vec<u8>, Box<bincode::ErrorKind>> {
+        let vec = bincode::serialize(self)?;
+        Ok(vec)
+    }
+
+    pub fn decoder_bloom_filter(
+        decoded_bytes: &[u8],
+    ) -> Result<BloomFilterType, Box<dyn std::error::Error>> {
+        if decoded_bytes.is_empty() {
+            return Err(bincode::Error::new(bincode::ErrorKind::Custom(
+                String::from("invalid data length"),
+            )));
+        }
+        let version = decoded_bytes[0];
+        match version {
+            1 => {
+                // always use new version to init bloomFilterType.
+                // This is to ensure that the new fields can be recognized when the object is serialized and deserialized in the future.
+                let (_, expansion, fp_rate, filters): (u8, u32, f32, Vec<BloomFilter>) =
+                    bincode::deserialize(decoded_bytes)?;
+                let filter = BloomFilterType {
+                    version: BLOOM_TYPE_VERSION,
+                    expansion,
+                    fp_rate,
+                    filters,
+                };
+                Ok(filter)
+            }
+
+            _ => Err(bincode::Error::new(bincode::ErrorKind::Custom(
+                String::from("not support version"),
+            ))),
+        }
+    }
 }
 
 /// Structure representing a single bloom filter. 200 Bytes.
@@ -196,6 +240,7 @@ impl BloomFilterType {
 /// we have a limit on the memory usage of a `BloomFilter` to be 64MB.
 /// Based on this, we expect the number of items on the `BloomFilter` to be
 /// well within the u32::MAX limit.
+#[derive(Serialize, Deserialize)]
 pub struct BloomFilter {
     pub bloom: bloomfilter::Bloom<[u8]>,
     pub num_items: u32,
@@ -620,5 +665,36 @@ mod tests {
         assert!(!BloomFilter::validate_size(capacity, 0.001_f64));
         let result2 = BloomFilterType::new_reserved(0.001_f64, capacity, 1, true);
         assert_eq!(result2.err(), Some(BloomError::ExceedsMaxBloomSize));
+    }
+
+    #[test]
+    fn test_bf_encoder_and_decoder() {
+        // arrange: prepare bloom filter
+        let mut bf = BloomFilterType::new_reserved(0.5_f32, 1000_u32, 2);
+        let key = "key";
+        let _ = bf.add_item(key.as_bytes());
+
+        // action
+        let encoder_result = bf.encoder_bloom_filter();
+
+        // assert
+        // encoder sucess
+        assert!(encoder_result.is_ok());
+        let vec = encoder_result.unwrap();
+
+        // assert decode:
+        let new_bf_result = BloomFilterType::decoder_bloom_filter(&vec);
+
+        assert!(new_bf_result.is_ok());
+
+        let new_bf = new_bf_result.unwrap();
+
+        // verify new_bf and bf
+        assert_eq!(bf.fp_rate, new_bf.fp_rate);
+        assert_eq!(bf.expansion, new_bf.expansion);
+        assert_eq!(bf.capacity(), new_bf.capacity());
+
+        // contains key
+        assert!(new_bf.item_exists(key.as_bytes()));
     }
 }

--- a/src/bloom/utils.rs
+++ b/src/bloom/utils.rs
@@ -3,6 +3,8 @@ use bloomfilter;
 use serde::{Deserialize, Serialize};
 use std::{mem, sync::atomic::Ordering};
 
+use super::data_type::BLOOM_TYPE_VERSION;
+
 /// KeySpace Notification Events
 pub const ADD_EVENT: &str = "bloom.add";
 pub const RESERVE_EVENT: &str = "bloom.reserve";
@@ -24,14 +26,18 @@ pub const EXCEEDS_MAX_BLOOM_SIZE: &str =
     "ERR operation results in filter allocation exceeding size limit";
 pub const INVALID_ARGUMENT: &str = "ERR invalid argument received";
 pub const KEY_EXISTS: &str = "-BUSYKEY Target key name already exists.";
-
-pub const BLOOM_TYPE_VERSION: u8 = 1;
+pub const ENCODE_BLOOM_FILTER_FAILED: &str = "ERR encode bloom filter failed.";
+pub const DECODE_BLOOM_FILTER_FAILED: &str = "ERR decode bloom filter failed.";
+pub const DECODE_NOT_SUPPORT_VERSION: &str = "ERR decode bloom filter failed. not support version.";
 
 #[derive(Debug, PartialEq)]
 pub enum BloomError {
     NonScalingFilterFull,
     MaxNumScalingFilters,
     ExceedsMaxBloomSize,
+    EncodeBloomFilterFailed,
+    DecodeBloomFilterFailed,
+    DecodeNotSupportVersion,
 }
 
 impl BloomError {
@@ -40,6 +46,9 @@ impl BloomError {
             BloomError::NonScalingFilterFull => NON_SCALING_FILTER_FULL,
             BloomError::MaxNumScalingFilters => MAX_NUM_SCALING_FILTERS,
             BloomError::ExceedsMaxBloomSize => EXCEEDS_MAX_BLOOM_SIZE,
+            BloomError::EncodeBloomFilterFailed => ENCODE_BLOOM_FILTER_FAILED,
+            BloomError::DecodeBloomFilterFailed => DECODE_BLOOM_FILTER_FAILED,
+            BloomError::DecodeNotSupportVersion => DECODE_NOT_SUPPORT_VERSION,
         }
     }
 }
@@ -198,26 +207,30 @@ impl BloomFilterType {
         Ok(0)
     }
 
-    pub fn encoder_bloom_filter(&self) -> Result<Vec<u8>, Box<bincode::ErrorKind>> {
-        let vec = bincode::serialize(self)?;
-        Ok(vec)
+    /// Serializes bloomFilter to a byte array.
+    pub fn encode_bloom_filter(&self) -> Result<Vec<u8>, BloomError> {
+        match bincode::serialize(self) {
+            Ok(vec) => Ok(vec),
+            Err(_) => Err(BloomError::EncodeBloomFilterFailed),
+        }
     }
 
-    pub fn decoder_bloom_filter(
-        decoded_bytes: &[u8],
-    ) -> Result<BloomFilterType, Box<dyn std::error::Error>> {
+    /// Deserialize a byte array to bloom filter.
+    /// We will need to handle any current or previous version and deserializing the bytes into a bloom object of the running Module's current version `BLOOM_TYPE_VERSION`.
+    pub fn decode_bloom_filter(decoded_bytes: &[u8]) -> Result<BloomFilterType, BloomError> {
         if decoded_bytes.is_empty() {
-            return Err(bincode::Error::new(bincode::ErrorKind::Custom(
-                String::from("invalid data length"),
-            )));
+            return Err(BloomError::DecodeBloomFilterFailed);
         }
         let version = decoded_bytes[0];
         match version {
             1 => {
                 // always use new version to init bloomFilterType.
                 // This is to ensure that the new fields can be recognized when the object is serialized and deserialized in the future.
-                let (_, expansion, fp_rate, filters): (u8, u32, f32, Vec<BloomFilter>) =
-                    bincode::deserialize(decoded_bytes)?;
+                let (_, expansion, fp_rate, filters): (u8, u32, f64, Vec<BloomFilter>) =
+                    match bincode::deserialize(decoded_bytes) {
+                        Ok(_v) => _v,
+                        Err(_) => return Err(BloomError::DecodeBloomFilterFailed),
+                    };
                 let filter = BloomFilterType {
                     version: BLOOM_TYPE_VERSION,
                     expansion,
@@ -227,9 +240,7 @@ impl BloomFilterType {
                 Ok(filter)
             }
 
-            _ => Err(bincode::Error::new(bincode::ErrorKind::Custom(
-                String::from("not support version"),
-            ))),
+            _ => Err(BloomError::DecodeNotSupportVersion),
         }
     }
 }
@@ -668,14 +679,14 @@ mod tests {
     }
 
     #[test]
-    fn test_bf_encoder_and_decoder() {
+    fn test_bf_encode_and_decode() {
         // arrange: prepare bloom filter
-        let mut bf = BloomFilterType::new_reserved(0.5_f32, 1000_u32, 2);
+        let mut bf = BloomFilterType::new_reserved(0.5_f64, 1000_u32, 2, true).unwrap();
         let key = "key";
-        let _ = bf.add_item(key.as_bytes());
+        let _ = bf.add_item(key.as_bytes(), true);
 
         // action
-        let encoder_result = bf.encoder_bloom_filter();
+        let encoder_result = bf.encode_bloom_filter();
 
         // assert
         // encoder sucess
@@ -683,7 +694,7 @@ mod tests {
         let vec = encoder_result.unwrap();
 
         // assert decode:
-        let new_bf_result = BloomFilterType::decoder_bloom_filter(&vec);
+        let new_bf_result = BloomFilterType::decode_bloom_filter(&vec);
 
         assert!(new_bf_result.is_ok());
 
@@ -696,5 +707,47 @@ mod tests {
 
         // contains key
         assert!(new_bf.item_exists(key.as_bytes()));
+    }
+
+    #[test]
+    fn test_bf_decode_when_unsupported_version_should_failed() {
+        // arrange: prepare bloom filter
+        let mut bf = BloomFilterType::new_reserved(0.5_f64, 1000_u32, 2, true).unwrap();
+        let key = "key";
+        let _ = bf.add_item(key.as_bytes(), true).unwrap();
+
+        let encoder_result = bf.encode_bloom_filter();
+        assert!(encoder_result.is_ok());
+
+        // 1. unsupport version should return error
+        let mut vec = encoder_result.unwrap();
+        vec[0] = 10;
+
+        // assert decode:
+        // should return error
+        assert_eq!(
+            BloomFilterType::decode_bloom_filter(&vec).err(),
+            Some(BloomError::DecodeNotSupportVersion)
+        );
+    }
+
+    #[test]
+    fn test_bf_decode_when_bytes_is_empty_should_failed() {
+        // arrange: prepare bloom filter
+        let mut bf = BloomFilterType::new_reserved(0.5_f64, 1000_u32, 2, true).unwrap();
+        let key = "key";
+        let _ = bf.add_item(key.as_bytes(), true);
+
+        let encoder_result = bf.encode_bloom_filter();
+        assert!(encoder_result.is_ok());
+
+        // 1. unsupport version should return error
+        let vec: Vec<u8> = Vec::new();
+        // assert decode:
+        // should return error
+        assert_eq!(
+            BloomFilterType::decode_bloom_filter(&vec).err(),
+            Some(BloomError::DecodeBloomFilterFailed)
+        );
     }
 }

--- a/src/bloom/utils.rs
+++ b/src/bloom/utils.rs
@@ -1,4 +1,7 @@
-use crate::{configs, metrics};
+use crate::{
+    configs::{self, BLOOM_FP_RATE_MAX, BLOOM_FP_RATE_MIN},
+    metrics,
+};
 use bloomfilter;
 use serde::{Deserialize, Serialize};
 use std::{mem, sync::atomic::Ordering};
@@ -24,11 +27,11 @@ pub const MAX_NUM_SCALING_FILTERS: &str = "ERR bloom object reached max number o
 pub const UNKNOWN_ARGUMENT: &str = "ERR unknown argument received";
 pub const EXCEEDS_MAX_BLOOM_SIZE: &str =
     "ERR operation results in filter allocation exceeding size limit";
-pub const INVALID_ARGUMENT: &str = "ERR invalid argument received";
 pub const KEY_EXISTS: &str = "-BUSYKEY Target key name already exists.";
 pub const ENCODE_BLOOM_FILTER_FAILED: &str = "ERR encode bloom filter failed.";
 pub const DECODE_BLOOM_FILTER_FAILED: &str = "ERR decode bloom filter failed.";
-pub const DECODE_NOT_SUPPORT_VERSION: &str = "ERR decode bloom filter failed. not support version.";
+pub const DECODE_UNSUPPORTED_VERSION: &str =
+    "ERR decode bloom filter failed.  Unsupported version.";
 
 #[derive(Debug, PartialEq)]
 pub enum BloomError {
@@ -38,6 +41,7 @@ pub enum BloomError {
     EncodeBloomFilterFailed,
     DecodeBloomFilterFailed,
     DecodeNotSupportVersion,
+    ErrorRateRange,
 }
 
 impl BloomError {
@@ -48,7 +52,8 @@ impl BloomError {
             BloomError::ExceedsMaxBloomSize => EXCEEDS_MAX_BLOOM_SIZE,
             BloomError::EncodeBloomFilterFailed => ENCODE_BLOOM_FILTER_FAILED,
             BloomError::DecodeBloomFilterFailed => DECODE_BLOOM_FILTER_FAILED,
-            BloomError::DecodeNotSupportVersion => DECODE_NOT_SUPPORT_VERSION,
+            BloomError::DecodeNotSupportVersion => DECODE_UNSUPPORTED_VERSION,
+            BloomError::ErrorRateRange => ERROR_RATE_RANGE,
         }
     }
 }
@@ -58,7 +63,6 @@ impl BloomError {
 /// This is a generic top level structure which is not coupled to any bloom crate.
 #[derive(Serialize, Deserialize)]
 pub struct BloomFilterType {
-    pub version: u8,
     pub expansion: u32,
     pub fp_rate: f64,
     pub filters: Vec<BloomFilter>,
@@ -87,7 +91,6 @@ impl BloomFilterType {
         let bloom = BloomFilter::new(fp_rate, capacity);
         let filters = vec![bloom];
         let bloom = BloomFilterType {
-            version: BLOOM_TYPE_VERSION,
             expansion,
             fp_rate,
             filters,
@@ -108,7 +111,6 @@ impl BloomFilterType {
             filters.push(new_filter);
         }
         BloomFilterType {
-            version: BLOOM_TYPE_VERSION,
             expansion: from_bf.expansion,
             fp_rate: from_bf.fp_rate,
             filters,
@@ -210,7 +212,12 @@ impl BloomFilterType {
     /// Serializes bloomFilter to a byte array.
     pub fn encode_bloom_filter(&self) -> Result<Vec<u8>, BloomError> {
         match bincode::serialize(self) {
-            Ok(vec) => Ok(vec),
+            Ok(vec) => {
+                let mut final_vec = Vec::with_capacity(1 + vec.len());
+                final_vec.push(BLOOM_TYPE_VERSION);
+                final_vec.extend(vec);
+                Ok(final_vec)
+            }
             Err(_) => Err(BloomError::EncodeBloomFilterFailed),
         }
     }
@@ -226,18 +233,47 @@ impl BloomFilterType {
             1 => {
                 // always use new version to init bloomFilterType.
                 // This is to ensure that the new fields can be recognized when the object is serialized and deserialized in the future.
-                let (_, expansion, fp_rate, filters): (u8, u32, f64, Vec<BloomFilter>) =
-                    match bincode::deserialize(decoded_bytes) {
-                        Ok(_v) => _v,
-                        Err(_) => return Err(BloomError::DecodeBloomFilterFailed),
+                let (expansion, fp_rate, filters): (u32, f64, Vec<BloomFilter>) =
+                    match bincode::deserialize::<(u32, f64, Vec<BloomFilter>)>(&decoded_bytes[1..])
+                    {
+                        Ok(values) => {
+                            if values.0 == 0 {
+                                return Err(BloomError::NonScalingFilterFull);
+                            }
+                            if values.1 < BLOOM_FP_RATE_MIN || values.1 > BLOOM_FP_RATE_MAX {
+                                return Err(BloomError::ErrorRateRange);
+                            }
+                            if values.2.len() >= configs::MAX_FILTERS_PER_OBJ as usize {
+                                return Err(BloomError::MaxNumScalingFilters);
+                            }
+                            values
+                        }
+                        Err(_) => {
+                            return Err(BloomError::DecodeBloomFilterFailed);
+                        }
                     };
-                let filter = BloomFilterType {
-                    version: BLOOM_TYPE_VERSION,
+                let item = BloomFilterType {
                     expansion,
                     fp_rate,
                     filters,
                 };
-                Ok(filter)
+                // add bloom filter type metrics.
+                metrics::BLOOM_NUM_OBJECTS.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+                metrics::BLOOM_OBJECT_TOTAL_MEMORY_BYTES.fetch_add(
+                    mem::size_of::<BloomFilterType>(),
+                    std::sync::atomic::Ordering::Relaxed,
+                );
+                // add bloom filter metrics.
+                for filter in &item.filters {
+                    metrics::BLOOM_NUM_FILTERS_ACROSS_OBJECTS
+                        .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+                    metrics::BLOOM_OBJECT_TOTAL_MEMORY_BYTES.fetch_add(
+                        filter.number_of_bytes(),
+                        std::sync::atomic::Ordering::Relaxed,
+                    );
+                }
+
+                Ok(item)
             }
 
             _ => Err(BloomError::DecodeNotSupportVersion),
@@ -695,7 +731,6 @@ mod tests {
 
         // assert decode:
         let new_bf_result = BloomFilterType::decode_bloom_filter(&vec);
-
         assert!(new_bf_result.is_ok());
 
         let new_bf = new_bf_result.unwrap();

--- a/src/bloom/utils.rs
+++ b/src/bloom/utils.rs
@@ -1,5 +1,7 @@
 use crate::{
-    configs::{self, BLOOM_FP_RATE_MAX, BLOOM_FP_RATE_MIN},
+    configs::{
+        self, BLOOM_EXPANSION_MAX, BLOOM_EXPANSION_MIN, BLOOM_FP_RATE_MAX, BLOOM_FP_RATE_MIN,
+    },
     metrics,
 };
 use bloomfilter;
@@ -242,7 +244,7 @@ impl BloomFilterType {
                     match bincode::deserialize::<(u32, f64, Vec<BloomFilter>)>(&decoded_bytes[1..])
                     {
                         Ok(values) => {
-                            if values.0 == 0 {
+                            if !(BLOOM_EXPANSION_MIN..=BLOOM_EXPANSION_MAX).contains(&values.0) {
                                 return Err(BloomError::BadExpansion);
                             }
                             if !(values.1 > BLOOM_FP_RATE_MIN && values.1 < BLOOM_FP_RATE_MAX) {
@@ -813,12 +815,20 @@ mod tests {
         bf.expansion = 0;
 
         let encoder_result = bf.encode_bloom_filter();
-        assert!(encoder_result.is_ok());
 
         // 1. unsupport expansion
         let vec = encoder_result.unwrap();
         // assert decode:
         // should return error
+        assert_eq!(
+            BloomFilterType::decode_bloom_filter(&vec, true).err(),
+            Some(BloomError::BadExpansion)
+        );
+
+        // 1.2 Exceeded the maximum expansion
+        bf.expansion = BLOOM_EXPANSION_MAX + 1;
+
+        let vec = bf.encode_bloom_filter().unwrap();
         assert_eq!(
             BloomFilterType::decode_bloom_filter(&vec, true).err(),
             Some(BloomError::BadExpansion)

--- a/src/bloom/utils.rs
+++ b/src/bloom/utils.rs
@@ -27,7 +27,7 @@ pub const MAX_NUM_SCALING_FILTERS: &str = "ERR bloom object reached max number o
 pub const UNKNOWN_ARGUMENT: &str = "ERR unknown argument received";
 pub const EXCEEDS_MAX_BLOOM_SIZE: &str =
     "ERR operation results in filter allocation exceeding size limit";
-pub const KEY_EXISTS: &str = "-BUSYKEY Target key name already exists.";
+pub const KEY_EXISTS: &str = "BUSYKEY Target key name already exists.";
 pub const ENCODE_BLOOM_FILTER_FAILED: &str = "ERR encode bloom filter failed.";
 pub const DECODE_BLOOM_FILTER_FAILED: &str = "ERR decode bloom filter failed.";
 pub const DECODE_UNSUPPORTED_VERSION: &str =
@@ -40,8 +40,9 @@ pub enum BloomError {
     ExceedsMaxBloomSize,
     EncodeBloomFilterFailed,
     DecodeBloomFilterFailed,
-    DecodeNotSupportVersion,
+    DecodeUnsupportedVersion,
     ErrorRateRange,
+    BadExpansion,
 }
 
 impl BloomError {
@@ -52,8 +53,9 @@ impl BloomError {
             BloomError::ExceedsMaxBloomSize => EXCEEDS_MAX_BLOOM_SIZE,
             BloomError::EncodeBloomFilterFailed => ENCODE_BLOOM_FILTER_FAILED,
             BloomError::DecodeBloomFilterFailed => DECODE_BLOOM_FILTER_FAILED,
-            BloomError::DecodeNotSupportVersion => DECODE_UNSUPPORTED_VERSION,
+            BloomError::DecodeUnsupportedVersion => DECODE_UNSUPPORTED_VERSION,
             BloomError::ErrorRateRange => ERROR_RATE_RANGE,
+            BloomError::BadExpansion => BAD_EXPANSION,
         }
     }
 }
@@ -224,7 +226,10 @@ impl BloomFilterType {
 
     /// Deserialize a byte array to bloom filter.
     /// We will need to handle any current or previous version and deserializing the bytes into a bloom object of the running Module's current version `BLOOM_TYPE_VERSION`.
-    pub fn decode_bloom_filter(decoded_bytes: &[u8]) -> Result<BloomFilterType, BloomError> {
+    pub fn decode_bloom_filter(
+        decoded_bytes: &[u8],
+        validate_size_limit: bool,
+    ) -> Result<BloomFilterType, BloomError> {
         if decoded_bytes.is_empty() {
             return Err(BloomError::DecodeBloomFilterFailed);
         }
@@ -238,13 +243,24 @@ impl BloomFilterType {
                     {
                         Ok(values) => {
                             if values.0 == 0 {
-                                return Err(BloomError::NonScalingFilterFull);
+                                return Err(BloomError::BadExpansion);
                             }
-                            if values.1 < BLOOM_FP_RATE_MIN || values.1 > BLOOM_FP_RATE_MAX {
+                            if !(values.1 > BLOOM_FP_RATE_MIN && values.1 < BLOOM_FP_RATE_MAX) {
                                 return Err(BloomError::ErrorRateRange);
                             }
                             if values.2.len() >= configs::MAX_FILTERS_PER_OBJ as usize {
                                 return Err(BloomError::MaxNumScalingFilters);
+                            }
+                            for _filter in values.2.iter() {
+                                // Reject the request, if the operation will result in creation of a filter of size greater than what is allowed.
+                                if validate_size_limit
+                                    && _filter.number_of_bytes()
+                                        > configs::BLOOM_MEMORY_LIMIT_PER_FILTER
+                                            .load(Ordering::Relaxed)
+                                            as usize
+                                {
+                                    return Err(BloomError::ExceedsMaxBloomSize);
+                                }
                             }
                             values
                         }
@@ -276,7 +292,7 @@ impl BloomFilterType {
                 Ok(item)
             }
 
-            _ => Err(BloomError::DecodeNotSupportVersion),
+            _ => Err(BloomError::DecodeUnsupportedVersion),
         }
     }
 }
@@ -730,8 +746,7 @@ mod tests {
         let vec = encoder_result.unwrap();
 
         // assert decode:
-        let new_bf_result = BloomFilterType::decode_bloom_filter(&vec);
-        assert!(new_bf_result.is_ok());
+        let new_bf_result = BloomFilterType::decode_bloom_filter(&vec, true);
 
         let new_bf = new_bf_result.unwrap();
 
@@ -761,8 +776,8 @@ mod tests {
         // assert decode:
         // should return error
         assert_eq!(
-            BloomFilterType::decode_bloom_filter(&vec).err(),
-            Some(BloomError::DecodeNotSupportVersion)
+            BloomFilterType::decode_bloom_filter(&vec, true).err(),
+            Some(BloomError::DecodeUnsupportedVersion)
         );
     }
 
@@ -776,13 +791,60 @@ mod tests {
         let encoder_result = bf.encode_bloom_filter();
         assert!(encoder_result.is_ok());
 
-        // 1. unsupport version should return error
+        // 1. empty vec should return error
         let vec: Vec<u8> = Vec::new();
         // assert decode:
         // should return error
         assert_eq!(
-            BloomFilterType::decode_bloom_filter(&vec).err(),
+            BloomFilterType::decode_bloom_filter(&vec, true).err(),
             Some(BloomError::DecodeBloomFilterFailed)
         );
+    }
+
+    #[test]
+    fn test_bf_decode_when_bytes_is_exceed_limit_should_failed() {
+        // arrange: prepare bloom filter
+        let mut bf = BloomFilterType::new_reserved(0.5_f64, 1000_u32, 2, true).unwrap();
+        let key = "key";
+        let _ = bf.add_item(key.as_bytes(), true);
+        let origin_expansion = bf.expansion;
+        let origin_fp_rate = bf.fp_rate;
+        let origin_size = configs::BLOOM_MEMORY_LIMIT_PER_FILTER.load(Ordering::SeqCst);
+        // unsupoort expansion
+        bf.expansion = 0;
+
+        let encoder_result = bf.encode_bloom_filter();
+        assert!(encoder_result.is_ok());
+
+        // 1. unsupport expansion
+        let vec = encoder_result.unwrap();
+        // assert decode:
+        // should return error
+        assert_eq!(
+            BloomFilterType::decode_bloom_filter(&vec, true).err(),
+            Some(BloomError::BadExpansion)
+        );
+        // recover
+        bf.expansion = origin_expansion;
+
+        // 2. unsupport fp_rate
+        bf.fp_rate = -0.5;
+        let vec = bf.encode_bloom_filter().unwrap();
+        // should return error
+        assert_eq!(
+            BloomFilterType::decode_bloom_filter(&vec, true).err(),
+            Some(BloomError::ErrorRateRange)
+        );
+        bf.fp_rate = origin_fp_rate;
+
+        // 3. unsupport filter size:
+        configs::BLOOM_MEMORY_LIMIT_PER_FILTER.store(1, Ordering::SeqCst);
+        let vec = bf.encode_bloom_filter().unwrap();
+        // should return error
+        assert_eq!(
+            BloomFilterType::decode_bloom_filter(&vec, true).err(),
+            Some(BloomError::ExceedsMaxBloomSize)
+        );
+        configs::BLOOM_MEMORY_LIMIT_PER_FILTER.store(origin_size, Ordering::SeqCst);
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -60,18 +60,18 @@ fn bloom_insert_command(ctx: &Context, args: Vec<ValkeyString>) -> ValkeyResult 
     command_handler::bloom_filter_insert(ctx, &args)
 }
 
+/// Command handler for:
+/// BF.LOAD <key> data
+fn bloom_load_command(ctx: &Context, args: Vec<ValkeyString>) -> ValkeyResult {
+    command_handler::bloom_filter_load(ctx, &args)
+}
+
 ///
 /// Module Info
 ///
 #[info_command_handler]
 fn info_handler(ctx: &InfoContext, _for_crash_report: bool) -> ValkeyResult<()> {
     bloom_info_handler(ctx)
-}
-
-/// Command handler for:
-/// BF.LOAD <key> data
-fn bloom_load_command(ctx: &Context, args: Vec<ValkeyString>) -> ValkeyResult {
-    command_handler::bloom_filter_load(ctx, &args)
 }
 
 //////////////////////////////////////////////////////

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -74,12 +74,6 @@ fn bloom_load_command(ctx: &Context, args: Vec<ValkeyString>) -> ValkeyResult {
     command_handler::bloom_filter_load(ctx, &args)
 }
 
-/// Command handler for:
-/// BF.DUMP <key>
-fn bloom_dump_command(ctx: &Context, args: Vec<ValkeyString>) -> ValkeyResult {
-    command_handler::bloom_filter_dump(ctx, &args)
-}
-
 //////////////////////////////////////////////////////
 
 valkey_module! {
@@ -100,8 +94,7 @@ valkey_module! {
         ["BF.RESERVE", bloom_reserve_command, "write fast deny-oom", 1, 1, 1],
         ["BF.INFO", bloom_info_command, "readonly fast", 1, 1, 1],
         ["BF.INSERT", bloom_insert_command, "write fast deny-oom", 1, 1, 1],
-        ["BF.LOAD", bloom_load_command, "write fast deny-oom", 1, 1, 1],
-        ["BF.DUMP", bloom_dump_command, "readonly fast", 1, 1, 1]
+        ["BF.LOAD", bloom_load_command, "write fast deny-oom", 1, 1, 1]
     ],
     configurations: [
         i64: [

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -68,6 +68,18 @@ fn info_handler(ctx: &InfoContext, _for_crash_report: bool) -> ValkeyResult<()> 
     bloom_info_handler(ctx)
 }
 
+/// Command handler for:
+/// BF.LOAD <key> data
+fn bloom_load_command(ctx: &Context, args: Vec<ValkeyString>) -> ValkeyResult {
+    command_handler::bloom_filter_load(ctx, &args)
+}
+
+/// Command handler for:
+/// BF.DUMP <key>
+fn bloom_dump_command(ctx: &Context, args: Vec<ValkeyString>) -> ValkeyResult {
+    command_handler::bloom_filter_dump(ctx, &args)
+}
+
 //////////////////////////////////////////////////////
 
 valkey_module! {
@@ -88,6 +100,8 @@ valkey_module! {
         ["BF.RESERVE", bloom_reserve_command, "write fast deny-oom", 1, 1, 1],
         ["BF.INFO", bloom_info_command, "readonly fast", 1, 1, 1],
         ["BF.INSERT", bloom_insert_command, "write fast deny-oom", 1, 1, 1],
+        ["BF.LOAD", bloom_load_command, "write fast deny-oom", 1, 1, 1],
+        ["BF.DUMP", bloom_dump_command, "readonly fast", 1, 1, 1]
     ],
     configurations: [
         i64: [

--- a/src/wrapper/bloom_callback.rs
+++ b/src/wrapper/bloom_callback.rs
@@ -2,6 +2,7 @@ use crate::bloom;
 use crate::bloom::data_type::ValkeyDataType;
 use crate::bloom::utils::BloomFilterType;
 use crate::configs;
+use std::ffi::CString;
 use std::os::raw::{c_char, c_int, c_void};
 use std::ptr::null_mut;
 use std::sync::atomic::Ordering;
@@ -48,6 +49,29 @@ pub unsafe extern "C" fn bloom_rdb_load(
     } else {
         null_mut()
     }
+}
+
+/// # Safety
+pub unsafe extern "C" fn bloom_aof_rewrite(
+    aof: *mut raw::RedisModuleIO,
+    key: *mut raw::RedisModuleString,
+    value: *mut c_void,
+) {
+    let filter = &*value.cast::<BloomFilterType>();
+    let hex = match filter.encoder_bloom_filter() {
+        Ok(val) => val,
+        Err(err) => panic!("encode bloom filter failed. {err}"),
+    };
+    let cmd = CString::new("BF.LOAD").unwrap();
+    let fmt = CString::new("sb").unwrap();
+    raw::RedisModule_EmitAOF.unwrap()(
+        aof,
+        cmd.as_ptr(),
+        fmt.as_ptr(),
+        key,
+        hex.as_ptr().cast::<c_char>(),
+        hex.len(),
+    );
 }
 
 /// # Safety

--- a/src/wrapper/bloom_callback.rs
+++ b/src/wrapper/bloom_callback.rs
@@ -6,6 +6,7 @@ use std::ffi::CString;
 use std::os::raw::{c_char, c_int, c_void};
 use std::ptr::null_mut;
 use std::sync::atomic::Ordering;
+use valkey_module::logging::{log_io_error, ValkeyLogLevel};
 use valkey_module::raw;
 use valkey_module::{RedisModuleDefragCtx, RedisModuleString};
 
@@ -58,13 +59,20 @@ pub unsafe extern "C" fn bloom_aof_rewrite(
     value: *mut c_void,
 ) {
     let filter = &*value.cast::<BloomFilterType>();
-    let hex = match filter.encoder_bloom_filter() {
+    let hex = match filter.encode_bloom_filter() {
         Ok(val) => val,
-        Err(err) => panic!("encode bloom filter failed. {err}"),
+        Err(err) => {
+            log_io_error(
+                aof,
+                ValkeyLogLevel::Warning,
+                &format!("encode bloom filter failed. {}", err.as_str()),
+            );
+            return;
+        }
     };
     let cmd = CString::new("BF.LOAD").unwrap();
     let fmt = CString::new("sb").unwrap();
-    raw::RedisModule_EmitAOF.unwrap()(
+    valkey_module::raw::RedisModule_EmitAOF.unwrap()(
         aof,
         cmd.as_ptr(),
         fmt.as_ptr(),

--- a/tests/test_aofrewrite.py
+++ b/tests/test_aofrewrite.py
@@ -1,0 +1,41 @@
+import time
+from valkeytests.valkey_test_case import ValkeyAction
+from valkey_bloom_test_case import ValkeyBloomTestCaseBase
+from valkeytests.conftest import resource_port_tracker
+
+class TestBloomAofRewrite(ValkeyBloomTestCaseBase):
+    
+    def get_custom_args(self):
+        # test aof rewrite should avoid bloom filter override as rdb. use aof
+        args = super().get_custom_args()
+        args.update({'aof-use-rdb-preamble': 'no', 'appendonly': 'yes', 'appenddirname': 'aof-{}'.format(self.port)})
+        return args
+
+    def test_basic_aofrewrite_and_restore(self):
+        client = self.server.get_new_client()
+        bf_add_result_1 = client.execute_command('BF.ADD testSave item')
+        assert bf_add_result_1 == 1
+        bf_exists_result_1 = client.execute_command('BF.EXISTS testSave item')
+        assert bf_exists_result_1 == 1
+        bf_info_result_1 = client.execute_command('BF.INFO testSave')
+        assert(len(bf_info_result_1)) != 0
+        curr_item_count_1 = client.info_obj().num_keys()
+        
+        # save aof, restart sever
+        client.bgrewriteaof()
+        self.server.wait_for_action_done(ValkeyAction.AOF_REWRITE)
+        # Keep the server running for 1 second more to have a larger uptime.
+        time.sleep(1)
+        uptime_in_sec_1 = self.client.info_obj().uptime_in_secs()
+        self.server.restart(remove_rdb=False, remove_nodes_conf=False, connect_client=True)
+        uptime_in_sec_2 = self.client.info_obj().uptime_in_secs()
+        assert self.server.is_alive()
+        assert uptime_in_sec_1 > uptime_in_sec_2
+
+        # verify restore results
+        curr_item_count_2 = client.info_obj().num_keys()
+        assert curr_item_count_2 == curr_item_count_1
+        bf_exists_result_2 = client.execute_command('BF.EXISTS testSave item')
+        assert bf_exists_result_2 == 1
+        bf_info_result_2 = client.execute_command('BF.INFO testSave')
+        assert bf_info_result_2 == bf_info_result_1

--- a/tests/test_aofrewrite.py
+++ b/tests/test_aofrewrite.py
@@ -26,11 +26,8 @@ class TestBloomAofRewrite(ValkeyBloomTestCaseBase):
         self.server.wait_for_action_done(ValkeyAction.AOF_REWRITE)
         # Keep the server running for 1 second more to have a larger uptime.
         time.sleep(1)
-        uptime_in_sec_1 = self.client.info_obj().uptime_in_secs()
         self.server.restart(remove_rdb=False, remove_nodes_conf=False, connect_client=True)
-        uptime_in_sec_2 = self.client.info_obj().uptime_in_secs()
         assert self.server.is_alive()
-        assert uptime_in_sec_1 > uptime_in_sec_2
 
         # verify restore results
         curr_item_count_2 = client.info_obj().num_keys()
@@ -39,3 +36,33 @@ class TestBloomAofRewrite(ValkeyBloomTestCaseBase):
         assert bf_exists_result_2 == 1
         bf_info_result_2 = client.execute_command('BF.INFO testSave')
         assert bf_info_result_2 == bf_info_result_1
+        client.execute_command('DEL testSave')
+
+    def test_aofrewrite_bloomfilter_metrics(self):
+        self.client.execute_command('BF.RESERVE key1 0.001 7000')
+        # We use a number greater than 7000 in order to have a buffer for any false positives
+        variables = [f"key{i+1}" for i in range(7500)]
+
+        # Get original size to compare against size after scaled
+        info_obj = self.client.execute_command('BF.INFO key1')
+        # Add keys until bloomfilter will scale out
+        for var in variables:
+            self.client.execute_command(f'BF.ADD key1 {var}')
+
+        # save aof, restart sever
+        self.client.bgrewriteaof()
+        self.server.wait_for_action_done(ValkeyAction.AOF_REWRITE)
+        # restart server
+        time.sleep(1)
+        self.server.restart(remove_rdb=False, remove_nodes_conf=False, connect_client=True)
+        
+        # Check info for scaled bloomfilter matches metrics data for bloomfilter
+        new_info_obj = self.client.execute_command(f'BF.INFO key1')
+        self.verify_bloom_metrics(self.client.execute_command("INFO bf"),  new_info_obj[3], 1, 2)
+
+        # Check bloomfilter size has increased
+        assert new_info_obj[3] > info_obj[3]
+
+        # Delete the scaled bloomfilter to check both filters are deleted and metrics stats are set accordingly
+        self.client.execute_command('DEL key1')
+        self.verify_bloom_metrics(self.client.execute_command("INFO bf"), 0, 0, 0)

--- a/tests/test_bloom_command.py
+++ b/tests/test_bloom_command.py
@@ -1,6 +1,8 @@
 import pytest
 from valkey_bloom_test_case import ValkeyBloomTestCaseBase
 from valkeytests.conftest import resource_port_tracker
+import valkey
+import uuid
 
 class TestBloomCommand(ValkeyBloomTestCaseBase):
 
@@ -146,3 +148,30 @@ class TestBloomCommand(ValkeyBloomTestCaseBase):
         assert bf_info[filter_index] == self.client.execute_command('BF.INFO BF_INFO FILTERS') == 1
         assert bf_info[item_index] == self.client.execute_command('BF.INFO BF_INFO ITEMS') == 0
         assert bf_info[expansion_index] == self.client.execute_command('BF.INFO BF_INFO EXPANSION') == None
+
+    def test_bloom_load_cant_override(self):
+        bf_key1 = uuid.uuid4()
+        bf_key2 = uuid.uuid4()
+        bf_new_key = uuid.uuid4()
+        # arrange insert two key
+        assert self.client.execute_command('BF.RESERVE {} 0.1 10'.format(bf_key1)) == b'OK'
+        assert self.client.execute_command('BF.RESERVE {} 0.1 20'.format(bf_key2)) == b'OK'
+        assert self.client.execute_command('BF.ADD {} item'.format(bf_key2)) == 1
+        
+        key2_dump_value = self.client.execute_command('BF.DUMP {}'.format(bf_key2))
+        
+        # bf.load can't override exists key.
+        try:
+            # dump value is bytes, can't build into a single param, can't use verify_error_response.
+            self.client.execute_command('BF.LOAD', str(bf_key1) ,key2_dump_value)
+            assert False
+        except valkey.exceptions.ResponseError as e:
+            expected_err_reply = "-BUSYKEY Target key name already exists."
+            assert_error_msg = f"Actual error message: '{str(e)}' is different from expected error message '{expected_err_reply}'"
+            assert str(e) == expected_err_reply, assert_error_msg
+            
+        assert self.client.execute_command('BF.LOAD', str(bf_new_key) ,key2_dump_value) == b'OK'
+
+        # assert bf_new_key bf.exists item
+        assert self.client.execute_command('BF.EXISTS {} item'.format(bf_new_key)) == 1
+        

--- a/tests/test_bloom_command.py
+++ b/tests/test_bloom_command.py
@@ -148,30 +148,3 @@ class TestBloomCommand(ValkeyBloomTestCaseBase):
         assert bf_info[filter_index] == self.client.execute_command('BF.INFO BF_INFO FILTERS') == 1
         assert bf_info[item_index] == self.client.execute_command('BF.INFO BF_INFO ITEMS') == 0
         assert bf_info[expansion_index] == self.client.execute_command('BF.INFO BF_INFO EXPANSION') == None
-
-    def test_bloom_load_cant_override(self):
-        bf_key1 = uuid.uuid4()
-        bf_key2 = uuid.uuid4()
-        bf_new_key = uuid.uuid4()
-        # arrange insert two key
-        assert self.client.execute_command('BF.RESERVE {} 0.1 10'.format(bf_key1)) == b'OK'
-        assert self.client.execute_command('BF.RESERVE {} 0.1 20'.format(bf_key2)) == b'OK'
-        assert self.client.execute_command('BF.ADD {} item'.format(bf_key2)) == 1
-        
-        key2_dump_value = self.client.execute_command('BF.DUMP {}'.format(bf_key2))
-        
-        # bf.load can't override exists key.
-        try:
-            # dump value is bytes, can't build into a single param, can't use verify_error_response.
-            self.client.execute_command('BF.LOAD', str(bf_key1) ,key2_dump_value)
-            assert False
-        except valkey.exceptions.ResponseError as e:
-            expected_err_reply = "-BUSYKEY Target key name already exists."
-            assert_error_msg = f"Actual error message: '{str(e)}' is different from expected error message '{expected_err_reply}'"
-            assert str(e) == expected_err_reply, assert_error_msg
-            
-        assert self.client.execute_command('BF.LOAD', str(bf_new_key) ,key2_dump_value) == b'OK'
-
-        # assert bf_new_key bf.exists item
-        assert self.client.execute_command('BF.EXISTS {} item'.format(bf_new_key)) == 1
-        


### PR DESCRIPTION
this pr is for #8  https://github.com/valkey-io/valkey-bloom/issues/8.


# design proposal

I use serde  and bincode to  deserialize and deserialize BloomFilterType. add data version in first element.

bf.load not support override old key.



