### PR TITLE
Adding a wrong type error message when performing a bloom operation on a non bloom key

### DIFF
--- a/src/bloom/command_handler.rs
+++ b/src/bloom/command_handler.rs
@@ -87,7 +87,7 @@ pub fn bloom_filter_add_value(
     let value = match filter_key.get_value::<BloomFilterType>(&BLOOM_FILTER_TYPE) {
         Ok(v) => v,
         Err(_) => {
-            return Err(ValkeyError::Str(utils::ERROR));
+            return Err(ValkeyError::WrongType);
         }
     };
     // Skip bloom filter size validation on replicated cmds.
@@ -173,7 +173,7 @@ pub fn bloom_filter_exists(
     let value = match filter_key.get_value::<BloomFilterType>(&BLOOM_FILTER_TYPE) {
         Ok(v) => v,
         Err(_) => {
-            return Err(ValkeyError::Str(utils::ERROR));
+            return Err(ValkeyError::WrongType);
         }
     };
     if !multi {
@@ -201,7 +201,7 @@ pub fn bloom_filter_card(ctx: &Context, input_args: &[ValkeyString]) -> ValkeyRe
     let value = match filter_key.get_value::<BloomFilterType>(&BLOOM_FILTER_TYPE) {
         Ok(v) => v,
         Err(_) => {
-            return Err(ValkeyError::Str(utils::ERROR));
+            return Err(ValkeyError::WrongType);
         }
     };
     match value {
@@ -270,7 +270,7 @@ pub fn bloom_filter_reserve(ctx: &Context, input_args: &[ValkeyString]) -> Valke
     let value = match filter_key.get_value::<BloomFilterType>(&BLOOM_FILTER_TYPE) {
         Ok(v) => v,
         Err(_) => {
-            return Err(ValkeyError::Str(utils::ERROR));
+            return Err(ValkeyError::WrongType);
         }
     };
     match value {
@@ -383,7 +383,7 @@ pub fn bloom_filter_insert(ctx: &Context, input_args: &[ValkeyString]) -> Valkey
     let value = match filter_key.get_value::<BloomFilterType>(&BLOOM_FILTER_TYPE) {
         Ok(v) => v,
         Err(_) => {
-            return Err(ValkeyError::Str(utils::ERROR));
+            return Err(ValkeyError::WrongType);
         }
     };
     // Skip bloom filter size validation on replicated cmds.
@@ -451,7 +451,7 @@ pub fn bloom_filter_info(ctx: &Context, input_args: &[ValkeyString]) -> ValkeyRe
     let value = match filter_key.get_value::<BloomFilterType>(&BLOOM_FILTER_TYPE) {
         Ok(v) => v,
         Err(_) => {
-            return Err(ValkeyError::Str(utils::ERROR));
+            return Err(ValkeyError::WrongType);
         }
     };
     match value {
@@ -513,7 +513,7 @@ pub fn bloom_filter_load(ctx: &Context, input_args: &[ValkeyString]) -> ValkeyRe
         Ok(v) => v,
         Err(_) => {
             // error
-            return Err(ValkeyError::Str(utils::ERROR));
+            return Err(ValkeyError::WrongType);
         }
     };
     match filter {

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -297,3 +297,28 @@ class TestBloomBasic(ValkeyBloomTestCaseBase):
             assert madd_scenario_object_digest != madd_default_object_digest
         else:
             madd_scenario_object_digest == madd_default_object_digest
+
+    def test_bloom_wrong_type(self):
+        # List of all bloom commands
+        bloom_commands = [
+            'BF.ADD key item',
+            'BF.EXISTS key item',
+            'BF.MADD key item1 item2 item3',
+            'BF.MEXISTS key item2 item3 item4',
+            'BF.INSERT key ITEMS item',
+            'BF.INFO key filters',
+            'BF.CARD key',
+            'BF.RESERVE key 0.01 1000',
+        ]
+        client = self.server.get_new_client()
+        # Set the key we try to perform bloom commands on
+        client.execute_command("set key value")
+        # Run each command and check we get the correct error returned
+        for cmd in bloom_commands:
+            cmd_name = cmd.split()[0]
+            try:
+                result = client.execute_command(cmd)
+                assert False, f"{cmd_name} on existing non bloom object should fail, instead: {result}"
+            except Exception as e:
+                
+                assert str(e) == f"WRONGTYPE Operation against a key holding the wrong kind of value"


### PR DESCRIPTION
Updated the error on the get_value return to be a WRONG_TYPE_ERROR. Added a test as well checking this happens and the error message is correct for each bloom command. 