### PR TITLE
Removing failing on clippy errors

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,13 +26,13 @@ jobs:
     - name: Run cargo and clippy format check
       run: |
         cargo fmt --check
-        cargo clippy --profile release --all-targets -- -D clippy::all
+        cargo clippy --profile release --all-targets
     - name: Release Build
       run: |
         if [ "${{ matrix.server_version }}" = "8.0" ]; then
-          RUSTFLAGS="-D warnings" cargo build --all --all-targets --release --features valkey_8_0
+          cargo build --all --all-targets --release --features valkey_8_0
         else
-          RUSTFLAGS="-D warnings" cargo build --all --all-targets --release
+          cargo build --all --all-targets --release
         fi
     - name: Run unit tests
       run: cargo test --features enable-system-alloc
@@ -72,9 +72,9 @@ jobs:
     - name: Run cargo and clippy format check
       run: |
         cargo fmt --check
-        cargo clippy --profile release --all-targets -- -D clippy::all
+        cargo clippy --profile release --all-targets
     - name: Release Build
-      run: RUSTFLAGS="-D warnings" cargo build --all --all-targets --release
+      run: cargo build --all --all-targets --release
     - name: Run unit tests
       run: cargo test --features enable-system-alloc
 
@@ -91,13 +91,13 @@ jobs:
     - name: Run cargo and clippy format check
       run: |
         cargo fmt --check
-        cargo clippy --profile release --all-targets -- -D clippy::all
+        cargo clippy --profile release --all-targets
     - name: Release Build
       run: |
         if [ "${{ matrix.server_version }}" = "8.0" ]; then
-          RUSTFLAGS="-D warnings" cargo build --all --all-targets --release --features valkey_8_0
+          cargo build --all --all-targets --release --features valkey_8_0
         else
-          RUSTFLAGS="-D warnings" cargo build --all --all-targets --release
+          cargo build --all --all-targets --release
         fi
     - name: Run unit tests
       run: cargo test --features enable-system-alloc


### PR DESCRIPTION
Removing failing on clippy errors, as clippy can change frequently on requirements.

Clippy errors are still displayed on a run as a warning but will no longer fail