### PR TITLE
Deterministic replication of bloom object creations

### DIFF
--- a/src/bloom/data_type.rs
+++ b/src/bloom/data_type.rs
@@ -117,27 +117,27 @@ impl ValkeyDataType for BloomFilterType {
             }
             filters.push(Box::new(filter));
         }
-
-        let item = BloomFilterType {
-            expansion: expansion as u32,
+        let item = BloomFilterType::from_existing(
+            expansion as u32,
             fp_rate,
             tightening_ratio,
             is_seed_random,
             filters,
-        };
-        item.bloom_filter_type_incr_metrics_on_new_create();
+        );
         Some(item)
     }
 
     /// Function that is used to generate a digest on the Bloom Object.
     fn debug_digest(&self, mut dig: Digest) {
-        dig.add_long_long(self.expansion.into());
-        dig.add_string_buffer(&self.fp_rate.to_le_bytes());
-        dig.add_string_buffer(&self.tightening_ratio.to_le_bytes());
-        for filter in &self.filters {
-            dig.add_string_buffer(filter.bloom.as_slice());
-            dig.add_long_long(filter.num_items);
-            dig.add_long_long(filter.capacity);
+        dig.add_long_long(self.expansion() as i64);
+        dig.add_string_buffer(&self.fp_rate().to_le_bytes());
+        dig.add_string_buffer(&self.tightening_ratio().to_le_bytes());
+        let is_seed_random = if self.is_seed_random() { 1 } else { 0 };
+        dig.add_long_long(is_seed_random);
+        for filter in self.filters() {
+            dig.add_string_buffer(filter.raw_bloom().as_slice());
+            dig.add_long_long(filter.num_items());
+            dig.add_long_long(filter.capacity());
         }
         dig.end_sequence();
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,7 +7,6 @@ pub mod metrics;
 pub mod wrapper;
 use crate::bloom::command_handler;
 use crate::bloom::data_type::BLOOM_FILTER_TYPE;
-use valkey_module::logging;
 use valkey_module_macros::info_command_handler;
 
 pub const MODULE_NAME: &str = "bf";

--- a/tests/test_replication.py
+++ b/tests/test_replication.py
@@ -23,13 +23,30 @@ class TestBloomReplication(ReplicationTestCase):
         elif bloom_config_parameterization == "fixed-seed":
             self.use_random_seed = "no"
 
+    def validate_cmd_stats(self, primary_cmd, replica_cmd, expected_primary_calls, expected_replica_calls):
+        """
+            Helper fn to validate cmd count on primary & replica for non BF.RESERVE cases for object creation & item add.
+        """
+        primary_cmd_stats = self.client.info("Commandstats")['cmdstat_' + primary_cmd]
+        assert primary_cmd_stats["calls"] == expected_primary_calls
+        replica_cmd_stats = self.replicas[0].client.info("Commandstats")['cmdstat_' + replica_cmd]
+        assert replica_cmd_stats["calls"] == expected_replica_calls
+
+    def validate_reserve_cmd_stats(self, primary_reserve_count, primary_add_count, replica_insert_count, replica_add_count):
+        """
+            Helper fn to validate cmd count on primary & replica for the BF.RESERVE case for object creation & item add.
+        """
+        primary_cmd_stats = self.client.info("Commandstats")
+        replica_cmd_stats = self.replicas[0].client.info("Commandstats")
+        assert primary_cmd_stats['cmdstat_BF.RESERVE']["calls"] == primary_reserve_count and primary_cmd_stats['cmdstat_BF.ADD']["calls"] == primary_add_count
+        assert replica_cmd_stats['cmdstat_BF.INSERT']["calls"] == replica_insert_count and replica_cmd_stats['cmdstat_BF.ADD']["calls"] == replica_add_count
+
     def test_replication_behavior(self):
         self.setup_replication(num_replicas=1)
-        is_random_seed = self.client.execute_command('CONFIG GET bf.bloom-use-random-seed')
         # Test replication for write commands.
         bloom_write_cmds = [
-            ('BF.ADD', 'BF.ADD key item', 'BF.ADD key item1', 2),
-            ('BF.MADD', 'BF.MADD key item', 'BF.MADD key item1', 2),
+            ('BF.ADD', 'BF.ADD key item', 'BF.ADD key item1', 1),
+            ('BF.MADD', 'BF.MADD key item', 'BF.MADD key item1', 1),
             ('BF.RESERVE', 'BF.RESERVE key 0.001 100000', 'BF.ADD key item1', 1),
             ('BF.INSERT', 'BF.INSERT key items item', 'BF.INSERT key items item1', 2),
         ]
@@ -37,35 +54,38 @@ class TestBloomReplication(ReplicationTestCase):
             prefix = test_case[0]
             create_cmd = test_case[1]
             # New bloom object being created is replicated.
+            # Validate that the bloom object creation command replicated as BF.INSERT.
             self.client.execute_command(create_cmd)
             assert self.client.execute_command('EXISTS key') == 1
             self.waitForReplicaToSyncUp(self.replicas[0])
             assert self.replicas[0].client.execute_command('EXISTS key') == 1
+            self.validate_cmd_stats(prefix, 'BF.INSERT', 1, 1)
 
             # New item added to an existing bloom is replicated.
             item_add_cmd = test_case[2]
+            expected_calls = test_case[3]
             self.client.execute_command(item_add_cmd)
             assert self.client.execute_command('BF.EXISTS key item1') == 1
             self.waitForReplicaToSyncUp(self.replicas[0])
             assert self.replicas[0].client.execute_command('BF.EXISTS key item1') == 1
-
-            # Validate that the bloom object creation command and item add command was replicated.
-            expected_calls = test_case[3]
-            primary_cmd_stats = self.client.info("Commandstats")['cmdstat_' + prefix]
-            replica_cmd_stats = self.replicas[0].client.info("Commandstats")['cmdstat_' + prefix]
-            assert primary_cmd_stats["calls"] == expected_calls and replica_cmd_stats["calls"] == expected_calls
-
+            # Validate that item addition (not bloom creation) is using the original command
+            if prefix != 'BF.RESERVE':
+                self.validate_cmd_stats(prefix, prefix, 2, expected_calls)
+            else:
+                # In case of the BF.RESERVE test case, we use BF.ADD to add items. Validate this is replicated.
+                self.validate_reserve_cmd_stats(1, 1, 1, 1)
             # Attempting to add an existing item to an existing bloom will NOT replicated.
             self.client.execute_command(item_add_cmd)
             self.waitForReplicaToSyncUp(self.replicas[0])
             primary_cmd_stats = self.client.info("Commandstats")
             replica_cmd_stats = self.replicas[0].client.info("Commandstats")
-            if prefix == 'BF.RESERVE':
-                assert primary_cmd_stats['cmdstat_' + prefix]["calls"] == 1 and replica_cmd_stats['cmdstat_' + prefix]["calls"] == 1
-                assert primary_cmd_stats['cmdstat_BF.ADD']["calls"] == 2 and replica_cmd_stats['cmdstat_BF.ADD']["calls"] == 1
+            if prefix != 'BF.RESERVE':
+                self.validate_cmd_stats(prefix, prefix, 3, expected_calls)
             else:
-                assert primary_cmd_stats['cmdstat_' + prefix]["calls"] == (expected_calls + 1) and replica_cmd_stats['cmdstat_' + prefix]["calls"] == expected_calls
-            
+                # In case of the BF.RESERVE test case, we use BF.ADD to add items. Validate this is not replicated since
+                # the item already exists.
+                self.validate_reserve_cmd_stats(1, 2, 1, 1)
+
             # cmd debug digest
             server_digest_primary = self.client.debug_digest()
             assert server_digest_primary != None or 0000000000000000000000000000000000000000
@@ -73,12 +93,7 @@ class TestBloomReplication(ReplicationTestCase):
             assert server_digest_primary == server_digest_replica
             object_digest_primary = self.client.execute_command('DEBUG DIGEST-VALUE key')
             debug_digest_replica = self.replicas[0].client.execute_command('DEBUG DIGEST-VALUE key')
-            # TODO: Update the test here to validate that digest always matches during replication. Once we implement
-            # deterministic replication (including replicating seeds), this assert will be updated.
-            if is_random_seed[1] == b'yes':
-                assert object_digest_primary != debug_digest_replica
-            else:
-                assert object_digest_primary == debug_digest_replica
+            assert object_digest_primary == debug_digest_replica
 
             self.client.execute_command('FLUSHALL')
             self.waitForReplicaToSyncUp(self.replicas[0])
@@ -139,3 +154,30 @@ class TestBloomReplication(ReplicationTestCase):
             assert primary_cmd_stats["calls"] == 1
             assert primary_cmd_stats["failed_calls"] == 1
             assert ('cmdstat_' + prefix) not in self.replicas[0].client.info("Commandstats")
+
+    def test_deterministic_replication(self):
+        self.setup_replication(num_replicas=1)
+        # Set non default global properties (config) on the primary node. Any bloom creation on the primary should be
+        # replicated with the properties below.
+        assert self.client.execute_command('CONFIG SET bf.bloom-capacity 1000') == b'OK'
+        assert self.client.execute_command('CONFIG SET bf.bloom-expansion 3') == b'OK'
+        # Test bloom object creation with every command type.
+        bloom_write_cmds = [
+            ('BF.ADD', 'BF.ADD key item'),
+            ('BF.MADD', 'BF.MADD key item'),
+            ('BF.RESERVE', 'BF.RESERVE key 0.001 100000'),
+            ('BF.INSERT', 'BF.INSERT key items item'),
+        ]
+        for test_case in bloom_write_cmds:
+            prefix = test_case[0]
+            create_cmd = test_case[1]
+            self.client.execute_command(create_cmd)
+            server_digest_primary = self.client.debug_digest()
+            assert server_digest_primary != None or 0000000000000000000000000000000000000000
+            server_digest_replica = self.client.debug_digest()
+            object_digest_primary = self.client.execute_command('DEBUG DIGEST-VALUE key')
+            debug_digest_replica = self.replicas[0].client.execute_command('DEBUG DIGEST-VALUE key')
+            assert server_digest_primary == server_digest_replica
+            assert object_digest_primary == debug_digest_replica
+            self.client.execute_command('FLUSHALL')
+            self.waitForReplicaToSyncUp(self.replicas[0])


### PR DESCRIPTION
With this PR, the following changes are made:
1. Every bloom object creation is replicated with a custom created BF.INSERT command that includes every bloom property that can be a result of global default configs on the primary. With this, the exact same bloom object created on the primary will be created on the replica. Replicated properties include: Capacity, False Positive Rate, Tightening Ratio, Seed (used by hash functions), Items (incase of a object creation + item add operation).
2. Refactored BloomFilterType and BloomFilter structures to not have public exposed structure members. This is accessible from getter methods now.
3. Updated the DIGEST logic to include the `is_seed_random` bool property which indicates whether the bloom object is using a fixed seed or random seed. 
4. Added python integration testing for validation of deterministic replication creation behavior wise. Also, when the primary node and replica nodes have different global configs, tests were added to validate the digest of the bloom object created from replicated command matches the object on the primary node
