### PR TITLE
Support random seed per bloom object by default (configurable)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,7 @@ bincode = "1.3"
 
 [dev-dependencies]
 rand = "0.8"
+rstest = "0.23.0"
 
 [lib]
 crate-type = ["cdylib"]

--- a/src/bloom/command_handler.rs
+++ b/src/bloom/command_handler.rs
@@ -112,10 +112,12 @@ pub fn bloom_filter_add_value(
             let fp_rate = configs::BLOOM_FP_RATE_DEFAULT;
             let capacity = configs::BLOOM_CAPACITY.load(Ordering::Relaxed) as u32;
             let expansion = configs::BLOOM_EXPANSION.load(Ordering::Relaxed) as u32;
+            let use_random_seed = configs::BLOOM_USE_RANDOM_SEED.load(Ordering::Relaxed);
             let mut bloom = match BloomFilterType::new_reserved(
                 fp_rate,
                 capacity,
                 expansion,
+                use_random_seed,
                 validate_size_limit,
             ) {
                 Ok(bf) => bf,
@@ -274,12 +276,14 @@ pub fn bloom_filter_reserve(ctx: &Context, input_args: &[ValkeyString]) -> Valke
     match value {
         Some(_) => Err(ValkeyError::Str(utils::ITEM_EXISTS)),
         None => {
+            let use_random_seed = configs::BLOOM_USE_RANDOM_SEED.load(Ordering::Relaxed);
             // Skip bloom filter size validation on replicated cmds.
             let validate_size_limit = !ctx.get_flags().contains(ContextFlags::REPLICATED);
             let bloom = match BloomFilterType::new_reserved(
                 fp_rate,
                 capacity,
                 expansion,
+                use_random_seed,
                 validate_size_limit,
             ) {
                 Ok(bf) => bf,
@@ -403,10 +407,12 @@ pub fn bloom_filter_insert(ctx: &Context, input_args: &[ValkeyString]) -> Valkey
             if nocreate {
                 return Err(ValkeyError::Str(utils::NOT_FOUND));
             }
+            let use_random_seed = configs::BLOOM_USE_RANDOM_SEED.load(Ordering::Relaxed);
             let mut bloom = match BloomFilterType::new_reserved(
                 fp_rate,
                 capacity,
                 expansion,
+                use_random_seed,
                 validate_size_limit,
             ) {
                 Ok(bf) => bf,

--- a/src/configs.rs
+++ b/src/configs.rs
@@ -1,4 +1,5 @@
 use lazy_static::lazy_static;
+use std::sync::atomic::AtomicBool;
 use std::sync::atomic::AtomicI64;
 
 /// Configurations
@@ -14,6 +15,8 @@ pub const BLOOM_FP_RATE_DEFAULT: f64 = 0.001;
 pub const BLOOM_FP_RATE_MIN: f64 = 0.0;
 pub const BLOOM_FP_RATE_MAX: f64 = 1.0;
 
+pub const BLOOM_USE_RANDOM_SEED_DEFAULT: bool = true;
+
 // Max Memory usage allowed per bloom filter within a bloom object (64MB).
 // Beyond this threshold, a bloom object is classified as large and is exempt from defrag operations.
 // Also, write operations that result in bloom object allocation larger than this size will be rejected.
@@ -26,6 +29,7 @@ lazy_static! {
     pub static ref BLOOM_EXPANSION: AtomicI64 = AtomicI64::new(BLOOM_EXPANSION_DEFAULT);
     pub static ref BLOOM_MEMORY_LIMIT_PER_FILTER: AtomicI64 =
         AtomicI64::new(BLOOM_MEMORY_LIMIT_PER_FILTER_DEFAULT);
+    pub static ref BLOOM_USE_RANDOM_SEED: AtomicBool = AtomicBool::default();
 }
 
 /// Constants
@@ -40,7 +44,3 @@ pub const FIXED_SEED: [u8; 32] = [
     89, 15, 245, 34, 234, 120, 17, 218, 167, 20, 216, 9, 59, 62, 123, 217, 29, 137, 138, 115, 62,
     152, 136, 135, 48, 127, 151, 205, 40, 7, 51, 131,
 ];
-pub const FIXED_SIP_KEY_ONE_A: u64 = 15713473521876537177;
-pub const FIXED_SIP_KEY_ONE_B: u64 = 15671187751654921383;
-pub const FIXED_SIP_KEY_TWO_A: u64 = 9766223185946773789;
-pub const FIXED_SIP_KEY_TWO_B: u64 = 9453907914610147120;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -105,6 +105,7 @@ valkey_module! {
         string: [
         ],
         bool: [
+            ["bloom-use-random-seed", &*configs::BLOOM_USE_RANDOM_SEED, configs::BLOOM_USE_RANDOM_SEED_DEFAULT, ConfigurationFlags::DEFAULT, None],
         ],
         enum: [
         ],

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,5 @@
+import pytest
+
+@pytest.fixture(params=['random-seed', 'fixed-seed'])
+def bloom_config_parameterization(request):
+    return request.param

--- a/tests/test_bloom_command.py
+++ b/tests/test_bloom_command.py
@@ -34,7 +34,6 @@ class TestBloomCommand(ValkeyBloomTestCaseBase):
             # not found
             ('BF.INFO TEST404', 'not found'),
             # incorrect syntax and argument usage
-            ('BF.ADD bf_non 2', 'non scaling filter is full'),
             ('bf.info key item', 'invalid information value'),
             ('bf.insert key CAPACITY 10000 ERROR 0.01 EXPANSION 0.99 NOCREATE NONSCALING ITEMS test1 test2 test3', 'bad expansion'),
             ('BF.INSERT KEY HELLO WORLD', 'unknown argument received'),

--- a/tests/test_correctness.py
+++ b/tests/test_correctness.py
@@ -80,7 +80,7 @@ class TestBloomCorrectness(ValkeyBloomTestCaseBase):
         total_error_count = 0
         add_operation_idx = 0
         for filter_idx in range(1, num_filters_to_scale + 1):
-            expected_total_capacity = initial_capacity * ((expansion ** filter_idx) - 1)
+            expected_total_capacity = self.calculate_expected_capacity(initial_capacity, expansion, filter_idx)
             error_count, new_add_operation_idx = self.add_items_till_capacity(client, filter_name, expected_total_capacity, add_operation_idx + 1, item_prefix)
             add_operation_idx = new_add_operation_idx
             total_error_count += error_count

--- a/tests/test_save_and_restore.py
+++ b/tests/test_save_and_restore.py
@@ -66,7 +66,7 @@ class TestBloomSaveRestore(ValkeyBloomTestCaseBase):
         self.server.wait_for_save_done()
         self.server.restart(remove_rdb=False, remove_nodes_conf=False, connect_client=False)
         logfile = os.path.join(self.testdir, self.server.args["logfile"])
-        large_obj_restore_err = "Failed to restore bloom object because it contains a filter larger than the max allowed size limit"
+        large_obj_restore_err = "Failed to restore bloom object: Contains a filter larger than the max allowed size limit."
         internal_rdb_err = "Internal error in RDB"
         self.wait_for_logfile(logfile, large_obj_restore_err)
         self.wait_for_logfile(logfile, internal_rdb_err)

--- a/tests/valkeytests/valkey_test_case.py
+++ b/tests/valkeytests/valkey_test_case.py
@@ -474,7 +474,7 @@ class ValkeyTestCaseBase:
         self.port_tracker = resource_port_tracker
 
     def _get_valkey_args(self):
-        self.args.update({"maxmemory":self.maxmemory, "maxmemory-policy":"allkeys-random", "activerehashing":"yes", "databases": self.num_dbs, "repl-diskless-sync": "yes", "save": "", "enable-debug-command":"yes"})
+        self.args.update({"maxmemory":self.maxmemory, "maxmemory-policy":"allkeys-random", "activerehashing":"yes", "databases": self.num_dbs, "repl-diskless-sync": "yes", "save": "", 'appenddirname': f'aof-{self.port}', "enable-debug-command":"yes"})
         self.args.update(self.get_custom_args())
         return self.args
 


### PR DESCRIPTION
Support random seed per bloom object by default (configurable) where all filters within the bloom object will use the same sip_keys (for their hash functions) as the first filter within the object which will be randomly generated.

When the new config (bf.bloom-use-random-seed) is disabled, new bloom object creates will use a fixed seed. In this case, the false positives on one bloom object can be reproduced on another bloom object with the same properties due to fixed seed making hashing results deterministic.