### PR TITLE
Add tightening_ratio support

### DIFF
--- a/src/bloom/data_type.rs
+++ b/src/bloom/data_type.rs
@@ -71,6 +71,9 @@ impl ValkeyDataType for BloomFilterType {
         let Ok(fp_rate) = raw::load_double(rdb) else {
             return None;
         };
+        let Ok(tightening_ratio) = raw::load_double(rdb) else {
+            return None;
+        };
         let mut filters: Vec<BloomFilter> = Vec::with_capacity(num_filters as usize);
         let Ok(is_seed_random_u64) = raw::load_unsigned(rdb) else {
             return None;
@@ -121,6 +124,7 @@ impl ValkeyDataType for BloomFilterType {
         let item = BloomFilterType {
             expansion: expansion as u32,
             fp_rate,
+            tightening_ratio,
             is_seed_random,
             filters,
         };
@@ -131,6 +135,7 @@ impl ValkeyDataType for BloomFilterType {
     fn debug_digest(&self, mut dig: Digest) {
         dig.add_long_long(self.expansion.into());
         dig.add_string_buffer(&self.fp_rate.to_le_bytes());
+        dig.add_string_buffer(&self.tightening_ratio.to_le_bytes());
         for filter in &self.filters {
             dig.add_string_buffer(filter.bloom.as_slice());
             dig.add_long_long(filter.num_items.into());

--- a/src/configs.rs
+++ b/src/configs.rs
@@ -36,6 +36,8 @@ lazy_static! {
 // Tightening ratio used during scale out for the calculation of fp_rate of every new filter within a bloom object to
 // maintain the bloom object's overall fp_rate to the configured value.
 pub const TIGHTENING_RATIO: f64 = 0.5;
+pub const TIGHTENING_RATIO_MIN: f64 = 0.0;
+pub const TIGHTENING_RATIO_MAX: f64 = 1.0;
 // Max number of filters allowed within a bloom object.
 pub const MAX_FILTERS_PER_OBJ: i32 = i32::MAX;
 /// Below constants are fixed seed and sip keys to help create bloom objects using the same seed and to restore the bloom objects with the same hasher which

--- a/src/wrapper/bloom_callback.rs
+++ b/src/wrapper/bloom_callback.rs
@@ -22,6 +22,7 @@ pub unsafe extern "C" fn bloom_rdb_save(rdb: *mut raw::RedisModuleIO, value: *mu
     raw::save_unsigned(rdb, v.filters.len() as u64);
     raw::save_unsigned(rdb, v.expansion as u64);
     raw::save_double(rdb, v.fp_rate);
+    raw::save_double(rdb, v.tightening_ratio);
     let mut is_seed_random = 0;
     if v.is_seed_random {
         is_seed_random = 1;

--- a/tests/test_bloom_metrics.py
+++ b/tests/test_bloom_metrics.py
@@ -4,7 +4,7 @@ from valkey_bloom_test_case import ValkeyBloomTestCaseBase
 from valkeytests.conftest import resource_port_tracker
 from util.waiters import *
 
-DEFAULT_BLOOM_FILTER_SIZE = 179952
+DEFAULT_BLOOM_FILTER_SIZE = 179960
 DEFAULT_BLOOM_FILTER_CAPACITY = 100000
 class TestBloomMetrics(ValkeyBloomTestCaseBase):
 


### PR DESCRIPTION
Add tightening_ratio support for tuning of the `TIGHENTING_RATIO` to allow scalable bloom objects to have a higher capacity at cost of higher false positive rate.

We allow the `TIGHTENING_RATIO` argument only if the command is replicated.

