### PR TITLE
Adding Bloom support for external server

### DIFF
--- a/tests/test_bloom_basic.py
+++ b/tests/test_bloom_basic.py
@@ -10,8 +10,12 @@ class TestBloomBasic(ValkeyBloomTestCaseBase):
         client = self.server.get_new_client()
         # Validate that the valkey-bloom module is loaded.
         module_list_data = client.execute_command('MODULE LIST')
-        module_list_count = len(module_list_data)
-        assert module_list_count == 1
+        
+        # Only check count for local servers (bundle has multiple modules)
+        use_external = os.environ.get("VALKEY_EXTERNAL_SERVER", "false").lower() == "true"
+        if not use_external:
+            module_list_count = len(module_list_data)
+            assert module_list_count == 1
         module_loaded = False
         for module in module_list_data:
             if (module[b'name'] == b'bf'):

--- a/tests/test_bloom_basic.py
+++ b/tests/test_bloom_basic.py
@@ -9,13 +9,7 @@ class TestBloomBasic(ValkeyBloomTestCaseBase):
     def test_basic(self):
         client = self.server.get_new_client()
         # Validate that the valkey-bloom module is loaded.
-        module_list_data = client.execute_command('MODULE LIST')
-        
-        # Only check count for local servers (bundle has multiple modules)
-        use_external = os.environ.get("VALKEY_EXTERNAL_SERVER", "false").lower() == "true"
-        if not use_external:
-            module_list_count = len(module_list_data)
-            assert module_list_count == 1
+        module_list_data = client.execute_command('MODULE LIST')      
         module_loaded = False
         for module in module_list_data:
             if (module[b'name'] == b'bf'):

--- a/tests/test_bloom_replication.py
+++ b/tests/test_bloom_replication.py
@@ -10,10 +10,33 @@ class TestBloomReplication(ReplicationTestCase):
 
     @pytest.fixture(autouse=True)
     def setup_test(self, setup):
-        self.args = {"enable-debug-command":"yes", 'loadmodule': os.getenv('MODULE_PATH'),'bf.bloom-use-random-seed': self.use_random_seed}
-        server_path = f"{os.path.dirname(os.path.realpath(__file__))}/build/binaries/{os.environ['SERVER_VERSION']}/valkey-server"
-
-        self.server, self.client = self.create_server(testdir = self.testdir,  server_path=server_path, args=self.args)
+        use_external = os.environ.get("VALKEY_EXTERNAL_SERVER", "false").lower() == "true"
+        
+        if use_external:
+            master_host = os.environ.get("VALKEY_HOST", "localhost")
+            master_port = int(os.environ.get("VALKEY_PORT", "6379"))
+            self.server, self.client = self.create_server(
+                testdir=self.testdir,
+                bind_ip=master_host,
+                port=master_port,
+                external_server=True
+            )
+            
+            replica_host = os.environ.get("VALKEY_REPLICA_HOST", "localhost")
+            replica_port = int(os.environ.get("VALKEY_REPLICA_PORT", "6380"))
+            replica_server, replica_client = self.create_server(
+                testdir=self.testdir,
+                bind_ip=replica_host,
+                port=replica_port,
+                external_server=True
+            )
+            
+            self.replicas = [replica_server]
+            self.num_replicas = 1
+        else:
+            self.args = {"enable-debug-command":"yes", 'loadmodule': os.getenv('MODULE_PATH'),'bf.bloom-use-random-seed': self.use_random_seed}
+            server_path = f"{os.path.dirname(os.path.realpath(__file__))}/build/binaries/{os.environ['SERVER_VERSION']}/valkey-server"
+            self.server, self.client = self.create_server(testdir = self.testdir,  server_path=server_path, args=self.args)
 
     @pytest.fixture(autouse=True)
     def use_random_seed_fixture(self, bloom_config_parameterization):
@@ -41,7 +64,12 @@ class TestBloomReplication(ReplicationTestCase):
         assert replica_cmd_stats['cmdstat_BF.INSERT']["calls"] == replica_insert_count and replica_cmd_stats['cmdstat_BF.ADD']["calls"] == replica_add_count
 
     def test_replication_behavior(self):
-        self.setup_replication(num_replicas=1)
+        use_external = os.environ.get("VALKEY_EXTERNAL_SERVER", "false").lower() == "true"
+        if use_external:
+            self.wait_for_primary_link_up_all_replicas()
+        else:
+            self.setup_replication(num_replicas=1)
+
         # Test replication for write commands.
         bloom_write_cmds = [
             ('BF.ADD', 'BF.ADD key item', 'BF.ADD key item1', 1),
@@ -155,7 +183,12 @@ class TestBloomReplication(ReplicationTestCase):
             assert ('cmdstat_' + prefix) not in self.replicas[0].client.info("Commandstats")
 
     def test_deterministic_replication(self):
-        self.setup_replication(num_replicas=1)
+        use_external = os.environ.get("VALKEY_EXTERNAL_SERVER", "false").lower() == "true"
+        if use_external:
+            self.wait_for_primary_link_up_all_replicas()
+        else:
+            self.setup_replication(num_replicas=1)
+
         # Set non default global properties (config) on the primary node. Any bloom creation on the primary should be
         # replicated with the properties below.
         assert self.client.execute_command('CONFIG SET bf.bloom-capacity 1000') == b'OK'

--- a/tests/valkey_bloom_test_case.py
+++ b/tests/valkey_bloom_test_case.py
@@ -5,6 +5,8 @@ from valkey import ResponseError
 import random
 import string
 import logging
+import subprocess
+import time
 
 class ValkeyBloomTestCaseBase(ValkeyTestCase):
 
@@ -274,3 +276,26 @@ class ValkeyBloomTestCaseBase(ValkeyTestCase):
                 key, value = line.split(':', 1)
                 stats_dict[key.strip()] = value.strip()
         return stats_dict
+    
+    def restart_external_server(self, server, remove_rdb=True, remove_nodes_conf=True, connect_client=True):
+        """This method will be used to restart external servers """
+        if not server.external_mode:
+            return server.restart(remove_rdb, remove_nodes_conf, connect_client)
+                
+        result = subprocess.run([
+            "docker", "ps", "--format", "{{.Names}}", 
+            "--filter", f"publish={server.port}"
+        ], capture_output=True, text=True, check=True)
+        
+        container_names = result.stdout.strip().split("\n")
+        if container_names and container_names[0]:
+            container_name = container_names[0]
+            subprocess.run(["docker", "restart", container_name], check=True)
+            time.sleep(3)
+        else:
+            raise RuntimeError(f"No Docker container found using port {server.port}")
+        
+        if connect_client:
+            server.connect()
+        
+        return server.client

--- a/tests/valkey_bloom_test_case.py
+++ b/tests/valkey_bloom_test_case.py
@@ -13,11 +13,23 @@ class ValkeyBloomTestCaseBase(ValkeyTestCase):
 
     @pytest.fixture(autouse=True)
     def setup_test(self, setup):
-        args = {"enable-debug-command":"yes", 'loadmodule': os.getenv('MODULE_PATH'),'bf.bloom-use-random-seed': self.use_random_seed}
-        server_path = f"{os.path.dirname(os.path.realpath(__file__))}/build/binaries/{os.environ['SERVER_VERSION']}/valkey-server"
-
-        self.server, self.client = self.create_server(testdir = self.testdir,  server_path=server_path, args=args)
-        logging.info("startup args are: %s", args)
+        use_external = os.environ.get("VALKEY_EXTERNAL_SERVER", "false").lower() == "true"
+        
+        if use_external:
+            # Use external server
+            external_host = os.environ.get("VALKEY_HOST", "localhost")
+            external_port = int(os.environ.get("VALKEY_PORT", "6379"))
+            self.server, self.client = self.create_server(
+                testdir=self.testdir,
+                bind_ip=external_host,
+                port=external_port,
+                external_server=True
+            )
+        else:
+            args = {"enable-debug-command":"yes", 'loadmodule': os.getenv('MODULE_PATH'),'bf.bloom-use-random-seed': self.use_random_seed}
+            server_path = f"{os.path.dirname(os.path.realpath(__file__))}/build/binaries/{os.environ['SERVER_VERSION']}/valkey-server"
+            self.server, self.client = self.create_server(testdir = self.testdir,  server_path=server_path, args=args)
+            logging.info("startup args are: %s", args)
 
     @pytest.fixture(autouse=True)
     def use_random_seed_fixture(self, bloom_config_parameterization):


### PR DESCRIPTION
This change adds the ability to run tests against an external Valkey server instead of always starting a new one.

External server mode: If we set the environment variable,  `VALKEY_EXTERNAL_SERVER=true , when we run the bloom pytests we will connect to an existing Valkey server at the specified host and port.

Local server mode: If not set or false, we will continue with the original behavior of starting a new Valkey server with the module loaded