### PR TITLE
Adding clean option for build script and fixing current clippy issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,8 @@ SERVER_VERSION=8.0.0
 # Build with asan, you may need to remove the old valkey binary if you have used ./build.sh before. You can do this by deleting the `.build` folder in the `tests` folder 
 ASAN_BUILD=true
 ./build.sh
+# Clean build artifacts
+./build.sh clean
 ```
 
 ## Load the Module

--- a/build.sh
+++ b/build.sh
@@ -8,6 +8,15 @@ set -e
 SCRIPT_DIR=$(pwd)
 echo "Script Directory: $SCRIPT_DIR"
 
+if [ "$1" = "clean" ]; then
+  echo "Cleaning build artifacts"
+  rm -rf target/
+  rm -rf tests/build/
+  rm -rf test-data/
+  echo "Clean completed."
+  exit 0
+fi
+
 echo "Running cargo and clippy format checks..."
 cargo fmt --check
 cargo clippy --profile release --all-targets -- -D clippy::all

--- a/src/bloom/utils.rs
+++ b/src/bloom/utils.rs
@@ -488,15 +488,15 @@ impl BloomObject {
     /// * `capacity` - The size of the initial filter in the bloom object.
     /// * `fp_rate` - the false positive rate for the bloom object
     /// * `validate_scale_to` - the capacity we check to see if it can scale to. If this method is called from BF.INFO this is set as -1 as we
-    ///                       want to check the maximum size we could scale up till
+    ///   want to check the maximum size we could scale up till
     /// * `tightening_ratio` - The tightening ratio of the object
     /// * `expansion` - The expanison rate of the object
     ///
     /// # Returns
     /// * i64 - The maximum capacity that can be reached if called from BF.INFO. If called from BF.INSERT the size it reached when it became greater than `validate_scale_to`
     /// * ValkeyError - Can return two different errors:
-    ///     VALIDATE_SCALE_TO_EXCEEDS_MAX_SIZE: When scaling to the wanted capacity would go over the bloom object memory limit
-    ///     VALIDATE_SCALE_TO_FALSE_POSITIVE_INVALID: When scaling to the wanted capacity would cause the false positive rate to reach 0
+    ///   VALIDATE_SCALE_TO_EXCEEDS_MAX_SIZE: When scaling to the wanted capacity would go over the bloom object memory limit
+    ///   VALIDATE_SCALE_TO_FALSE_POSITIVE_INVALID: When scaling to the wanted capacity would cause the false positive rate to reach 0
     pub fn calculate_max_scaled_capacity(
         capacity: i64,
         fp_rate: f64,


### PR DESCRIPTION
This will add an easy way of cleaning up the bloom repo instead of running cargo commands. This will remove all build artifacts 
Also fixed the clippy errors that were being emitted


Let me know if we want to clean test-data if that exists as well