### PR TITLE
Update README to fix 8.0 build and update build.sh to support 9.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,8 +37,8 @@ valkey-server --loadmodule ./target/release/libvalkey_bloom.so
 # Builds the valkey-server (unstable) for integration testing.
 SERVER_VERSION=unstable
 ./build.sh
-# Same as above, but uses valkey-server (8.0.0) for integration testing.
-SERVER_VERSION=8.0.0
+# Same as above, but uses valkey-server (8.0) for integration testing.
+SERVER_VERSION=8.0
 ./build.sh
 # Build with asan, you may need to remove the old valkey binary if you have used ./build.sh before. You can do this by deleting the `.build` folder in the `tests` folder 
 ASAN_BUILD=true
@@ -76,4 +76,4 @@ valkey-server --loadmodule /path/to/libvalkey_bloom.so
 cargo build --release --features valkey_8_0
 ```
 
-This can also be done by specifying SERVER_VERSION=8.0.0 and then running `./build.sh`
+This can also be done by specifying SERVER_VERSION=8.0 and then running `./build.sh`

--- a/build.sh
+++ b/build.sh
@@ -31,7 +31,7 @@ if [ -z "$SERVER_VERSION" ]; then
     export SERVER_VERSION="unstable"
 fi
 
-if [ "$SERVER_VERSION" != "unstable" ] && [ "$SERVER_VERSION" != "8.0" ] && [ "$SERVER_VERSION" != "8.1" ]; then
+if [ "$SERVER_VERSION" != "unstable" ] && [ "$SERVER_VERSION" != "8.0" ] && [ "$SERVER_VERSION" != "8.1" ] && [ "$SERVER_VERSION" != "9.0" ]; then
   echo "ERROR: Unsupported version - $SERVER_VERSION"
   exit 1
 fi


### PR DESCRIPTION
In #57 we changed SERVER_VERSION to something like branch name, so
we also need to update 8.0.0 to 8.0, otherwise we will get a error
like `ERROR: Unsupported version - 8.0.0`.

Also added 9.0 to build.sh to support `SERVER_VERSION=9.0 ./build.sh`.