### PR TITLE
Deflaking tests to remove chance of false positives causing tests to fail

### DIFF
--- a/tests/test_aofrewrite.py
+++ b/tests/test_aofrewrite.py
@@ -1,4 +1,4 @@
-import time
+from util.waiters import *
 from valkeytests.valkey_test_case import ValkeyAction
 from valkey_bloom_test_case import ValkeyBloomTestCaseBase
 from valkeytests.conftest import resource_port_tracker
@@ -61,7 +61,6 @@ class TestBloomAofRewrite(ValkeyBloomTestCaseBase):
         self.client.bgrewriteaof()
         self.server.wait_for_action_done(ValkeyAction.AOF_REWRITE)
         # restart server
-        time.sleep(1)
         self.server.restart(remove_rdb=False, remove_nodes_conf=False, connect_client=True)
         assert self.server.is_alive()
         restored_server_digest = self.client.debug_digest()
@@ -78,4 +77,5 @@ class TestBloomAofRewrite(ValkeyBloomTestCaseBase):
 
         # Delete the scaled bloomfilter to check both filters are deleted and metrics stats are set accordingly
         self.client.execute_command('DEL key1')
+        wait_for_equal(lambda: self.client.execute_command('BF.EXISTS key1 item_prefix1'), 0)
         self.verify_bloom_metrics(self.client.execute_command("INFO bf"), 0, 0, 0, 0, 0)

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -31,7 +31,7 @@ class TestBloomBasic(ValkeyBloomTestCaseBase):
         bf_exists_result = client.execute_command('BF.EXISTS filter1 item1')
         assert bf_exists_result == 1
         bf_exists_result = client.execute_command('BF.EXISTS filter1 item2')
-        assert bf_exists_result == 0
+        assert bf_exists_result == 0 or bf_exists_result == 1
 
     def test_copy_and_exists_cmd(self):
         client = self.server.get_new_client()

--- a/tests/test_bloom_command.py
+++ b/tests/test_bloom_command.py
@@ -127,6 +127,8 @@ class TestBloomCommand(ValkeyBloomTestCaseBase):
 
         for test_case in basic_behavior_test_case:
             cmd = test_case[0]
+            # For non multi commands, this is the verbatim expected result. 
+            # For multi commands, test_case[1] contains the number of item add/exists results which are expected to be 0 or 1.
             expected_result = test_case[1]
             # For Cardinality commands we want to add items till we are at the number of items we expect then check Cardinality worked
             if cmd.upper().startswith("BF.CARD"):

--- a/tests/test_bloom_command.py
+++ b/tests/test_bloom_command.py
@@ -25,10 +25,6 @@ class TestBloomCommand(ValkeyBloomTestCaseBase):
         # test set up
         assert self.client.execute_command('BF.ADD key item') == 1
         assert self.client.execute_command('BF.RESERVE bf 0.01 1000') == b'OK'
-        # non scaling filter
-        assert self.client.execute_command('BF.RESERVE bf_non 0.01 2 NONSCALING') == b'OK'
-        assert self.client.execute_command('BF.ADD bf_non 0') == 1
-        assert self.client.execute_command('BF.ADD bf_non 1') == 1
 
         basic_error_test_cases = [
             # not found
@@ -93,27 +89,24 @@ class TestBloomCommand(ValkeyBloomTestCaseBase):
         basic_behavior_test_case = [
             ('BF.ADD key item', 1),
             ('BF.ADD key item', 0),
-            ('BF.ADD key item1', 1),
             ('BF.EXISTS key item', 1),
-            ('BF.EXISTS key item2', 0),
-            ('BF.MADD key item item2', [0, 1]),
+            ('BF.MADD key item item2', 2),
             ('BF.EXISTS key item', 1),
             ('BF.EXISTS key item2', 1),
-            ('BF.EXISTS key item3', 0),
-            ('BF.MADD hello world1 world2 world3', [1, 1, 1]),
-            ('BF.MADD hello world1 world2 world3 world4', [0, 0, 0, 1]),
-            ('BF.MEXISTS hello world5', [0]),
-            ('BF.MADD hello world5', [1]),
-            ('BF.MEXISTS hello world5 world6 world7', [1, 0, 0]),
-            ('BF.INSERT TEST ITEMS ITEM', [1]),
-            ('BF.INSERT TEST CAPACITY 1000 ITEMS ITEM', [0]),
-            ('BF.INSERT TEST CAPACITY 200 error 0.50 ITEMS ITEM ITEM1 ITEM2', [0, 1, 1]),
-            ('BF.INSERT TEST CAPACITY 300 ERROR 0.50 EXPANSION 1 ITEMS ITEM FOO', [0, 1]),
-            ('BF.INSERT TEST ERROR 0.50 EXPANSION 3 NOCREATE items BOO', [1]), 
-            ('BF.INSERT TEST ERROR 0.50 EXPANSION 1 NOCREATE NONSCALING items BOO', [0]),
-            ('BF.INSERT TEST_EXPANSION EXPANSION 9 ITEMS ITEM', [1]),
-            ('BF.INSERT TEST_CAPACITY CAPACITY 2000 ITEMS ITEM', [1]),
-            ('BF.INSERT TEST_ITEMS ITEMS 1 2 3 EXPANSION 2', [1, 1, 1, 1, 0]),
+            ('BF.MADD hello world1 world2 world3', 3),
+            ('BF.MADD hello world1 world2 world3 world4', 4),
+            ('BF.MEXISTS hello world5', 1),
+            ('BF.MADD hello world5', 1),
+            ('BF.MEXISTS hello world5 world6 world7', 3),
+            ('BF.INSERT TEST ITEMS ITEM', 1),
+            ('BF.INSERT TEST CAPACITY 1000 ITEMS ITEM', 1),
+            ('BF.INSERT TEST CAPACITY 200 error 0.50 ITEMS ITEM ITEM1 ITEM2', 3),
+            ('BF.INSERT TEST CAPACITY 300 ERROR 0.50 EXPANSION 1 ITEMS ITEM FOO', 2),
+            ('BF.INSERT TEST ERROR 0.50 EXPANSION 3 NOCREATE items BOO', 1), 
+            ('BF.INSERT TEST ERROR 0.50 EXPANSION 1 NOCREATE NONSCALING items BOO', 1),
+            ('BF.INSERT TEST_EXPANSION EXPANSION 9 ITEMS ITEM', 1),
+            ('BF.INSERT TEST_CAPACITY CAPACITY 2000 ITEMS ITEM', 1),
+            ('BF.INSERT TEST_ITEMS ITEMS 1 2 3 EXPANSION 2', 5),
             ('BF.INFO TEST Capacity', 100),
             ('BF.INFO TEST ITEMS', 5),
             ('BF.INFO TEST filters', 1),
@@ -125,6 +118,7 @@ class TestBloomCommand(ValkeyBloomTestCaseBase):
             ('BF.CARD TEST', 5),
             ('bf.card HELLO', 0),
             ('BF.RESERVE bf 0.01 1000', b'OK'),
+            ('BF.EXISTS bf non_existant', 0),
             ('BF.RESERVE bf_exp 0.01 1000 EXPANSION 2', b'OK'),
             ('BF.RESERVE bf_non 0.01 1000 NONSCALING', b'OK'),
             ('bf.info bf_exp expansion', 2),
@@ -134,6 +128,11 @@ class TestBloomCommand(ValkeyBloomTestCaseBase):
         for test_case in basic_behavior_test_case:
             cmd = test_case[0]
             expected_result = test_case[1]
+            # For Cardinality commands we want to add items till we are at the number of items we expect then check Cardinality worked
+            if cmd.upper().startswith("BF.CARD"):
+                self.add_items_till_capacity(self.client, cmd.split()[-1], expected_result, 1, "item_prefix")
+            # For multi commands expected result is actually the length of the expected return. While for other commands this we have the literal
+            # expected result
             self.verify_command_success_reply(self.client, cmd, expected_result)
 
         # test bf.info

--- a/tests/test_bloom_metrics.py
+++ b/tests/test_bloom_metrics.py
@@ -21,11 +21,11 @@ class TestBloomMetrics(ValkeyBloomTestCaseBase):
         # Check that other commands don't influence metrics
         assert(self.client.execute_command('BF.EXISTS key item1') == 1)
         assert(self.client.execute_command('BF.ADD key item2') == 1)
-        assert(self.client.execute_command('BF.MADD key item3 item4')== [1, 1])
-        assert(self.client.execute_command('BF.MEXISTS key item3 item5')== [1, 0])
-        assert(self.client.execute_command('BF.CARD key') == 4)
+        assert(len(self.client.execute_command('BF.MADD key item3 item4')) == 2)
+        assert(len(self.client.execute_command('BF.MEXISTS key item3 item5')) == 2)
+        assert(1 <= self.client.execute_command('BF.CARD key') <= 4)
         self.client.execute_command("BF.INFO key")
-        assert(self.client.execute_command('BF.INSERT key ITEMS item5 item6')== [1, 1])
+        assert(len(self.client.execute_command('BF.INSERT key ITEMS item5 item6'))== 2)
         
         self.verify_bloom_metrics(self.client.execute_command("INFO bf"), DEFAULT_BLOOM_FILTER_SIZE, 1, 1, 6, DEFAULT_BLOOM_FILTER_CAPACITY)
         self.verify_bloom_metrics(self.client.execute_command("INFO Modules"), DEFAULT_BLOOM_FILTER_SIZE, 1, 1, 6, DEFAULT_BLOOM_FILTER_CAPACITY)
@@ -79,9 +79,6 @@ class TestBloomMetrics(ValkeyBloomTestCaseBase):
 
     def test_scaled_bloomfilter_metrics(self):
         self.client.execute_command('BF.RESERVE key1 0.001 7000')
-        # We use a number greater than 7000 in order to have a buffer for any false positives
-        variables = [f"key{i+1}" for i in range(7500)]
-
         # Get original size to compare against size after scaled
         info_obj = self.client.execute_command('BF.INFO key1')
         # Add keys until bloomfilter will scale out

--- a/tests/test_correctness.py
+++ b/tests/test_correctness.py
@@ -15,8 +15,7 @@ class TestBloomCorrectness(ValkeyBloomTestCaseBase):
         assert client.execute_command(f'BF.RESERVE {filter_name} {expected_fp_rate} {capacity} NONSCALING') == b"OK"
         # Add items and fill the filter to capacity.
         error_count, add_operation_idx = self.add_items_till_capacity(client, filter_name, capacity, 1, item_prefix)
-        with pytest.raises(Exception, match="non scaling filter is full"):
-            client.execute_command(f'BF.ADD {filter_name} new_item')
+        self.add_items_till_scaling_failure(client, filter_name, add_operation_idx, item_prefix)
         # Validate that is is filled.
         info = client.execute_command(f'BF.INFO {filter_name}')
         it = iter(info)

--- a/tests/test_save_and_restore.py
+++ b/tests/test_save_and_restore.py
@@ -85,7 +85,6 @@ class TestBloomSaveRestore(ValkeyBloomTestCaseBase):
         assert bf_exists_result_1 == 1
         bf_info_result_1 = client.execute_command('BF.INFO testSave')
         assert(len(bf_info_result_1)) != 0
-        curr_item_count_1 = client.info_obj().num_keys()
 
         # Save rdb and try to load this on a sever. Validate module data type load fails and server does not startup.
         client.bgsave()


### PR DESCRIPTION
Updated unit tests and integration tests to remove the chance of false positives causing the tests to fail. Before we would assert for each item of insert madd and mexists but due to false positive sometimes the output can be unexpected. For these outputs we now assert if they are equal to 1 or 0 and the length of the return is correct instead of the exact number we expect.
I also updated areas where we are checking bf.card as again false positives could cause this number to be lower than expected. In order to remedy this I changed where we test this command or I called a method that will add up until that number of items taking into account fp's.  
For the unit tests we could have a false positive in the add where that item thinks its already been added. To remedy this we now perform a loop until we try and add an item we don't think exists. This will still then check that we get the correct error while not having a small chance to fail on a fp.

Also removed some creations and commands that weren't used anywhere 

