### PR TITLE
Removing unnecessary code form valkey_test_case

### DIFF
--- a/tests/test_bloom_aofrewrite.py
+++ b/tests/test_bloom_aofrewrite.py
@@ -6,10 +6,8 @@ from valkeytests.conftest import resource_port_tracker
 class TestBloomAofRewrite(ValkeyBloomTestCaseBase):
     
     def get_custom_args(self):
-        # test aof rewrite should avoid bloom filter override as rdb. use aof
-        args = super().get_custom_args()
-        args.update({'aof-use-rdb-preamble': 'no', 'appendonly': 'yes'})
-        return args
+        self.args.update({'aof-use-rdb-preamble': 'no', 'appendonly': 'yes'})
+        return self.args
 
     def test_basic_aofrewrite_and_restore(self):
         client = self.server.get_new_client()

--- a/tests/test_bloom_aofrewrite.py
+++ b/tests/test_bloom_aofrewrite.py
@@ -4,10 +4,6 @@ from valkey_bloom_test_case import ValkeyBloomTestCaseBase
 from valkeytests.conftest import resource_port_tracker
 
 class TestBloomAofRewrite(ValkeyBloomTestCaseBase):
-    
-    def get_custom_args(self):
-        self.args.update({'aof-use-rdb-preamble': 'no', 'appendonly': 'yes'})
-        return self.args
 
     def test_basic_aofrewrite_and_restore(self):
         client = self.server.get_new_client()

--- a/tests/test_bloom_aofrewrite.py
+++ b/tests/test_bloom_aofrewrite.py
@@ -19,9 +19,10 @@ class TestBloomAofRewrite(ValkeyBloomTestCaseBase):
         assert bf_exists_result_1 == 1
         bf_info_result_1 = client.execute_command('BF.INFO testSave')
         assert(len(bf_info_result_1)) != 0
-        curr_item_count_1 = client.info_obj().num_keys()
+        curr_item_count_1 = self.server.num_keys()
+
         # cmd debug digest
-        server_digest = client.debug_digest()
+        server_digest = client.execute_command('DEBUG', 'DIGEST')
         assert server_digest != None or 0000000000000000000000000000000000000000
         object_digest = client.execute_command('DEBUG DIGEST-VALUE testSave')
 
@@ -32,13 +33,13 @@ class TestBloomAofRewrite(ValkeyBloomTestCaseBase):
         time.sleep(1)
         self.server.restart(remove_rdb=False, remove_nodes_conf=False, connect_client=True)
         assert self.server.is_alive()
-        restored_server_digest = client.debug_digest()
+        restored_server_digest = client.execute_command('DEBUG', 'DIGEST')
         restored_object_digest = client.execute_command('DEBUG DIGEST-VALUE testSave')
         assert restored_server_digest == server_digest
         assert restored_object_digest == object_digest
 
         # verify restore results
-        curr_item_count_2 = client.info_obj().num_keys()
+        curr_item_count_2 = self.server.num_keys()
         assert curr_item_count_2 == curr_item_count_1
         bf_exists_result_2 = client.execute_command('BF.EXISTS testSave item')
         assert bf_exists_result_2 == 1
@@ -53,7 +54,7 @@ class TestBloomAofRewrite(ValkeyBloomTestCaseBase):
         self.add_items_till_capacity(self.client, "key1", 7500, 1, "item_prefix")
 
         # cmd debug digest
-        server_digest = self.client.debug_digest()
+        server_digest = self.client.execute_command('DEBUG', 'DIGEST')
         assert server_digest != None or 0000000000000000000000000000000000000000
         object_digest = self.client.execute_command('DEBUG DIGEST-VALUE key1')
 
@@ -63,7 +64,7 @@ class TestBloomAofRewrite(ValkeyBloomTestCaseBase):
         # restart server
         self.server.restart(remove_rdb=False, remove_nodes_conf=False, connect_client=True)
         assert self.server.is_alive()
-        restored_server_digest = self.client.debug_digest()
+        restored_server_digest = self.client.execute_command('DEBUG', 'DIGEST')
         restored_object_digest = self.client.execute_command('DEBUG DIGEST-VALUE key1')
         assert restored_server_digest == server_digest
         assert restored_object_digest == object_digest

--- a/tests/test_bloom_basic.py
+++ b/tests/test_bloom_basic.py
@@ -37,11 +37,11 @@ class TestBloomBasic(ValkeyBloomTestCaseBase):
         mexists_result = client.execute_command('BF.MEXISTS filter item1 item2 item3 item4')
         assert len(madd_result) == 4 and len(mexists_result) == 4
         # cmd debug digest
-        server_digest = client.debug_digest()
+        server_digest = client.execute_command('DEBUG', 'DIGEST')
         assert server_digest != None or 0000000000000000000000000000000000000000
         object_digest = client.execute_command('DEBUG DIGEST-VALUE filter')
         assert client.execute_command('COPY filter new_filter') == 1
-        copied_server_digest = client.debug_digest()
+        copied_server_digest = client.execute_command('DEBUG', 'DIGEST')
         assert copied_server_digest != None or 0000000000000000000000000000000000000000
         copied_object_digest = client.execute_command('DEBUG DIGEST-VALUE filter')
         assert client.execute_command('EXISTS new_filter') == 1
@@ -112,30 +112,30 @@ class TestBloomBasic(ValkeyBloomTestCaseBase):
         client = self.server.get_new_client()
         assert client.execute_command("CONFIG SET maxmemory-policy allkeys-lru") == b"OK"
         assert client.execute_command("CONFIG SET maxmemory {}".format(two_megabytes)) == b"OK"
-        used_memory = client.info_obj().used_memory()
-        maxmemory = client.info_obj().maxmemory()
+        used_memory = client.info()['used_memory']
+        maxmemory = client.info()['maxmemory']
         client.execute_command('BF.ADD filter item1')
-        new_used_memory = client.info_obj().used_memory()
+        new_used_memory = client.info()['used_memory']
         assert new_used_memory > used_memory and new_used_memory < maxmemory
         assert client.execute_command(bloom_cmd_large_allocation) == b"OK"
         assert client.execute_command('DBSIZE') < 2
         assert client.info("Stats")['evicted_keys'] > 0
-        used_memory = client.info_obj().used_memory()
+        used_memory = client.info()['used_memory']
         assert used_memory < maxmemory
         client.execute_command('FLUSHALL')
         client.execute_command('BF.ADD filter item1')
         assert client.execute_command("CONFIG SET maxmemory-policy volatile-lru") == b"OK"
         assert client.execute_command(bloom_cmd_large_allocation) == b"OK"
         assert client.execute_command('DBSIZE') == 2
-        used_memory = client.info_obj().used_memory()
+        used_memory = client.info()['used_memory']
         assert used_memory > maxmemory
 
     def test_large_allocation_when_above_maxmemory(self):
         client = self.server.get_new_client()
         assert client.execute_command("CONFIG SET maxmemory-policy allkeys-lru") == b"OK"
-        used_memory = client.info_obj().used_memory()
+        used_memory = client.info()['used_memory']
         client.execute_command('BF.ADD filter item1')
-        new_used_memory = client.info_obj().used_memory()
+        new_used_memory = client.info()['used_memory']
         assert new_used_memory > used_memory
         # Configure the server to now be over maxmemory with allkeys-lru policy. Test that allocation fails.
         assert client.execute_command("CONFIG SET maxmemory {}".format(used_memory)) == b"OK"

--- a/tests/test_bloom_defrag.py
+++ b/tests/test_bloom_defrag.py
@@ -64,9 +64,9 @@ class TestBloomDefrag(ValkeyBloomTestCaseBase):
         assert float(memory_info_after_defrag.get('allocator_frag_ratio', 0)) < float(memory_info_non_defragged.get('allocator_frag_ratio', 0))
         # Check that items we added still exist in the respective bloom objects
         self.check_values_present(scale_names, num_items_inserted_per_object)
-        info_results = self.client.info_section("bf")
-        assert info_results.info['bf_bloom_defrag_hits'] + info_results.info['bf_bloom_defrag_misses'] > 0
-        self.client.bgsave()
+        info_results = self.client.info("bf")
+        assert info_results['bf_bloom_defrag_hits'] + info_results['bf_bloom_defrag_misses'] > 0
+        self.client.execute_command('BGSAVE')
         self.server.wait_for_save_done()
 
         self.server.restart(remove_rdb=False, remove_nodes_conf=False, connect_client=True)
@@ -88,8 +88,8 @@ class TestBloomDefrag(ValkeyBloomTestCaseBase):
         assert  final_defrag_hits > initial_defrag_hits or final_defrag_misses > initial_defrag_misses, "No defragmentation occurred after RDB load"
         # Check that items we added still exist in the respective bloom objects
         self.check_values_present(scale_names, num_items_inserted_per_object)
-        info_results = self.client.info_section("bf")
-        assert info_results.info['bf_bloom_defrag_hits'] + info_results.info['bf_bloom_defrag_misses'] > 0
+        info_results = self.client.info("bf")
+        assert info_results['bf_bloom_defrag_hits'] + info_results['bf_bloom_defrag_misses'] > 0
  
     def check_values_present(self, scale_names, num_items_inserted_per_object):
         for index, scale in enumerate(scale_names[1::2]):

--- a/tests/test_bloom_metrics.py
+++ b/tests/test_bloom_metrics.py
@@ -120,7 +120,7 @@ class TestBloomMetrics(ValkeyBloomTestCaseBase):
         # Get info and metrics stats of bloomfilter before rdb load
         original_info_obj = self.client.execute_command('BF.INFO key1')
 
-        self.client.bgsave()
+        self.client.execute_command('BGSAVE')
         self.server.wait_for_save_done()
 
         # Restart, and verify metrics are correct

--- a/tests/test_bloom_replication.py
+++ b/tests/test_bloom_replication.py
@@ -10,7 +10,7 @@ class TestBloomReplication(ReplicationTestCase):
 
     @pytest.fixture(autouse=True)
     def setup_test(self, setup):
-        self.args = {"maxmemory-policy":"allkeys-random", "activerehashing":"yes", "repl-diskless-sync": "yes", "save": "", "enable-debug-command":"yes", 'loadmodule': os.getenv('MODULE_PATH'),'bf.bloom-use-random-seed': self.use_random_seed}
+        self.args = {"enable-debug-command":"yes", 'loadmodule': os.getenv('MODULE_PATH'),'bf.bloom-use-random-seed': self.use_random_seed}
         server_path = f"{os.path.dirname(os.path.realpath(__file__))}/.build/binaries/{os.environ['SERVER_VERSION']}/valkey-server"
 
         self.server, self.client = self.create_server(testdir = self.testdir,  server_path=server_path, args=self.args)

--- a/tests/test_bloom_replication.py
+++ b/tests/test_bloom_replication.py
@@ -86,9 +86,9 @@ class TestBloomReplication(ReplicationTestCase):
                 self.validate_reserve_cmd_stats(1, 2, 1, 1)
 
             # cmd debug digest
-            server_digest_primary = self.client.debug_digest()
+            server_digest_primary = self.client.execute_command('DEBUG', 'DIGEST')
             assert server_digest_primary != None or 0000000000000000000000000000000000000000
-            server_digest_replica = self.client.debug_digest()
+            server_digest_replica = self.client.execute_command('DEBUG', 'DIGEST')
             assert server_digest_primary == server_digest_replica
             object_digest_primary = self.client.execute_command('DEBUG DIGEST-VALUE key')
             debug_digest_replica = self.replicas[0].client.execute_command('DEBUG DIGEST-VALUE key')
@@ -173,9 +173,9 @@ class TestBloomReplication(ReplicationTestCase):
             prefix = test_case[0]
             create_cmd = test_case[1]
             self.client.execute_command(create_cmd)
-            server_digest_primary = self.client.debug_digest()
+            server_digest_primary = self.client.execute_command('DEBUG', 'DIGEST')
             assert server_digest_primary != None or 0000000000000000000000000000000000000000
-            server_digest_replica = self.client.debug_digest()
+            server_digest_replica = self.client.execute_command('DEBUG', 'DIGEST')
             object_digest_primary = self.client.execute_command('DEBUG DIGEST-VALUE key')
             debug_digest_replica = self.replicas[0].client.execute_command('DEBUG DIGEST-VALUE key')
             assert server_digest_primary == server_digest_replica

--- a/tests/test_bloom_replication.py
+++ b/tests/test_bloom_replication.py
@@ -8,12 +8,12 @@ class TestBloomReplication(ReplicationTestCase):
     # Global Parameterized Configs
     use_random_seed = 'no'
 
-    def get_custom_args(self):
-        self.set_server_version(os.environ['SERVER_VERSION'])
-        return {
-            'loadmodule': os.getenv('MODULE_PATH'),
-            'bf.bloom-use-random-seed': self.use_random_seed,
-        }
+    @pytest.fixture(autouse=True)
+    def setup_test(self, setup):
+        self.args = {"maxmemory-policy":"allkeys-random", "activerehashing":"yes", "repl-diskless-sync": "yes", "save": "", "enable-debug-command":"yes", 'loadmodule': os.getenv('MODULE_PATH'),'bf.bloom-use-random-seed': self.use_random_seed}
+        server_path = f"{os.path.dirname(os.path.realpath(__file__))}/.build/binaries/{os.environ['SERVER_VERSION']}/valkey-server"
+
+        self.server, self.client = self.create_server(testdir = self.testdir,  server_path=server_path, args=self.args)
 
     @pytest.fixture(autouse=True)
     def use_random_seed_fixture(self, bloom_config_parameterization):

--- a/tests/test_bloom_save_and_restore.py
+++ b/tests/test_bloom_save_and_restore.py
@@ -112,9 +112,8 @@ class TestBloomSaveRestore(ValkeyBloomTestCaseBase):
         rdb_file = self.server.args["dbfilename"]
 
         # Create a server without bloom-module
-        self.server_id += 1
         new_server = ValkeyServerHandle(bind_ip=self.get_bind_ip(), port=self.get_bind_port(), port_tracker=self.port_tracker,
-                                        cwd=self.testdir, server_id=self.server_id, server_path=self.server_path)
+                                        cwd=self.testdir, server_path=self.server_path)
         new_server.set_startup_args({"dbfilename": rdb_file})
         new_server.start()
         assert new_server.is_alive()

--- a/tests/test_bloom_save_and_restore.py
+++ b/tests/test_bloom_save_and_restore.py
@@ -15,20 +15,20 @@ class TestBloomSaveRestore(ValkeyBloomTestCaseBase):
         assert bf_exists_result_1 == 1
         bf_info_result_1 = client.execute_command('BF.INFO testSave')
         assert(len(bf_info_result_1)) != 0
-        curr_item_count_1 = client.info_obj().num_keys()
+        curr_item_count_1 = self.server.num_keys(client=client)
         # cmd debug digest
-        server_digest = client.debug_digest()
+        server_digest = client.execute_command('DEBUG', 'DIGEST')
         assert server_digest != None or 0000000000000000000000000000000000000000
         object_digest = client.execute_command('DEBUG DIGEST-VALUE testSave')
 
         # save rdb, restart sever
-        client.bgsave()
+        client.execute_command('BGSAVE')
         self.server.wait_for_save_done()
         self.server.restart(remove_rdb=False, remove_nodes_conf=False, connect_client=True)
 
         assert self.server.is_alive()
         wait_for_equal(lambda: self.server.is_rdb_done_loading(), True)
-        restored_server_digest = client.debug_digest()
+        restored_server_digest = client.execute_command('DEBUG', 'DIGEST')
         restored_object_digest = client.execute_command('DEBUG DIGEST-VALUE testSave')
         assert restored_server_digest == server_digest
         assert restored_object_digest == object_digest
@@ -36,7 +36,7 @@ class TestBloomSaveRestore(ValkeyBloomTestCaseBase):
         self.server.verify_string_in_logfile("Done loading RDB, keys loaded: 1, keys expired: 0")
 
         # verify restore results
-        curr_item_count_2 = client.info_obj().num_keys()
+        curr_item_count_2 = self.server.num_keys(client=client)
         assert curr_item_count_2 == curr_item_count_1
         bf_exists_result_2 = client.execute_command('BF.EXISTS testSave item')
         assert bf_exists_result_2 == 1
@@ -52,10 +52,10 @@ class TestBloomSaveRestore(ValkeyBloomTestCaseBase):
             bf_add_result_1 = client.execute_command('BF.ADD ' + name + ' item')
             assert bf_add_result_1 == 1
 
-        curr_item_count_1 = client.info_obj().num_keys()
+        curr_item_count_1 = self.server.num_keys(client=client)
         assert curr_item_count_1 == count
         # save rdb, restart sever
-        client.bgsave()
+        client.execute_command('BGSAVE')
         self.server.wait_for_save_done()
 
         self.server.restart(remove_rdb=False, remove_nodes_conf=False, connect_client=True)
@@ -65,7 +65,7 @@ class TestBloomSaveRestore(ValkeyBloomTestCaseBase):
         self.server.verify_string_in_logfile("Done loading RDB, keys loaded: 500, keys expired: 0")
 
         # verify restore results
-        curr_item_count_1 = client.info_obj().num_keys()
+        curr_item_count_1 = self.server.num_keys(client=client)
 
         assert curr_item_count_1 == count
 
@@ -88,7 +88,7 @@ class TestBloomSaveRestore(ValkeyBloomTestCaseBase):
         assert(len(bf_info_result_1)) != 0
 
         # Save rdb and try to load this on a sever. Validate module data type load fails and server does not startup.
-        client.bgsave()
+        client.execute_command('BGSAVE')
         self.server.wait_for_save_done()
         self.server.restart(remove_rdb=False, remove_nodes_conf=False, connect_client=False)
         logfile = os.path.join(self.testdir, self.server.args["logfile"])
@@ -103,11 +103,11 @@ class TestBloomSaveRestore(ValkeyBloomTestCaseBase):
         bf_client = self.server.get_new_client()
         bf_client.execute_command("BF.ADD key val")
         bf_client.execute_command("set string val")
-        assert bf_client.info_obj().num_keys() == 2
+        assert self.server.num_keys(client=bf_client) == 2
         assert bf_client.execute_command("del key") == 1
-        assert bf_client.info_obj().num_keys() == 1
+        assert self.server.num_keys(client=bf_client) == 1
         assert bf_client.get("string") == b"val"
-        bf_client.bgsave()
+        bf_client.execute_command('BGSAVE')
         self.server.wait_for_save_done()
         rdb_file = self.server.args["dbfilename"]
 
@@ -129,6 +129,6 @@ class TestBloomSaveRestore(ValkeyBloomTestCaseBase):
         except ResponseError as e:
             assert "unknown command" in str(e)
 
-        assert new_client.info_obj().num_keys() == 1
+        assert self.server.num_keys(client=new_client) == 1
         assert new_client.get("string") == b"val"
         new_server.exit()

--- a/tests/valkey_bloom_test_case.py
+++ b/tests/valkey_bloom_test_case.py
@@ -4,6 +4,7 @@ from valkeytests.valkey_test_case import ValkeyTestCase
 from valkey import ResponseError
 import random
 import string
+import logging
 
 class ValkeyBloomTestCaseBase(ValkeyTestCase):
 
@@ -12,13 +13,11 @@ class ValkeyBloomTestCaseBase(ValkeyTestCase):
 
     @pytest.fixture(autouse=True)
     def setup_test(self, setup):
-        args = {"maxmemory-policy":"allkeys-random", "activerehashing":"yes", "repl-diskless-sync": "yes", "save": "", "enable-debug-command":"yes", 'loadmodule': os.getenv('MODULE_PATH'),'bf.bloom-use-random-seed': self.use_random_seed}
+        args = {"enable-debug-command":"yes", 'loadmodule': os.getenv('MODULE_PATH'),'bf.bloom-use-random-seed': self.use_random_seed}
         server_path = f"{os.path.dirname(os.path.realpath(__file__))}/.build/binaries/{os.environ['SERVER_VERSION']}/valkey-server"
 
         self.server, self.client = self.create_server(testdir = self.testdir,  server_path=server_path, args=args)
-
-        print("startup args are: ", args)
-
+        logging.info("startup args are: %s", args)
 
     @pytest.fixture(autouse=True)
     def use_random_seed_fixture(self, bloom_config_parameterization):

--- a/tests/valkey_bloom_test_case.py
+++ b/tests/valkey_bloom_test_case.py
@@ -10,12 +10,15 @@ class ValkeyBloomTestCaseBase(ValkeyTestCase):
     # Global Parameterized Configs
     use_random_seed = 'no'
 
-    def get_custom_args(self):
-        self.set_server_version(os.environ['SERVER_VERSION'])
-        return {
-            'loadmodule': os.getenv('MODULE_PATH'),
-            'bf.bloom-use-random-seed': self.use_random_seed,
-        }
+    @pytest.fixture(autouse=True)
+    def setup_test(self, setup):
+        args = {"maxmemory-policy":"allkeys-random", "activerehashing":"yes", "repl-diskless-sync": "yes", "save": "", "enable-debug-command":"yes", 'loadmodule': os.getenv('MODULE_PATH'),'bf.bloom-use-random-seed': self.use_random_seed}
+        server_path = f"{os.path.dirname(os.path.realpath(__file__))}/.build/binaries/{os.environ['SERVER_VERSION']}/valkey-server"
+
+        self.server, self.client = self.create_server(testdir = self.testdir,  server_path=server_path, args=args)
+
+        print("startup args are: ", args)
+
 
     @pytest.fixture(autouse=True)
     def use_random_seed_fixture(self, bloom_config_parameterization):

--- a/tests/valkey_bloom_test_case.py
+++ b/tests/valkey_bloom_test_case.py
@@ -52,7 +52,7 @@ class ValkeyBloomTestCaseBase(ValkeyTestCase):
             assert client.execute_command(f'BF.EXISTS {key} {value}') == 0, f"Item {key} {value} exists"
 
     def verify_server_key_count(self, client, expected_num_keys):
-        actual_num_keys = client.info_obj().num_keys()
+        actual_num_keys = self.server.num_keys()
         assert_num_key_error_msg = f"Actual key number {actual_num_keys} is different from expected key number {expected_num_keys}"
         assert actual_num_keys == expected_num_keys, assert_num_key_error_msg
 

--- a/tests/valkeytests/util/waiters.py
+++ b/tests/valkeytests/util/waiters.py
@@ -85,3 +85,17 @@ def wait_for_true(func, **kwargs):
     asserts that this happens within a timeout.
     """
     _wait_for(func, **kwargs)
+
+def wait_for_false(func, **kwargs):
+    """
+    Wait for a given function to return False, and
+    asserts that this happens within a timeout.
+    """
+    _wait_for(func, expected_value=True, op=operator.ne, **kwargs)
+
+def wait_for_ne(func, expected_value, **kwargs):
+    """
+    Wait for a given function to return a value not equal to the expected_value, and
+    asserts that this happens within a timeout.
+    """
+    _wait_for(func, expected_value=expected_value, op=operator.ne, **kwargs)

--- a/tests/valkeytests/valkey_test_case.py
+++ b/tests/valkeytests/valkey_test_case.py
@@ -2,6 +2,7 @@ import subprocess
 import time
 import os
 import pytest
+import shutil
 import re
 from contextlib import contextmanager
 from functools import wraps
@@ -51,157 +52,8 @@ def expect(lhs, op, rhs):
     if not op(lhs, rhs):
         raise ExpectException(lhs, op, rhs)
 
-
-@wait()
-def wait_for_true(expr):
-    return expr
-
 class ValkeyAction(Enum):
     AOF_REWRITE = 1
-
-
-class ValkeyInfo:
-    """Contains information about a point in time of Valkey"""
-    def __init__(self, info):
-        self.info = info
-
-    def is_save_in_progress(self):
-        """Return True if there is a save in progress."""
-        return self.info['rdb_bgsave_in_progress'] == 1
-    
-    def is_aof_rewrite_in_progress(self):
-        """Return True if there is a aof rwrite in progress."""
-        return self.info['aof_rewrite_in_progress'] == 1
-
-    def num_keys(self, db=0):
-        if 'db{}'.format(db) in self.info:
-            return self.info['db{}'.format(db)]['keys']
-        return 0
-
-    def get_master_repl_offset(self):
-        return self.info['master_repl_offset']
-
-    def get_master_replid(self):
-        return self.info['master_replid']
-
-    def get_replica_repl_offset(self):
-        return self.info['slave_repl_offset']
-
-    def is_master_link_up(self):
-        """Returns True if role is slave and master_link_status is up"""
-        if self.info['role'] == 'slave' and self.info['master_link_status'] == 'up':
-            return True
-        return False
-
-    def num_replicas(self):
-        return self.info['connected_slaves']
-
-    def num_replicas_online(self):
-        count=0
-        for k,v in self.info.items():
-            if re.match('^slave[0-9]', k) and v['state'] == 'online':
-                count += 1
-        return count
-
-    def was_save_successful(self):
-        return self.info['rdb_last_bgsave_status'] == 'ok'
-
-    def was_aofrewrite_successful(self):
-        return self.info['aof_last_bgrewrite_status'] == 'ok'
-
-    def used_memory(self):
-        return self.info['used_memory']
-
-    def maxmemory(self):
-        return self.info['maxmemory']
-
-    def maxmemory_policy(self):
-        return self.info['maxmemory_policy']
-
-    def uptime_in_secs(self):
-        return self.info['uptime_in_seconds']
-
-# An extension of the StrictValkey client
-# that supports additional Valkey functionality
-class ValkeyClient(StrictValkey):
-    def set_password(self, pw):
-        """
-        Set the password for the server's connection.  Must be called after requirepass has been applied.
-        """
-        self.connection_pool.reset()
-        self.connection_pool.connection_kwargs.update({'password': pw})
-
-    def get_connection(self):
-        """
-        Obtain a raw connection from the client's connection pool.  Callers must ensure that they
-        return the connection via release_connection().
-        """
-        return self.connection_pool.get_connection(None)
-
-    def release_connection(self, connection):
-        """
-        Release a raw connection back into the pool.
-        """
-        self.connection_pool.release(connection)
-
-    @classmethod
-    def create_from_server(self, server, db=0):
-        print(("Created regular client for port {}".format(server.port)))
-        r = ValkeyClient(host='localhost', port=server.port, db=db)
-        return r
-
-    # Add a flag to shutdown so that we can avoid a save
-    def shutdown(self, flag=None):
-        """Shutdown the server.
-
-        Args:
-            flag: an optional argument to indicate whether a snapshot should be taken
-        """
-        try:
-            if flag:
-                self.execute_command('SHUTDOWN', flag)
-            else:
-                self.shutdown()
-        except ConnectionError:
-            # a ConnectionError here is expected
-            return
-        raise ValkeyError("SHUTDOWN seems to have failed.")
-
-    def bgsave(self, type=None):
-        """Perform a background save.
-
-        Args:
-            type: an optional argument to indicate the type of snapshot.
-        """
-        if type is None:
-            return self.execute_command('BGSAVE')
-        else:
-            return self.execute_command('BGSAVE', type)
-
-    def restore(self, name, ttl, value, replace=False):
-        """Create a key using the provided serialized value, previously obtained
-        using DUMP.
-        """
-        return self.execute_command('RESTORE', name, ttl, value, 'REPLACE' if replace else "")
-
-    def info_obj(self):
-        """Return a ValkeyInfo object for the current client info"""
-        return ValkeyInfo(self.info('all'))
-    
-    def info_section(self, section):
-        """Return a ValkeyInfo object for the current client info section"""
-        return ValkeyInfo(self.info(section))
-
-    def bitfield(self, name, *values):
-        """
-        Executes specified subcommands to the specified key identified by
-        the ``name`` argument. We are not doing any syntax validation of
-        the specified subcommands idenfied by ``values``
-        """
-        return self.execute_command('BITFIELD', name, *values)
-
-    def debug_digest(self):
-        return self.execute_command('DEBUG', 'DIGEST')
 
 class ValkeyServerHandle(object):
     """Handle to a valkey server process"""
@@ -221,13 +73,19 @@ class ValkeyServerHandle(object):
         self.cwd = cwd
         self.valkey_path = server_path
 
+    @classmethod
+    def create_from_server(self, server, db=0):
+        print(("Created regular client for port {}".format(server.port)))
+        r = StrictValkey(host='localhost', port=server.port, db=db)
+        return r
+    
     def set_startup_args(self, args):
         self.args.update(args)
 
     def get_new_client(self):
-        return ValkeyClient.create_from_server(self)
+        return self.create_from_server(self)
 
-    def exit(self, remove_rdb=True, remove_nodes_conf=True):
+    def exit(self, test_teardown=True, remove_nodes_conf=True):
         if self.client:
             try:
                 self.client.shutdown('nosave')
@@ -244,7 +102,10 @@ class ValkeyServerHandle(object):
             if "logfile" in self.args and os.path.exists(os.path.join(self.cwd, self.args["logfile"])):
                 os.remove(os.path.join(self.cwd, self.args["logfile"]))
 
-        if remove_rdb and "dbfilename" in self.args and os.path.exists(os.path.join(self.cwd, self.args["dbfilename"])):
+            if test_teardown and "appenddirname" in self.args and os.path.exists(os.path.join(self.cwd, self.args["appenddirname"])):
+                shutil.rmtree(os.path.join(self.cwd, self.args["appenddirname"]))
+
+        if test_teardown and "dbfilename" in self.args and os.path.exists(os.path.join(self.cwd, self.args["dbfilename"])):
             try:
                 os.remove(os.path.join(self.cwd, self.args["dbfilename"]))
             except OSError:
@@ -256,9 +117,8 @@ class ValkeyServerHandle(object):
             except OSError:
                 os.rmdir(os.path.join(self.cwd, self.args["cluster-config-file"]))
 
-    @wait()
     def _waitForServerPoll(self):
-        return self.server.poll() != None
+        wait_for_ne(lambda: self.server.poll(), None, timeout=TEST_MAX_WAIT_TIME_SECONDS)
 
     def _waitForExit(self):
         try:
@@ -277,9 +137,9 @@ class ValkeyServerHandle(object):
     def pid(self):
         return self.server.pid
 
-    @wait(timeout = 5)
+    # DO we even need this it does the same as _waitForServerPoll
     def is_down(self):
-        return self.server.poll() != None
+        wait_for_ne(lambda: self.server.poll(), None, timeout=TEST_MAX_WAIT_TIME_SECONDS)
 
     def children_pids(self):
         process = subprocess.Popen("ps --no-headers -o pid --ppid %s" % self.pid(),
@@ -293,13 +153,12 @@ class ValkeyServerHandle(object):
         return children
 
     def wait_for_replicas(self, num_of_replicas):
-        wait_for_equal(lambda: self.client.info_obj().num_replicas(), num_of_replicas, timeout=MAX_REPLICA_WAIT_TIME)
+        wait_for_equal(lambda: self.client.info()["connected_slaves"], num_of_replicas, timeout=MAX_REPLICA_WAIT_TIME)
 
-    @wait(timeout = 60) # wait upto 30 sec checking every sec
     def wait_for_ready_to_accept_connections(self):
         logfile = os.path.join(self.cwd, self.args['logfile'])
         strings = ['Ready to accept connections']
-        return verify_any_of_strings_in_file(strings, logfile)
+        wait_for_true(lambda: verify_any_of_strings_in_file(strings, logfile), timeout=TEST_MAX_WAIT_TIME_SECONDS)
 
     def verify_string_in_logfile(self, string):
         logfile = os.path.join(self.cwd, self.args['logfile'])
@@ -366,88 +225,89 @@ class ValkeyServerHandle(object):
         except:
             return False
 
-    @wait(timeout = MAX_PING_WAIT_TIME)
     def _waitForPing(self, c):
         try:
-            return c.ping()
+            wait_for_true(lambda: c.ping(), timeout=MAX_PING_WAIT_TIME)
+            return True
         except (ConnectionError, TimeoutError) as e:
             print(e)
             return False
 
-    @wait()
     def wait_for_key(self, key, value):
         if isinstance(value, str):
             value = value.encode()
-        return self.client.get(key)== value
+        wait_for_equal(lambda: self.client.get(key), value, timeout=TEST_MAX_WAIT_TIME_SECONDS)
 
     def connect(self):
-        c = ValkeyClient.create_from_server(self)
+        c = self.create_from_server(self)
         try:
             self._waitForPing(c)
         except WaitTimeout:
              raise RuntimeError("Failed to connect or ping server")
         self.client = c
 
-    def wait_for_all_replicas_online(self, num_of_replicas):
-        """Wait for n replicas to show online"""
-        wait_for_equal(lambda: self.client.info_obj().num_replicas_online(), num_of_replicas, timeout=MAX_REPLICA_WAIT_TIME)
-
-    @wait()
-    def _wait_for_save(self, client=None):
-        """Wait the default number of seconds for the save to finish"""
-        if client is None:
-            client = self.client
-        if client.info_obj().is_save_in_progress():
-            return False
-        return True
-
     def wait_for_save_done(self, client=None):
         """Wait for the save to complete, failing if it does not complete successfully in the timeout"""
         if client is None:
             client = self.client
         try:
-            self._wait_for_save(client)
+            wait_for_ne(lambda: client.info()['rdb_bgsave_in_progress'], 1, timeout=TEST_MAX_WAIT_TIME_SECONDS)
         except WaitTimeout:
             raise RuntimeError("Save failed to complete in time")
-        assert(client.info_obj().was_save_successful())
+        assert(client.info()['rdb_last_bgsave_status'] == 'ok')
 
-    def wait_for_save_in_progress(self):
-        assert(self._wait_for_save_in_progress())
-
-    @wait()
-    def _wait_for_save_in_progress(self):
-        return self.client.info_obj().is_save_in_progress()
+    def wait_for_save_in_progress(self, client=None):
+        if client is None:
+            client = self.client
+        wait_for_equal(lambda: client.info()['rdb_bgsave_in_progress'], 1, timeout=TEST_MAX_WAIT_TIME_SECONDS)
 
     def is_rdb_done_loading(self):
         rdb_load_log = "Done loading RDB"
         return self.verify_string_in_logfile(rdb_load_log) == True
 
-
-    @wait()
-    def _wait_for_action(self, action, client=None):
-        """Wait the default number of seconds for the action to finish"""
+    def num_replicas_online(self, client=None):
         if client is None:
             client = self.client
-        
-        if action == ValkeyAction.AOF_REWRITE:
-            if client.info_obj().is_aof_rewrite_in_progress():
-                return False
-        else:
-            raise RuntimeError("{} not support".format(action))
-        return True
+        count=0
+        for k,v in client.info().items():
+            if re.match('^slave[0-9]', k) and v['state'] == 'online':
+                count += 1
+        return count
+
+    def get_default_client(self, client):
+        if client is None:
+            return self.client
+        return client
+
+    def num_keys(self, db=0, client = None):
+        if client is None:
+            client = self.client
+        if f'db{db}'.format(db) in client.info('all').keys():
+            return client.info('all')['db{}'.format(db)]['keys']
+        return 0
     
+    def is_master_link_up(self, client=None):
+        if client is None:
+            client = self.client
+        """Returns True if role is slave and master_link_status is up"""
+        if client.info()['role'] == 'slave' and client.info()['master_link_status'] == 'up':
+            return True
+        return False
+
     def _action_success_flag(self, action, client):
         if action == ValkeyAction.AOF_REWRITE:
-            return client.info_obj().was_aofrewrite_successful()
+            return client.info()['aof_last_bgrewrite_status'] == 'ok'
         else:
             raise RuntimeError("{} not support".format(action))
 
     def wait_for_action_done(self, action, client=None):
-        """Wait for the some action to complete, failing if it does not complete successfully in the timeout"""
         if client is None:
             client = self.client
         try:
-            self._wait_for_action(action, client)
+            if action == ValkeyAction.AOF_REWRITE:
+                wait_for_equal(lambda: client.info()['aof_rewrite_in_progress'], 1, timeout=TEST_MAX_WAIT_TIME_SECONDS)
+            else:
+                raise RuntimeError("{} not support".format(action))
         except WaitTimeout:
             raise RuntimeError("{} failed to complete in time".format(action))
         assert(self._action_success_flag(action, client))
@@ -497,9 +357,8 @@ class ValkeyTestCaseBase:
     def doesLogfileContain(self, filename, regex):
         return self.findLogfileLine(filename, regex) != None
 
-    @wait()
     def wait_for_logfile(self, filename, regex):
-        return self.doesLogfileContain(filename, regex)
+        wait_for_true(lambda: self.doesLogfileContain(filename, regex), timeout=TEST_MAX_WAIT_TIME_SECONDS)
 
     def check_all_keys_in_valkey(self, node, dictionary):
         """ Check that all the keys in Valkey matches that in the dictionary """
@@ -514,12 +373,8 @@ class ValkeyTestCaseBase:
             num_keys_in_valkey += 1
         return num_keys_in_valkey
 
-    @wait(timeout=MAX_SYNC_WAIT)
-    def waitForReplicaToSyncUpByClient(self, client):
-        return client.info_obj().is_master_link_up()
-
     def waitForReplicaToSyncUp(self, server):
-        return self.waitForReplicaToSyncUpByClient(server.client)
+        wait_for_true(lambda: server.is_master_link_up(), timeout=MAX_SYNC_WAIT)
 
     # Wait until a client in the Valkey is executing a command
     # Used to ensure that a thread running a blocking command has started
@@ -574,7 +429,7 @@ class ValkeyTestCase(ValkeyTestCaseBase):
         self.client = self.server.start()
         self.clients = []
         for db in range(self.num_dbs):
-            self.clients.append(ValkeyClient.create_from_server(self.server, db))
+            self.clients.append(self.server.create_from_server(self.server, db))
 
     def get_valkey_handle(self):
         """Return valkey node handle. Allow child class to override the handle type"""
@@ -597,7 +452,7 @@ class ValkeyTestCase(ValkeyTestCaseBase):
         return valkey_server
     
     def wait_for_all_replicas_online(self, n):
-        self.server.wait_for_all_replicas_online(n)
+        wait_for_equal(lambda: self.server.num_replicas_online(), n, timeout=MAX_REPLICA_WAIT_TIME)
 
     def wait_for_replicas(self, n):
         self.server.wait_for_replicas(n)
@@ -627,7 +482,7 @@ class ValkeyReplica(ValkeyServerHandle):
     
     def create_client_for_dbs(self, num_dbs):
         for db in range(num_dbs):
-            self.clients.append(ValkeyClient.create_from_server(self, db))
+            self.clients.append(ValkeyServerHandle.create_from_server(self, db))
         return self.clients
 
 class ReplicationTestCase(ValkeyTestCase):
@@ -701,30 +556,14 @@ class ReplicationTestCase(ValkeyTestCase):
         self.num_replicas = 0
         del self.replicas[:]
 
-    @wait()
     def wait_for_master_link_up_all_replicas(self):
         for i in range(self.num_replicas):
-            if self.replicas[i].client.info_obj().is_master_link_up() == False:
-                return False
-        return True
+            wait_for_true(lambda: self.replicas[i].is_master_link_up(), timeout=MAX_SYNC_WAIT)
 
-    @wait()
     def wait_for_value_propagate_to_replicas(self, key, value, db=0):
         for i in range(self.num_replicas):
-            if str(value) != self.replicas[i].clients[db].get(key):
-                return False
-        return True
+            wait_for_equal(lambda: self.replicas[i].clients[db].get(key), value, timout=TEST_MAX_WAIT_TIME_SECONDS)
 
-    @wait()
     def waitForReplicaOffsetToSyncUp(self, master, replica):
-        minfo = master.client.info_obj()
-        rinfo = replica.client.info_obj()
-        if minfo.get_master_repl_offset() == rinfo.get_replica_repl_offset():
-            return True
-
-        print("MASTER: master_repl_offset({0}), REPLICA: master_repl_offset({1}), slave_repl_offset({2}), slave_read_repl_offset({3})".format(
-                minfo.info['master_repl_offset'],
-                rinfo.info['master_repl_offset'],
-                rinfo.info['slave_repl_offset'],
-                rinfo.info['slave_read_repl_offset']))
-        return False
+        minfo = master.info()['master_repl_offset']
+        wait_for_equal(lambda: replica.client.info()['slave_repl_offset'], minfo.get_master_repl_offset(), timeout=TEST_MAX_WAIT_TIME_SECONDS)

--- a/tests/valkeytests/valkey_test_case.py
+++ b/tests/valkeytests/valkey_test_case.py
@@ -69,6 +69,7 @@ class ValkeyServerHandle(object):
         self.args["port"] = self.port
         self.args["logfile"] = "logfile_{}".format(port)
         self.args["dbfilename"] = "testrdb-{}.rdb".format(port)
+        self.args["appenddirname"] = "aof-{}".format(port)
         self.cwd = cwd
         self.valkey_path = server_path
 
@@ -181,7 +182,7 @@ class ValkeyServerHandle(object):
         if self.server:
             raise RuntimeError("Server already started")
         server_args = []
-        server_args.extend([('%s/../' + self.valkey_path) % os.path.dirname(os.path.realpath(__file__))])
+        server_args.extend([self.valkey_path])
         for k, v in list(self.args.items()):
             server_args.append('--' + k.replace("_", "-"))
             args = str(v).split()
@@ -330,11 +331,6 @@ class ValkeyTestCaseBase:
         self.args = {}
         self.port_tracker = resource_port_tracker
 
-    def _get_valkey_args(self):
-        self.args.update({"maxmemory":self.maxmemory, "maxmemory-policy":"allkeys-random", "activerehashing":"yes", "databases": self.num_dbs, "repl-diskless-sync": "yes", "save": "", 'appenddirname': f'aof-{self.port}', "enable-debug-command":"yes"})
-        self.args.update(self.get_custom_args())
-        return self.args
-
     def ensureDirExists(self, dir):
         if not os.path.isdir(self.testdir):
             try:
@@ -397,55 +393,40 @@ class ValkeyTestCaseBase:
         return self.DEFAULT_BIND_IP
 
 class ValkeyTestCase(ValkeyTestCaseBase):
-    num_dbs = 5
-    num_keys = 100
-    rdb_size = 168231
-    repl_save_info_size = 83 # Bytes used for saving replication info in RDB aux fields
-    diskless_overhead = 87 # RDB overhead is 2 x 40 byte EOF marker + 7 characters ("$EOF:" + "\r\n") for the beginning of the EOF marker
-    server_path = ".build/binaries/unstable/valkey-server" #Unstable is the default server build
-
-    def set_server_version(self, new_version):
-        self.server_path = f".build/binaries/{new_version}/valkey-server"
+    server_path = "valkey-server" # The default server build is assumed that valkey-server is set
 
     def common_setup(self):
         self.maxmemory = "500MB"
-        print(dir(self))
         self.port = self.port_tracker.get_unused_port()
         self.ensureDirExists(self.testdir)
         self.server_list = []
 
-
     @pytest.fixture(autouse=True)
     def setup(self, port_tracker_fixture):
         self.common_setup()
-        args = self._get_valkey_args()
-        self.server = self.create_server(testdir = self.testdir,  server_path=self.server_path)
-        self.server.set_startup_args(args)
-        print("startup args are: ", args)
-
-        self.client = self.server.start()
-        self.clients = []
-        for db in range(self.num_dbs):
-            self.clients.append(self.server.create_from_server(self.server, db))
+        yield
 
     def get_valkey_handle(self):
         """Return valkey node handle. Allow child class to override the handle type"""
         return ValkeyServerHandle
 
     # Expose bind_ip parameter to caller to have more flexible
-    def create_server(self, testdir, bind_ip=None, port=None, server_path=server_path):
+    def create_server(self, testdir, bind_ip=None, port=None, server_path=server_path, args=""):
         if not bind_ip:
             bind_ip = self.get_bind_ip()
 
         if not port:
             port = self.get_bind_port()
         valkey_server_handle = self.get_valkey_handle()
+        self.server_path = server_path
         valkey_server = valkey_server_handle( bind_ip = bind_ip, port = port,
             port_tracker = self.port_tracker,
             cwd = testdir, server_path=server_path)
         self.server_list.append(valkey_server)
-        return valkey_server
-    
+        valkey_server.args.update(args)
+        valkey_cli = valkey_server.start()
+        return valkey_server, valkey_cli
+
     def wait_for_all_replicas_online(self, n):
         wait_for_equal(lambda: self.server.num_replicas_online(), n, timeout=MAX_REPLICA_WAIT_TIME)
 
@@ -456,10 +437,6 @@ class ValkeyTestCase(ValkeyTestCaseBase):
         if self.server:
             self.server.exit()
             self.server = None
-
-    def set_small_amount_of_keys(self):
-        for i in range(self.num_keys):
-            self.clients[0].set('key_{}'.format(i), i)
 
 class ValkeyReplica(ValkeyServerHandle):
     def __init__(self, masterhost, masterport, bind_ip, port, port_tracker,
@@ -474,11 +451,6 @@ class ValkeyReplica(ValkeyServerHandle):
     def exit(self, remove_rdb=True, remove_nodes_conf=True):
         super(ValkeyReplica, self).exit(remove_rdb, remove_nodes_conf)
         del self.clients[:]
-    
-    def create_client_for_dbs(self, num_dbs):
-        for db in range(num_dbs):
-            self.clients.append(ValkeyServerHandle.create_from_server(self, db))
-        return self.clients
 
 class ReplicationTestCase(ValkeyTestCase):
     num_replicas = 1
@@ -532,13 +504,12 @@ class ReplicationTestCase(ValkeyTestCase):
         self.replicas = []
         for _ in range(self.num_replicas):
             replica = self._create_replica(masterhost, masterport, server_path)
-            replica.set_startup_args(self._get_valkey_args())
+            replica.set_startup_args(self.args)
             self.replicas.append(replica)
 
     def start_replicas(self, wait_for_ping=True):
         for i in range(self.num_replicas):
             self.replicas[i].start(wait_for_ping=wait_for_ping)
-            self.replicas[i].create_client_for_dbs(self.num_dbs)
 
     def destroy_replicas(self):
         try:

--- a/tests/valkeytests/valkey_test_case.py
+++ b/tests/valkeytests/valkey_test_case.py
@@ -60,12 +60,11 @@ class ValkeyServerHandle(object):
     
     DEFAULT_BIND_IP = "0.0.0.0"
 
-    def __init__(self, bind_ip, port, port_tracker, server_path, cwd='.', server_id=0):
+    def __init__(self, bind_ip, port, port_tracker, server_path, cwd='.'):
         self.server = None
         self.client = None
         self.port = port
         self.bind_ip = bind_ip
-        self.server_id = server_id
         self.args = {}
         self.args["port"] = self.port
         self.args["logfile"] = "logfile_{}".format(port)
@@ -392,10 +391,6 @@ class ValkeyTestCaseBase:
     def get_bind_port(self):
         return self.port_tracker.get_unused_port()
 
-    @pytest.fixture(autouse=True)
-    def server_id_fixture(self):
-        self.server_id = 0
-    
     def get_bind_ip(self, multi_ip_mode=False):
         if multi_ip_mode:
             return self.ip_tracker.get_ip_address()
@@ -414,12 +409,14 @@ class ValkeyTestCase(ValkeyTestCaseBase):
 
     def common_setup(self):
         self.maxmemory = "500MB"
+        print(dir(self))
         self.port = self.port_tracker.get_unused_port()
         self.ensureDirExists(self.testdir)
         self.server_list = []
 
 
-    def setup(self):
+    @pytest.fixture(autouse=True)
+    def setup(self, port_tracker_fixture):
         self.common_setup()
         args = self._get_valkey_args()
         self.server = self.create_server(testdir = self.testdir,  server_path=self.server_path)
@@ -442,12 +439,10 @@ class ValkeyTestCase(ValkeyTestCaseBase):
 
         if not port:
             port = self.get_bind_port()
-            
-        self.server_id += 1
         valkey_server_handle = self.get_valkey_handle()
         valkey_server = valkey_server_handle( bind_ip = bind_ip, port = port,
             port_tracker = self.port_tracker,
-            cwd = testdir, server_id = self.server_id, server_path=server_path)
+            cwd = testdir, server_path=server_path)
         self.server_list.append(valkey_server)
         return valkey_server
     
@@ -468,9 +463,9 @@ class ValkeyTestCase(ValkeyTestCaseBase):
 
 class ValkeyReplica(ValkeyServerHandle):
     def __init__(self, masterhost, masterport, bind_ip, port, port_tracker,
-                 testdir, server_id, server_path):
+                 testdir, server_path):
         super(ValkeyReplica, self).__init__(bind_ip, port, port_tracker,
-                                             server_path, testdir, server_id)
+                                             server_path, testdir)
         self.clients = []
         self.masterhost = masterhost
         self.masterport = masterport
@@ -505,10 +500,9 @@ class ReplicationTestCase(ValkeyTestCase):
         self.destroy_replicas()
 
     def _create_replica(self, masterhost, masterport, server_path):
-        self.server_id += 1
         return ValkeyReplica(masterhost, masterport,
                             self.get_bind_ip(), self.get_bind_port(),
-                            self.port_tracker, self.testdir, self.server_id, self.server_path)
+                            self.port_tracker, self.testdir, self.server_path)
 
     def create_replicas(self, num_replicas, masterhost=None, masterport=None,
                         connection_type='tcp', server_path=None):

--- a/tests/valkeytests/valkey_test_case.py
+++ b/tests/valkeytests/valkey_test_case.py
@@ -60,7 +60,7 @@ class ValkeyServerHandle(object):
     
     DEFAULT_BIND_IP = "0.0.0.0"
 
-    def __init__(self, bind_ip, port, port_tracker, server_path, cwd='.'):
+    def __init__(self, bind_ip, port, port_tracker, server_path='valkey-server', cwd='.'):
         self.server = None
         self.client = None
         self.port = port
@@ -75,7 +75,7 @@ class ValkeyServerHandle(object):
 
     @classmethod
     def create_from_server(self, server, db=0):
-        print(("Created regular client for port {}".format(server.port)))
+        logging.info(("Created regular client for port {}".format(server.port)))
         r = StrictValkey(host='localhost', port=server.port, db=db)
         return r
     
@@ -85,12 +85,12 @@ class ValkeyServerHandle(object):
     def get_new_client(self):
         return self.create_from_server(self)
 
-    def exit(self, test_teardown=True, remove_nodes_conf=True):
+    def exit(self, cleanup=True, remove_nodes_conf=True):
         if self.client:
             try:
                 self.client.shutdown('nosave')
             except:
-                print("SHUTDOWN was unsuccessful")
+                logging.warning("SHUTDOWN was unsuccessful")
 
             self.client = None
 
@@ -102,10 +102,10 @@ class ValkeyServerHandle(object):
             if "logfile" in self.args and os.path.exists(os.path.join(self.cwd, self.args["logfile"])):
                 os.remove(os.path.join(self.cwd, self.args["logfile"]))
 
-            if test_teardown and "appenddirname" in self.args and os.path.exists(os.path.join(self.cwd, self.args["appenddirname"])):
+            if cleanup and "appenddirname" in self.args and os.path.exists(os.path.join(self.cwd, self.args["appenddirname"])):
                 shutil.rmtree(os.path.join(self.cwd, self.args["appenddirname"]))
 
-        if test_teardown and "dbfilename" in self.args and os.path.exists(os.path.join(self.cwd, self.args["dbfilename"])):
+        if cleanup and "dbfilename" in self.args and os.path.exists(os.path.join(self.cwd, self.args["dbfilename"])):
             try:
                 os.remove(os.path.join(self.cwd, self.args["dbfilename"]))
             except OSError:
@@ -117,28 +117,24 @@ class ValkeyServerHandle(object):
             except OSError:
                 os.rmdir(os.path.join(self.cwd, self.args["cluster-config-file"]))
 
-    def _waitForServerPoll(self):
-        wait_for_ne(lambda: self.server.poll(), None, timeout=TEST_MAX_WAIT_TIME_SECONDS)
-
     def _waitForExit(self):
         try:
-            self._waitForServerPoll()
+            self.wait_for_shutdown()
         except WaitTimeout:
-            print("Server did not exit in time, killing...")
+            logging.warning("Server did not exit in time, killing...")
             if self.is_alive():
                 # check server is still running before kill it.
                 self.kill()
             try:
-                self._waitForServerPoll()
+                self.wait_for_shutdown()
             except WaitTimeout:
-                print("Could not tear down server")
+                logging.error("Could not tear down server")
                 assert False
 
     def pid(self):
         return self.server.pid
 
-    # DO we even need this it does the same as _waitForServerPoll
-    def is_down(self):
+    def wait_for_shutdown(self):
         wait_for_ne(lambda: self.server.poll(), None, timeout=TEST_MAX_WAIT_TIME_SECONDS)
 
     def children_pids(self):
@@ -188,14 +184,14 @@ class ValkeyServerHandle(object):
             args = str(v).split()
             for arg in args:
                 server_args.append(arg)
-        print(server_args)
+        logging.info(server_args)
 
         # Provide some warnings to help debug failing tests
         if "cluster-config-file" in self.args and os.path.exists(os.path.join(self.cwd, self.args["cluster-config-file"])):
-            print(("cluster-config-file exists ({}) before startup for node with port {}".format(os.path.join(os.getcwd(), self.args["cluster-config-file"]), self.port)))
+            logging.info(("cluster-config-file exists ({}) before startup for node with port {}".format(os.path.join(os.getcwd(), self.args["cluster-config-file"]), self.port)))
 
         if "dbfilename" in self.args and os.path.exists(os.path.join(self.cwd, self.args["dbfilename"])):
-            print("dbfilename exists before startup for node with port %d" % self.port)
+            logging.info("dbfilename exists before startup for node with port %d" % self.port)
 
         self.server = subprocess.Popen(server_args, cwd=self.cwd)
         if connect_client:
@@ -230,7 +226,7 @@ class ValkeyServerHandle(object):
             wait_for_true(lambda: c.ping(), timeout=MAX_PING_WAIT_TIME)
             return True
         except (ConnectionError, TimeoutError) as e:
-            print(e)
+            logging.error(e)
             return False
 
     def wait_for_key(self, key, value):
@@ -286,7 +282,7 @@ class ValkeyServerHandle(object):
             return client.info('all')['db{}'.format(db)]['keys']
         return 0
     
-    def is_master_link_up(self, client=None):
+    def is_primary_link_up(self, client=None):
         if client is None:
             client = self.client
         """Returns True if role is slave and master_link_status is up"""
@@ -318,16 +314,13 @@ class ValkeyTestCaseBase:
 
     DEFAULT_BIND_IP = "0.0.0.0"
 
-    def get_custom_args(self):
-        return {}
-
     @pytest.fixture(autouse=True)
     def port_tracker_fixture(self, resource_port_tracker):
         '''
         port_tracker_fixture using resource_port_tracker.
         '''
         # Inject port tracker
-        print ("port tracker")
+        logging.info("port tracker")
         self.args = {}
         self.port_tracker = resource_port_tracker
 
@@ -369,7 +362,7 @@ class ValkeyTestCaseBase:
         return num_keys_in_valkey
 
     def waitForReplicaToSyncUp(self, server):
-        wait_for_true(lambda: server.is_master_link_up(), timeout=MAX_SYNC_WAIT)
+        wait_for_true(lambda: server.is_primary_link_up(), timeout=MAX_SYNC_WAIT)
 
     # Wait until a client in the Valkey is executing a command
     # Used to ensure that a thread running a blocking command has started
@@ -396,7 +389,6 @@ class ValkeyTestCase(ValkeyTestCaseBase):
     server_path = "valkey-server" # The default server build is assumed that valkey-server is set
 
     def common_setup(self):
-        self.maxmemory = "500MB"
         self.port = self.port_tracker.get_unused_port()
         self.ensureDirExists(self.testdir)
         self.server_list = []
@@ -439,14 +431,14 @@ class ValkeyTestCase(ValkeyTestCaseBase):
             self.server = None
 
 class ValkeyReplica(ValkeyServerHandle):
-    def __init__(self, masterhost, masterport, bind_ip, port, port_tracker,
+    def __init__(self, primaryhost, primaryport, bind_ip, port, port_tracker,
                  testdir, server_path):
         super(ValkeyReplica, self).__init__(bind_ip, port, port_tracker,
                                              server_path, testdir)
         self.clients = []
-        self.masterhost = masterhost
-        self.masterport = masterport
-        self.args["slaveof"] = self.masterhost + " " + str(self.masterport)
+        self.primaryhost = primaryhost
+        self.primaryport = primaryport
+        self.args["slaveof"] = self.primaryhost + " " + str(self.primaryport)
 
     def exit(self, remove_rdb=True, remove_nodes_conf=True):
         super(ValkeyReplica, self).exit(remove_rdb, remove_nodes_conf)
@@ -458,11 +450,9 @@ class ReplicationTestCase(ValkeyTestCase):
     def setup_replication(self, num_replicas = num_replicas):
         self.create_replicas(num_replicas)
         self.start_replicas()
-        for i in range(len(self.replicas)):
-            self.replicas[i].set_startup_args(self.get_custom_args())
         self.wait_for_all_replicas_online(self.num_replicas)
         self.wait_for_replicas(self.num_replicas)
-        self.wait_for_master_link_up_all_replicas()
+        self.wait_for_primary_link_up_all_replicas()
         self.wait_for_all_replicas_online(self.num_replicas)
         for i in range(len(self.replicas)):
             self.waitForReplicaToSyncUp(self.replicas[i])
@@ -471,39 +461,39 @@ class ReplicationTestCase(ValkeyTestCase):
         ValkeyTestCase.teardown(self)
         self.destroy_replicas()
 
-    def _create_replica(self, masterhost, masterport, server_path):
-        return ValkeyReplica(masterhost, masterport,
+    def _create_replica(self, primaryhost, primaryport, server_path):
+        return ValkeyReplica(primaryhost, primaryport,
                             self.get_bind_ip(), self.get_bind_port(),
                             self.port_tracker, self.testdir, self.server_path)
 
-    def create_replicas(self, num_replicas, masterhost=None, masterport=None,
+    def create_replicas(self, num_replicas, primaryhost=None, primaryport=None,
                         connection_type='tcp', server_path=None):
 
         self.destroy_replicas()
 
-        default_masterhost = None
+        default_primaryhost = None
         default_port = None
         if connection_type == 'tcp':
             if hasattr(self.server, 'bind_ip'):
-                default_masterhost = self.server.bind_ip
+                default_primaryhost = self.server.bind_ip
             if hasattr(self.server, 'port'):
                 default_port = self.server.port
         elif connection_type == 'unix':
-            default_masterhost = self.server.args["unixsocket"]
+            default_primaryhost = self.server.args["unixsocket"]
             default_port = 0    # Valkey treats the hostname as a unix socket path if the port is zero.
         else:
             raise ValueError("Invalid connection type %r, expected 'tcp' or 'unix'" % connection_type)
 
-        if not masterhost:
-            masterhost = default_masterhost
+        if not primaryhost:
+            primaryhost = default_primaryhost
 
-        if not masterport:
-            masterport = default_port
+        if not primaryport:
+            primaryport = default_port
 
         self.num_replicas = num_replicas
         self.replicas = []
         for _ in range(self.num_replicas):
-            replica = self._create_replica(masterhost, masterport, server_path)
+            replica = self._create_replica(primaryhost, primaryport, server_path)
             replica.set_startup_args(self.args)
             self.replicas.append(replica)
 
@@ -516,19 +506,19 @@ class ReplicationTestCase(ValkeyTestCase):
             for i in range(self.num_replicas):
                 self.replicas[i].exit()
         except AttributeError:
-            print("this test was skipped. Nothing to destroy")
+            logging.info("this test was skipped. Nothing to destroy")
             return
         self.num_replicas = 0
         del self.replicas[:]
 
-    def wait_for_master_link_up_all_replicas(self):
+    def wait_for_primary_link_up_all_replicas(self):
         for i in range(self.num_replicas):
-            wait_for_true(lambda: self.replicas[i].is_master_link_up(), timeout=MAX_SYNC_WAIT)
+            wait_for_true(lambda: self.replicas[i].is_primary_link_up(), timeout=MAX_SYNC_WAIT)
 
     def wait_for_value_propagate_to_replicas(self, key, value, db=0):
         for i in range(self.num_replicas):
             wait_for_equal(lambda: self.replicas[i].clients[db].get(key), value, timout=TEST_MAX_WAIT_TIME_SECONDS)
 
-    def waitForReplicaOffsetToSyncUp(self, master, replica):
-        minfo = master.info()['master_repl_offset']
-        wait_for_equal(lambda: replica.client.info()['slave_repl_offset'], minfo.get_master_repl_offset(), timeout=TEST_MAX_WAIT_TIME_SECONDS)
+    def waitForReplicaOffsetToSyncUp(self, primary, replica):
+        pinfo = primary.info()['master_repl_offset']
+        wait_for_equal(lambda: replica.client.info()['slave_repl_offset'], pinfo.get_primary_repl_offset(), timeout=TEST_MAX_WAIT_TIME_SECONDS)


### PR DESCRIPTION
Cleaning up valkey_test_case. Consists of:
## [Commit 1](https://github.com/valkey-io/valkey-bloom/pull/51/commits/d671c81bd977ae695a69796b4ab6c79b7a49f4bc)
1. Removing ValkeyInfo and ValkeyClient which had no purpose other than extra function calls which could be removed
2. Updating waiters so now we won't use `@wait` and instead use explicit function calls
3. Added clean up for aof folder and files in that folder after running tests
4. Removed functions which only purpose was to be called by another function for waits

## [Commit 2](https://github.com/valkey-io/valkey-bloom/pull/51/commits/795eb42012c0ef66194b2786d345798901e4cb36)
1. Removed server_id variable
2. Updated port tracker fixture so framework is now compatible with pytest version 7 as well as 6

## [Commit 3](https://github.com/valkey-io/valkey-bloom/pull/51/commits/73d2334ec0fd9432bb0ae654985a1d187d7df499)
1. Removed automatic creation of server with specific args in `valkey_test_case.py`. Instead now the `valkey_bloom_test_case.py` now creates the server and decides what args to use
2. Updated server_path to be more flexible in being set. Now `valkey_test_case.py` will try to find valkey server from just valkey_server if server path is not provided in creating server
3. Consolidated creating, arg setting and starting a server in one function call so now less calls are needed for a test by test basis for creating and starting a server
4. Removed unnecessary variables set in `valkey_test_case.py` eg `num_keys`