### PR TITLE
Adding info handler, that contains two fields, num objects and memory…

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,8 @@ homepage = "https://github.com/valkey-io/valkey-bloom"
 
 [dependencies]
 valkey-module = "0.1.2"
+valkey-module-macros = "0"
+linkme = "0"
 bloomfilter = "1.0.13"
 lazy_static = "1.4.0"
 libc = "0.2"

--- a/src/bloom/data_type.rs
+++ b/src/bloom/data_type.rs
@@ -3,8 +3,11 @@ use crate::bloom::utils::BloomFilterType;
 use crate::configs::{
     FIXED_SIP_KEY_ONE_A, FIXED_SIP_KEY_ONE_B, FIXED_SIP_KEY_TWO_A, FIXED_SIP_KEY_TWO_B,
 };
+use crate::metrics::BLOOM_NUM_OBJECTS;
+use crate::metrics::BLOOM_OBJECT_TOTAL_MEMORY_BYTES;
 use crate::wrapper::bloom_callback;
 use crate::MODULE_NAME;
+use std::mem;
 use std::os::raw::c_int;
 use valkey_module::native_types::ValkeyType;
 use valkey_module::{logging, raw};
@@ -108,6 +111,11 @@ impl ValkeyDataType for BloomFilterType {
             );
             filters.push(filter);
         }
+        BLOOM_OBJECT_TOTAL_MEMORY_BYTES.fetch_add(
+            mem::size_of::<BloomFilterType>(),
+            std::sync::atomic::Ordering::Relaxed,
+        );
+        BLOOM_NUM_OBJECTS.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
         let item = BloomFilterType {
             expansion: expansion as u32,
             fp_rate,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,10 +1,13 @@
+use metrics::bloom_info_handler;
 use valkey_module::configuration::ConfigurationFlags;
-use valkey_module::{valkey_module, Context, Status, ValkeyResult, ValkeyString};
+use valkey_module::{valkey_module, Context, InfoContext, Status, ValkeyResult, ValkeyString};
 pub mod bloom;
 pub mod configs;
+pub mod metrics;
 pub mod wrapper;
 use crate::bloom::command_handler;
 use crate::bloom::data_type::BLOOM_FILTER_TYPE;
+use valkey_module_macros::info_command_handler;
 
 pub const MODULE_NAME: &str = "bf";
 
@@ -55,6 +58,14 @@ fn bloom_info_command(ctx: &Context, args: Vec<ValkeyString>) -> ValkeyResult {
 /// BF.INSERT <key> [ERROR <fp_error>] [CAPACITY <capacity>] [EXPANSION <expansion>] [NOCREATE] [NONSCALING] ITEMS <item> [<item> ...]
 fn bloom_insert_command(ctx: &Context, args: Vec<ValkeyString>) -> ValkeyResult {
     command_handler::bloom_filter_insert(ctx, &args)
+}
+
+///
+/// Module Info
+///
+#[info_command_handler]
+fn info_handler(ctx: &InfoContext, _for_crash_report: bool) -> ValkeyResult<()> {
+    bloom_info_handler(ctx)
 }
 
 //////////////////////////////////////////////////////

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -1,0 +1,34 @@
+use lazy_static::lazy_static;
+use std::sync::atomic::{AtomicU64, AtomicUsize, Ordering};
+use valkey_module::{InfoContext, ValkeyResult};
+
+lazy_static! {
+    pub static ref BLOOM_NUM_OBJECTS: AtomicU64 = AtomicU64::new(0);
+    pub static ref BLOOM_OBJECT_TOTAL_MEMORY_BYTES: AtomicUsize = AtomicUsize::new(0);
+    pub static ref BLOOM_NUM_FILTERS_ACROSS_OBJECTS: AtomicU64 = AtomicU64::new(0);
+}
+
+pub fn bloom_info_handler(ctx: &InfoContext) -> ValkeyResult<()> {
+    ctx.builder()
+        .add_section("bloom_core_metrics")
+        .field(
+            "bloom_total_memory_bytes",
+            BLOOM_OBJECT_TOTAL_MEMORY_BYTES
+                .load(Ordering::Relaxed)
+                .to_string(),
+        )?
+        .field(
+            "bloom_num_objects",
+            BLOOM_NUM_OBJECTS.load(Ordering::Relaxed).to_string(),
+        )?
+        .field(
+            "bloom_num_filters_across_objects",
+            BLOOM_NUM_FILTERS_ACROSS_OBJECTS
+                .load(Ordering::Relaxed)
+                .to_string(),
+        )?
+        .build_section()?
+        .build_info()?;
+
+    Ok(())
+}

--- a/src/wrapper/bloom_callback.rs
+++ b/src/wrapper/bloom_callback.rs
@@ -61,7 +61,7 @@ pub unsafe extern "C" fn bloom_aux_load(
 }
 
 /// # Safety
-/// Free a bloom item
+/// Free a bloom object
 pub unsafe extern "C" fn bloom_free(value: *mut c_void) {
     drop(Box::from_raw(value.cast::<BloomFilterType>()));
 }

--- a/tests/test_bloom_metrics.py
+++ b/tests/test_bloom_metrics.py
@@ -1,0 +1,141 @@
+import pytest, time
+import os
+from valkey_bloom_test_case import ValkeyBloomTestCaseBase
+from valkeytests.conftest import resource_port_tracker
+from util.waiters import *
+
+DEFAULT_BLOOM_FILTER_SIZE = 179960
+class TestBloomMetrics(ValkeyBloomTestCaseBase):
+
+    def test_basic_command_metrics(self):
+        # Check that bloom metrics stats start at 0
+        self.verify_bloom_metrics(self.client.execute_command("INFO bf"), 0, 0, 0)
+        self.verify_bloom_metrics(self.client.execute_command("INFO Modules"), 0, 0, 0)
+
+        # Create a default bloom filter and check its metrics values are correct
+        assert(self.client.execute_command('BF.ADD key item') == 1)
+        self.verify_bloom_metrics(self.client.execute_command("INFO bf"), DEFAULT_BLOOM_FILTER_SIZE, 1, 1)
+        self.verify_bloom_metrics(self.client.execute_command("INFO Modules"), DEFAULT_BLOOM_FILTER_SIZE, 1, 1)
+
+        # Check that other commands don't influence metrics
+        assert(self.client.execute_command('BF.EXISTS key item') == 1)
+        assert(self.client.execute_command('BF.ADD key item2') == 1)
+        assert(self.client.execute_command('BF.MADD key item3 item4')== [1, 1])
+        assert(self.client.execute_command('BF.MEXISTS key item3 item5')== [1, 0])
+        assert(self.client.execute_command('BF.CARD key') == 4)
+        self.client.execute_command("BF.INFO key")
+        assert(self.client.execute_command('BF.INSERT key ITEMS item5 item6')== [1, 1])
+        
+        self.verify_bloom_metrics(self.client.execute_command("INFO bf"), DEFAULT_BLOOM_FILTER_SIZE, 1, 1)
+        self.verify_bloom_metrics(self.client.execute_command("INFO Modules"), DEFAULT_BLOOM_FILTER_SIZE, 1, 1)
+
+        # Create a new default bloom filter and check metrics again 
+        assert(self.client.execute_command('BF.ADD key2 item') == 1)
+        self.verify_bloom_metrics(self.client.execute_command("INFO bf"), DEFAULT_BLOOM_FILTER_SIZE*2, 2, 2)
+        self.verify_bloom_metrics(self.client.execute_command("INFO Modules"), DEFAULT_BLOOM_FILTER_SIZE*2, 2, 2)
+
+        # Create a non default filter with BF.RESERVE and check its metrics are correct
+        assert(self.client.execute_command('BF.RESERVE key3 0.001 2917251') == b'OK')
+        info_obj = self.client.execute_command('BF.INFO key3')
+
+        # We want to check the size of the newly created bloom filter but metrics contains the size of all bloomfilters so we must minus the 
+        # two default bloomfilters we already created
+        self.verify_bloom_metrics(self.client.execute_command("INFO bf"), info_obj[3] + DEFAULT_BLOOM_FILTER_SIZE * 2, 3, 3)
+        self.verify_bloom_metrics(self.client.execute_command("INFO Modules"), info_obj[3] + DEFAULT_BLOOM_FILTER_SIZE * 2, 3, 3)
+
+        # Delete a non default key and make sure the metrics stats are still correct
+        self.client.execute_command('DEL key3')
+        self.verify_bloom_metrics(self.client.execute_command("INFO bf"), DEFAULT_BLOOM_FILTER_SIZE * 2, 2, 2)
+        self.verify_bloom_metrics(self.client.execute_command("INFO Modules"), DEFAULT_BLOOM_FILTER_SIZE * 2, 2, 2)
+
+        # Create a default filter with BF.INSERT and check its metrics are correct
+        assert(self.client.execute_command('BF.INSERT key4 ITEMS item1 item2') == [1, 1])
+        self.verify_bloom_metrics(self.client.execute_command("INFO bf"), DEFAULT_BLOOM_FILTER_SIZE * 3, 3, 3)
+        self.verify_bloom_metrics(self.client.execute_command("INFO Modules"), DEFAULT_BLOOM_FILTER_SIZE * 3, 3, 3)
+
+        # Delete a default key and make sure the metrics are still correct
+        self.client.execute_command('UNLINK key')
+        self.verify_bloom_metrics(self.client.execute_command("INFO bf"), DEFAULT_BLOOM_FILTER_SIZE * 2, 2, 2)
+        self.verify_bloom_metrics(self.client.execute_command("INFO Modules"), DEFAULT_BLOOM_FILTER_SIZE * 2, 2, 2)
+
+        # Create a key then cause it to expire and check if metrics are updated correctly
+        assert self.client.execute_command('BF.ADD TEST_EXP ITEM') == 1
+        self.verify_bloom_metrics(self.client.execute_command("INFO bf"), DEFAULT_BLOOM_FILTER_SIZE * 3, 3, 3)
+        self.verify_bloom_metrics(self.client.execute_command("INFO Modules"), DEFAULT_BLOOM_FILTER_SIZE * 3, 3, 3)
+        assert self.client.execute_command('TTL TEST_EXP') == -1
+        self.verify_bloom_filter_item_existence(self.client, 'TEST_EXP', 'ITEM')
+        curr_time = int(time.time())
+        assert self.client.execute_command(f'EXPIREAT TEST_EXP {curr_time + 5}') == 1
+        wait_for_equal(lambda: self.client.execute_command('BF.EXISTS TEST_EXP ITEM'), 0)
+        self.verify_bloom_metrics(self.client.execute_command("INFO bf"), DEFAULT_BLOOM_FILTER_SIZE * 2, 2, 2)
+        self.verify_bloom_metrics(self.client.execute_command("INFO Modules"), DEFAULT_BLOOM_FILTER_SIZE * 2, 2, 2)
+
+        # Flush database so all keys should now be gone and metrics should all be at 0
+        self.client.execute_command('FLUSHDB')
+        wait_for_equal(lambda: self.client.execute_command('BF.EXISTS key2 item'), 0)
+        self.verify_bloom_metrics(self.client.execute_command("INFO bf"), 0, 0, 0)
+        self.verify_bloom_metrics(self.client.execute_command("INFO Modules"), 0, 0, 0)
+
+    def test_scaled_bloomfilter_metrics(self):
+        self.client.execute_command('BF.RESERVE key1 0.001 7000')
+        # We use a number greater than 7000 in order to have a buffer for any false positives
+        variables = [f"key{i+1}" for i in range(7500)]
+
+        # Get original size to compare against size after scaled
+        info_obj = self.client.execute_command('BF.INFO key1')
+        # Add keys until bloomfilter will scale out
+        for var in variables:
+            self.client.execute_command(f'BF.ADD key1 {var}')
+
+        # Check info for scaled bloomfilter matches metrics data for bloomfilter
+        new_info_obj = self.client.execute_command(f'BF.INFO key1')
+        self.verify_bloom_metrics(self.client.execute_command("INFO bf"),  new_info_obj[3], 1, 2)
+
+        # Check bloomfilter size has increased
+        assert new_info_obj[3] > info_obj[3]
+
+        # Delete the scaled bloomfilter to check both filters are deleted and metrics stats are set accordingly
+        self.client.execute_command('DEL key1')
+        self.verify_bloom_metrics(self.client.execute_command("INFO bf"), 0, 0, 0)
+
+
+    def test_copy_metrics(self):
+        # Create a bloomfilter and copy it
+        assert(self.client.execute_command('BF.ADD key{123} item') == 1)
+        assert(self.client.execute_command('COPY key{123} copiedkey{123}') == 1)
+    
+        # Verify that the metrics were updated correctly after copying
+        self.verify_bloom_metrics(self.client.execute_command("INFO bf"), DEFAULT_BLOOM_FILTER_SIZE * 2, 2, 2)
+
+        # Perform a FLUSHALL which should set all metrics data to 0
+        self.client.execute_command('FLUSHALL')
+        wait_for_equal(lambda: self.client.execute_command('BF.EXISTS key{123} item'), 0)
+        self.verify_bloom_metrics(self.client.execute_command("INFO bf"), 0, 0, 0)
+
+
+    def test_save_and_restore_metrics(self):
+        # Create default bloom filter
+        assert(self.client.execute_command('BF.ADD testSave item') == 1)
+
+        # Create scaled bloom filter
+        self.client.execute_command('BF.RESERVE key1 0.001 7000')
+        variables = [f"key{i+1}" for i in range(7500)]
+        for var in variables:
+            self.client.execute_command(f'BF.ADD key1 {var}')
+        
+        # Get info and metrics stats of bloomfilter before rdb load
+        original_info_obj = self.client.execute_command('BF.INFO key1')
+
+        self.client.bgsave()
+        self.server.wait_for_save_done()
+
+        # Restart, and verify metrics are correct
+        self.server.restart(remove_rdb=False, remove_nodes_conf=False, connect_client=True)
+
+        # Compare original and loaded scaled bloomfilter infos
+        new_client = self.server.get_new_client()
+        restored_info_obj = new_client.execute_command('BF.INFO key1')
+        for i in range(1, len(original_info_obj), 2):
+            assert original_info_obj[i] == restored_info_obj[i]
+
+        self.verify_bloom_metrics(self.client.execute_command("INFO bf"), original_info_obj[3] + DEFAULT_BLOOM_FILTER_SIZE, 2, 3)

--- a/tests/valkey_bloom_test_case.py
+++ b/tests/valkey_bloom_test_case.py
@@ -139,3 +139,27 @@ class ValkeyBloomTestCaseBase(ValkeyTestCase):
             item_prefix,
         )
         self.fp_assert(error_count, num_operations, expected_fp_rate, fp_margin)
+
+    def verify_bloom_metrics(self, info_response, expected_memory, expected_num_objects, expected_num_filters):
+        """
+            Verify the metric values are recorded properly, the expected values are as below
+            expected_memory: the size of the memory used by the objects
+            expected_num_objects: the number of module objects stored
+            expected_num_filters: the number of filters currently created
+        """
+        response_str = info_response.decode('utf-8')
+        lines = response_str.split('\r\n')
+        total_memory_bites = -1
+        num_objects = -1
+        num_filters = -1
+        for line in lines:
+            if line.startswith('bf_bloom_total_memory_bytes:'):
+                total_memory_bites = int(line.split(':')[1])
+            elif line.startswith('bf_bloom_num_objects:'):
+                num_objects = int(line.split(':')[1])
+            elif line.startswith('bf_bloom_num_filters_across_objects'):
+                num_filters = int(line.split(':')[1])
+
+        assert total_memory_bites == expected_memory 
+        assert num_objects == expected_num_objects
+        assert num_filters == expected_num_filters


### PR DESCRIPTION
Added an info handler which required updating Cargo.toml to include valkey-module-macros and linkme. The info handler contains two fields bloom_total_memory_bytes and bloom_num_objects. I then updated the creation and copy methods of bloom objects to increment these values where necessary. In order to deincrement added impl Drop for bloom in order to decrease the info fields as necessary.

Testing:
Created a new test file specifically for info. This test file contains for different tests:
test_basic_command_metrics: This tests all create commands and non create commands to check that create commands increase the info metrics while non create dont have an influence.
test_scaled_bloomfilter_metrics: Tests scaling a bloom filter increases the metrics as desired
test_copy_metrics: Tests copying a bloom filter will double the metrics as desired
test_save_and_restore_metrics: Tests saving and restoring a scaled and non scaled bloom filter will increase metrics as desired