### PR TITLE
Adding bloom defrag hits and misses to info, added check these metrics get incremented in defrag test

### DIFF
--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -8,6 +8,8 @@ lazy_static! {
     pub static ref BLOOM_NUM_FILTERS_ACROSS_OBJECTS: AtomicU64 = AtomicU64::new(0);
     pub static ref BLOOM_NUM_ITEMS_ACROSS_OBJECTS: AtomicU64 = AtomicU64::new(0);
     pub static ref BLOOM_CAPACITY_ACROSS_OBJECTS: AtomicU64 = AtomicU64::new(0);
+    pub static ref BLOOM_DEFRAG_HITS: AtomicU64 = AtomicU64::new(0);
+    pub static ref BLOOM_DEFRAG_MISSES: AtomicU64 = AtomicU64::new(0);
 }
 
 pub fn bloom_info_handler(ctx: &InfoContext) -> ValkeyResult<()> {
@@ -40,6 +42,16 @@ pub fn bloom_info_handler(ctx: &InfoContext) -> ValkeyResult<()> {
             BLOOM_CAPACITY_ACROSS_OBJECTS
                 .load(Ordering::Relaxed)
                 .to_string(),
+        )?
+        .build_section()?
+        .add_section("bloom_defrag_metrics")
+        .field(
+            "bloom_defrag_hits",
+            BLOOM_DEFRAG_HITS.load(Ordering::Relaxed).to_string(),
+        )?
+        .field(
+            "bloom_defrag_misses",
+            BLOOM_DEFRAG_MISSES.load(Ordering::Relaxed).to_string(),
         )?
         .build_section()?
         .build_info()?;

--- a/tests/test_bloom_defrag.py
+++ b/tests/test_bloom_defrag.py
@@ -65,7 +65,8 @@ class TestBloomDefrag(ValkeyBloomTestCaseBase):
         assert float(memory_info_after_defrag.get('allocator_frag_ratio', 0)) < float(memory_info_non_defragged.get('allocator_frag_ratio', 0))
         # Check that items we added still exist in the respective bloom objects
         self.check_values_present(scale_names, num_items_inserted_per_object)
-
+        info_results = self.client.info_section("bf")
+        assert info_results.info['bf_bloom_defrag_hits'] + info_results.info['bf_bloom_defrag_misses'] > 0
         self.client.bgsave()
         self.server.wait_for_save_done()
 
@@ -88,6 +89,8 @@ class TestBloomDefrag(ValkeyBloomTestCaseBase):
         assert  final_defrag_hits > initial_defrag_hits or final_defrag_misses > initial_defrag_misses, "No defragmentation occurred after RDB load"
         # Check that items we added still exist in the respective bloom objects
         self.check_values_present(scale_names, num_items_inserted_per_object)
+        info_results = self.client.info_section("bf")
+        assert info_results.info['bf_bloom_defrag_hits'] + info_results.info['bf_bloom_defrag_misses'] > 0
  
     def check_values_present(self, scale_names, num_items_inserted_per_object):
         for index, scale in enumerate(scale_names[1::2]):

--- a/tests/valkeytests/valkey_test_case.py
+++ b/tests/valkeytests/valkey_test_case.py
@@ -193,6 +193,10 @@ class ValkeyClient(StrictValkey):
     def info_obj(self):
         """Return a ValkeyInfo object for the current client info"""
         return ValkeyInfo(self.info('all'))
+    
+    def info_section(self, section):
+        """Return a ValkeyInfo object for the current client info section"""
+        return ValkeyInfo(self.info(section))
 
     def bitfield(self, name, *values):
         """


### PR DESCRIPTION
Added a new section in info specifically for defrag. Added two new fields in this section of defrag hits and misses that are incremented in bloom_callback.
Added a check in defrag test to make sure these metrics are actually incremented