### PR TITLE
Add server version validation during module loading

### DIFF
--- a/src/bloom/utils.rs
+++ b/src/bloom/utils.rs
@@ -10,6 +10,7 @@ use bloomfilter::Bloom;
 use bloomfilter::{deserialize, serialize};
 use serde::{Deserialize, Deserializer, Serialize};
 use std::sync::atomic::Ordering;
+use valkey_module::raw::Version;
 
 /// KeySpace Notification Events
 pub const ADD_EVENT: &str = "bloom.add";
@@ -708,6 +709,15 @@ impl Drop for BloomFilter {
     }
 }
 
+pub fn valid_server_version(version: Version) -> bool {
+    let server_version = &[
+        version.major.into(),
+        version.minor.into(),
+        version.patch.into(),
+    ];
+    server_version >= configs::BLOOM_MIN_SUPPORTED_VERSION
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -715,6 +725,7 @@ mod tests {
     use configs;
     use rand::{distributions::Alphanumeric, Rng};
     use rstest::rstest;
+    use valkey_module::raw::Version;
 
     /// Returns random string with specified number of characters.
     fn random_prefix(len: usize) -> String {
@@ -1253,5 +1264,45 @@ mod tests {
             assert!(test_v.capacity() == x as usize);
             test_v.push(i);
         }
+    }
+
+    #[test]
+    fn test_valid_server_version() {
+        let v1 = Version {
+            major: 8,
+            minor: 1,
+            patch: 0,
+        };
+        let v2 = Version {
+            major: 8,
+            minor: 0,
+            patch: 1,
+        };
+        let v3 = Version {
+            major: 7,
+            minor: 1,
+            patch: 0,
+        };
+        let v4 = Version {
+            major: 7,
+            minor: 0,
+            patch: 1,
+        };
+        let v5 = Version {
+            major: 8,
+            minor: 0,
+            patch: -1,
+        };
+        let v6 = Version {
+            major: 8,
+            minor: 0,
+            patch: 0,
+        };
+        assert!(valid_server_version(v1));
+        assert!(valid_server_version(v2));
+        assert!(!valid_server_version(v3));
+        assert!(!valid_server_version(v4));
+        assert!(!valid_server_version(v5));
+        assert!(valid_server_version(v6));
     }
 }

--- a/src/configs.rs
+++ b/src/configs.rs
@@ -69,6 +69,8 @@ pub const FIXED_SEED: [u8; 32] = [
     89, 15, 245, 34, 234, 120, 17, 218, 167, 20, 216, 9, 59, 62, 123, 217, 29, 137, 138, 115, 62,
     152, 136, 135, 48, 127, 151, 205, 40, 7, 51, 131,
 ];
+/// Minimal Valkey version that supports Bloom Module
+pub const BLOOM_MIN_SUPPORTED_VERSION: &[i64; 3] = &[8, 0, 0];
 
 /// This is a config set handler for the False Positive Rate and Tightening Ratio configs.
 pub fn on_string_config_set(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,12 +9,27 @@ pub mod metrics;
 pub mod wrapper;
 use crate::bloom::command_handler;
 use crate::bloom::data_type::BLOOM_TYPE;
+use crate::bloom::utils::valid_server_version;
 use valkey_module_macros::info_command_handler;
 
 pub const MODULE_NAME: &str = "bf";
 
-fn initialize(_ctx: &Context, _args: &[ValkeyString]) -> Status {
-    Status::Ok
+fn initialize(ctx: &Context, _args: &[ValkeyString]) -> Status {
+    let ver = ctx
+        .get_redis_version()
+        .expect("Unable to get server version!");
+    if !valid_server_version(ver) {
+        ctx.log_warning(
+            format!(
+                "The minimum supported Valkey server version for the valkey-bloom module is {:?}",
+                configs::BLOOM_MIN_SUPPORTED_VERSION
+            )
+            .as_str(),
+        );
+        Status::Err
+    } else {
+        Status::Ok
+    }
 }
 
 fn deinitialize(_ctx: &Context) -> Status {


### PR DESCRIPTION
Check server version during module loading. If server version not satisfy minimal required version, module failed loading with message in log.

### Testing
#### Manually Testing
Created 2 versions of valkey-server and valkey-cli:
* server version 7.255.255 : `make` valkey/unstable locally with `version.h` updated to `VALKEY_VERSION 7.255.255` and `VALKEY_VERSION_NUM 0x0007FFFF`. 
* server version 255.255.255: `make` valkey/unstable

##### Load module during server initialized
`./valkey-server-7255255 --loadmodule /<path>/libvalkey_bloom.so`
**Sever aborting**. 
Output like following:
```
112072:M 20 Feb 2025 22:48:00.892 # WARNING Your system is configured to use the 'xen' clocksource which might lead to degraded performance. Check the result of the [slow-clocksource] system check: run 'valkey-server --check-system' to check if the system's clocksource isn't degrading performance.
112072:M 20 Feb 2025 22:48:00.892 * oO0OoO0OoO0Oo Valkey is starting oO0OoO0OoO0Oo
112072:M 20 Feb 2025 22:48:00.892 * Valkey version=7.255.255, bits=64, commit=54c4bbce, modified=1, pid=112072, just started
112072:M 20 Feb 2025 22:48:00.892 * Configuration loaded
112072:M 20 Feb 2025 22:48:00.892 * monotonic clock: POSIX clock_gettime
                .+^+.                                                
            .+#########+.                                            
        .+########+########+.           Valkey 7.255.255 (54c4bbce/1) 64 bit
    .+########+'     '+########+.                                    
 .########+'     .+.     '+########.    Running in standalone mode
 |####+'     .+#######+.     '+####|    Port: 6379
 |###|   .+###############+.   |###|    PID: 112072                     
 |###|   |#####*'' ''*#####|   |###|                                 
 |###|   |####'  .-.  '####|   |###|                                 
 |###|   |###(  (@@@)  )###|   |###|          https://valkey.io      
 |###|   |####.  '-'  .####|   |###|                                 
 |###|   |#####*.   .*#####|   |###|                                 
 |###|   '+#####|   |#####+'   |###|                                 
 |####+.     +##|   |#+'     .+####|                                 
 '#######+   |##|        .+########'                                 
    '+###|   |##|    .+########+'                                    
        '|   |####+########+'                                        
             +#########+'                                            
                '+v+'                                                

112072:M 20 Feb 2025 22:48:00.894 * Legacy Redis Module /<path>/libvalkey_bloom.so found
112072:M 20 Feb 2025 22:48:00.894 * <bf> Created new data type 'bloomfltr'
112072:M 20 Feb 2025 22:48:00.894 # <bf> Current server version doesn't satisfy minimal required version for bloom module!
112072:M 20 Feb 2025 22:48:00.894 # Module /<path>/libvalkey_bloom.so initialization failed. Module not loaded.
112072:M 20 Feb 2025 22:48:00.894 # Can't load module from /<path>/libvalkey_bloom.so: server aborting
```

##### Loading module via command module load
Client response with `(error) ERR Error loading the extension. Please check the server logs.`
Server initialized with error message in log, 
```
110951:M 20 Feb 2025 22:46:36.914 * Server initialized
110951:M 20 Feb 2025 22:46:36.914 * Loading RDB produced by Valkey version 7.255.255
110951:M 20 Feb 2025 22:46:36.914 * RDB age 13 seconds
110951:M 20 Feb 2025 22:46:36.914 * RDB memory usage when created 0.93 Mb
110951:M 20 Feb 2025 22:46:36.914 * Done loading RDB, keys loaded: 0, keys expired: 0.
110951:M 20 Feb 2025 22:46:36.914 * DB loaded from disk: 0.000 seconds
110951:M 20 Feb 2025 22:46:36.914 * Ready to accept connections tcp
110951:M 20 Feb 2025 22:47:09.193 * Legacy Redis Module /<path>/libvalkey_bloom.so found
110951:M 20 Feb 2025 22:47:09.193 * <bf> Created new data type 'bloomfltr'
110951:M 20 Feb 2025 22:47:09.193 # <bf> Current server version doesn't satisfy minimal required version for bloom module!
110951:M 20 Feb 2025 22:47:09.193 # Module /<path>/libvalkey_bloom.so initialization failed. Module not loaded.
```

#### Integration Test
`./build.sh` successfully completed. All tests passed.