### PR TITLE
Adding tightening ratio to bf.info and updating allowed range for bloom-expansion config

### DIFF
--- a/src/bloom/command_handler.rs
+++ b/src/bloom/command_handler.rs
@@ -716,6 +716,9 @@ pub fn bloom_filter_info(ctx: &Context, input_args: &[ValkeyString]) -> ValkeyRe
                 "FILTERS" => Ok(ValkeyValue::Integer(val.num_filters() as i64)),
                 "ITEMS" => Ok(ValkeyValue::Integer(val.cardinality())),
                 "ERROR" => Ok(ValkeyValue::Float(val.fp_rate())),
+                "TIGHTENING" if val.expansion() > 0 => {
+                    Ok(ValkeyValue::Float(val.tightening_ratio()))
+                }
                 "EXPANSION" => {
                     if val.expansion() == 0 {
                         return Ok(ValkeyValue::Null);
@@ -759,8 +762,9 @@ pub fn bloom_filter_info(ctx: &Context, input_args: &[ValkeyString]) -> ValkeyRe
                 result.push(ValkeyValue::Null);
             } else {
                 result.push(ValkeyValue::Integer(val.expansion() as i64));
-            }
-            if val.expansion() != 0 {
+                // The following fields are only relevant to scalable filters, so will only be included if expansion is not equal to 0.
+                result.push(ValkeyValue::SimpleStringStatic("Tightening ratio"));
+                result.push(ValkeyValue::Float(val.tightening_ratio()));
                 let max_capacity = match utils::BloomObject::calculate_max_scaled_capacity(
                     val.starting_capacity(),
                     val.fp_rate(),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -119,7 +119,7 @@ valkey_module! {
     configurations: [
         i64: [
             ["bloom-capacity", &*configs::BLOOM_CAPACITY, configs::BLOOM_CAPACITY_DEFAULT, configs::BLOOM_CAPACITY_MIN, configs::BLOOM_CAPACITY_MAX, ConfigurationFlags::DEFAULT, None],
-            ["bloom-expansion", &*configs::BLOOM_EXPANSION, configs::BLOOM_EXPANSION_DEFAULT, configs::BLOOM_EXPANSION_MIN as i64, configs::BLOOM_EXPANSION_MAX as i64, ConfigurationFlags::DEFAULT, None],
+            ["bloom-expansion", &*configs::BLOOM_EXPANSION, configs::BLOOM_EXPANSION_DEFAULT, 0, configs::BLOOM_EXPANSION_MAX as i64, ConfigurationFlags::DEFAULT, None],
             ["bloom-memory-usage-limit", &*configs::BLOOM_MEMORY_LIMIT_PER_OBJECT, configs::BLOOM_MEMORY_LIMIT_PER_OBJECT_DEFAULT, configs::BLOOM_MEMORY_LIMIT_PER_OBJECT_MIN, configs::BLOOM_MEMORY_LIMIT_PER_OBJECT_MAX, ConfigurationFlags::DEFAULT, None],
         ],
         string: [

--- a/tests/test_bloom_basic.py
+++ b/tests/test_bloom_basic.py
@@ -362,6 +362,25 @@ class TestBloomBasic(ValkeyBloomTestCaseBase):
         except ResponseError as e:
             assert str(e) == f"CONFIG SET failed (possibly related to argument 'bf.bloom-tightening-ratio') - ERR (0 < tightening ratio range < 1)"
 
+    def test_bloom_config_set_changes_default_creations(self):
+        """
+        This is a test that validates the bloom configuration set logic changes the defualt creations for bloom objects
+        """     
+        assert self.client.execute_command('CONFIG SET bf.bloom-capacity 10000') == b'OK'
+        assert self.client.execute_command('CONFIG SET bf.bloom-expansion 0') == b'OK'
+        assert self.client.execute_command('CONFIG SET bf.bloom-fp-rate 0.75') == b'OK'
+        assert self.client.execute_command('CONFIG SET bf.bloom-tightening-ratio 0.4') == b'OK'
+        
+        assert self.client.execute_command("BF.ADD changed_default item") == 1
+
+        assert self.client.execute_command('BF.INFO changed_default CAPACITY') == 10000
+        assert self.client.execute_command('BF.INFO changed_default ERROR') == str(0.75).encode()
+
+
+        bf_info_full = self.client.execute_command("BF.INFO changed_default")
+        assert b'Max scaled capacity' not in bf_info_full
+        assert b'Tightening ratio' not in bf_info_full
+
     def test_bloom_dump_and_restore(self):
         """
         This is a test that validates the bloom data has same debug digest value before and after using restore command

--- a/tests/test_bloom_command.py
+++ b/tests/test_bloom_command.py
@@ -22,12 +22,14 @@ class TestBloomCommand(ValkeyBloomTestCaseBase):
         # test set up
         assert self.client.execute_command('BF.ADD key item') == 1
         assert self.client.execute_command('BF.RESERVE bf 0.01 1000') == b'OK'
-
+        assert self.client.execute_command('BF.RESERVE non_scaling_info 0.01 1000 NONSCALING') == b'OK'
         basic_error_test_cases = [
             # not found
             ('BF.INFO TEST404', 'not found'),
             # incorrect syntax and argument usage
             ('bf.info key item', 'invalid information value'),
+            ('bf.info non_scaling_info TIGHTENING', 'invalid information value'),
+            ('bf.info non_scaling_info MAXSCALEDCAPACITY', 'invalid information value'),
             ('bf.insert key CAPACITY 10000 ERROR 0.01 EXPANSION 0.99 NOCREATE NONSCALING ITEMS test1 test2 test3', 'bad expansion'),
             ('BF.INSERT KEY HELLO WORLD', 'unknown argument received'),
             ('BF.INSERT KEY error 2 ITEMS test1', '(0 < error rate range < 1)'),
@@ -123,6 +125,7 @@ class TestBloomCommand(ValkeyBloomTestCaseBase):
             ('BF.INFO TEST MAXSCALEDCAPACITY', 26214300),
             ('BF.INFO TEST_VAL_SCALE_1 ERROR', b'0.0001'),
             ('BF.INFO TEST_VAL_SCALE_2 ERROR', b'0.5'),
+            ('BF.INFO TEST TIGHTENING', b'0.5'),
             ('BF.CARD key', 3),
             ('BF.CARD hello', 5),
             ('BF.CARD TEST', 5),
@@ -148,13 +151,33 @@ class TestBloomCommand(ValkeyBloomTestCaseBase):
             self.verify_command_success_reply(self.client, cmd, expected_result)
 
         # test bf.info
-        assert self.client.execute_command('BF.RESERVE BF_INFO 0.50 2000 NONSCALING') == b'OK'
-        bf_info = self.client.execute_command('BF.INFO BF_INFO')
-        capacity_index = bf_info.index(b'Capacity') + 1
-        filter_index = bf_info.index(b'Number of filters') + 1
-        item_index = bf_info.index(b'Number of items inserted') + 1
-        expansion_index = bf_info.index(b'Expansion rate') + 1
-        assert bf_info[capacity_index] == self.client.execute_command('BF.INFO BF_INFO CAPACITY') == 2000
-        assert bf_info[filter_index] == self.client.execute_command('BF.INFO BF_INFO FILTERS') == 1
-        assert bf_info[item_index] == self.client.execute_command('BF.INFO BF_INFO ITEMS') == 0
-        assert bf_info[expansion_index] == self.client.execute_command('BF.INFO BF_INFO EXPANSION') == None
+        assert self.client.execute_command('BF.RESERVE BF_INFO_NON_SCALING 0.50 2000 NONSCALING') == b'OK'
+        assert self.client.execute_command('BF.RESERVE BF_INFO_SCALING 0.50 2000') == b'OK'
+
+        for bf_name in ['BF_INFO_NON_SCALING', 'BF_INFO_SCALING']:
+            bf_info = self.client.execute_command(f'BF.INFO {bf_name}')
+            
+            capacity_index = bf_info.index(b'Capacity') + 1
+            filter_index = bf_info.index(b'Number of filters') + 1
+            item_index = bf_info.index(b'Number of items inserted') + 1
+            error_rate_index = bf_info.index(b'Error rate') + 1
+            expansion_index = bf_info.index(b'Expansion rate') + 1
+
+            assert bf_info[capacity_index] == self.client.execute_command(f'BF.INFO {bf_name} CAPACITY') == 2000
+            assert bf_info[filter_index] == self.client.execute_command(f'BF.INFO {bf_name} FILTERS') == 1
+            assert bf_info[item_index] == self.client.execute_command(f'BF.INFO {bf_name} ITEMS') == 0
+            assert bf_info[error_rate_index] == self.client.execute_command(f'BF.INFO {bf_name} ERROR') == str(0.5).encode()
+
+            if bf_name == 'BF_INFO_SCALING':
+                assert bf_info[expansion_index] == self.client.execute_command(f'BF.INFO {bf_name} EXPANSION') == 2
+                # Check scaling specific fields
+                max_scaled_capacity_index = bf_info.index(b'Max scaled capacity') + 1
+                tightening_ratio_index = bf_info.index(b'Tightening ratio') + 1
+                assert bf_info[max_scaled_capacity_index] == self.client.execute_command(f'BF.INFO {bf_name} MAXSCALEDCAPACITY') == 32766000
+                assert bf_info[tightening_ratio_index] == self.client.execute_command(f'BF.INFO {bf_name} TIGHTENING') == str(0.5).encode()
+            else:
+                # For non-scaling, expansion should be None
+                assert bf_info[expansion_index] == self.client.execute_command(f'BF.INFO {bf_name} EXPANSION') == None
+                # Check scaling specific fields don't appear in info
+                assert b'Max scaled capacity' not in bf_info
+                assert b'Tightening ratio' not in bf_info

--- a/tests/test_bloom_correctness.py
+++ b/tests/test_bloom_correctness.py
@@ -25,6 +25,7 @@ class TestBloomCorrectness(ValkeyBloomTestCaseBase):
         assert info_dict[b'Size'] > 0
         assert info_dict[b'Expansion rate'] == None
         assert info_dict[b'Error rate'] == str(expected_fp_rate).encode()
+
         assert "Max scaled capacity" not in info_dict
         # Use a margin on the expected_fp_rate when asserting for correctness.
         fp_margin = 0.002
@@ -61,6 +62,7 @@ class TestBloomCorrectness(ValkeyBloomTestCaseBase):
         client = self.server.get_new_client()
         item_prefix = self.generate_random_string()
         expected_fp_rate = 0.001
+        expected_tightening_ratio = 0.5
         initial_capacity = 10000
         expansion = 2
         num_filters_to_scale = 5
@@ -76,6 +78,7 @@ class TestBloomCorrectness(ValkeyBloomTestCaseBase):
         assert info_dict[b'Size'] > 0
         assert info_dict[b'Expansion rate'] == expansion
         assert info_dict[b'Error rate'] == str(expected_fp_rate).encode()
+        assert info_dict[b'Tightening ratio'] == str(expected_tightening_ratio).encode()
         assert info_dict[b'Max scaled capacity'] == 20470000
 
         # Scale out by adding items.
@@ -96,6 +99,8 @@ class TestBloomCorrectness(ValkeyBloomTestCaseBase):
             assert info_dict[b'Size'] > 0
             assert info_dict[b'Expansion rate'] == expansion
             assert info_dict[b'Error rate'] == str(expected_fp_rate).encode()
+            assert info_dict[b'Tightening ratio'] == str(expected_tightening_ratio).encode()
+
             assert info_dict[b'Max scaled capacity'] == 20470000
 
         # Use a margin on the expected_fp_rate when asserting for correctness.


### PR DESCRIPTION
Two changes in this PR
### First Change
Added it so tightening ratio is returned by BF.INFO.
**Testing**
Expanded two tests that check info to make sure the tightening ratio we get returned is what we expect. Also added a similar check in one place for false positive rate as well. Tested the negative case as well so if we have a scaling filter we should not return the tightening ratio.

### Second Change
Previously we had a lower limit of 1 for setting the expansion rate, this meant we wouldn't allow a user to have by default a non scaling filter. I updated this range to now include 0 at the lower end so now the user can set it so they create non-scaling filters by default
**Testing**
Added a new test that checks that setting configs actually updated the default creations.