### PR TITLE
Fix inconsistent assertion

### DIFF
--- a/src/bloom/utils.rs
+++ b/src/bloom/utils.rs
@@ -813,7 +813,7 @@ mod tests {
         let real_fp_rate = error_count as f64 / num_operations as f64;
         let fp_rate_with_margin = expected_fp_rate + fp_margin;
         assert!(
-            real_fp_rate < fp_rate_with_margin,
+            real_fp_rate <= fp_rate_with_margin,
             "The actual fp_rate, {}, is greater than the configured fp_rate with margin. {}.",
             real_fp_rate,
             fp_rate_with_margin


### PR DESCRIPTION
For this assertion, the predicate requires `real_fp_rate < fp_rate_with_margin`. While the message requires `real_fp_rate <= fp_rate_with_margin` as it indicates assertion will panic when real_fp_rate > fp_rate_with_margin("is greater than"). Semantically, the predicate should be fixed into `real_fp_rate <= fp_rate_with_margin`.
```rust
fn fp_assert(error_count: i64, num_operations: i64, expected_fp_rate: f64, fp_margin: f64) {
        let real_fp_rate = error_count as f64 / num_operations as f64;
        let fp_rate_with_margin = expected_fp_rate + fp_margin;
        assert!(
            real_fp_rate < fp_rate_with_margin,
            "The actual fp_rate, {}, is greater than the configured fp_rate with margin. {}.",
            real_fp_rate,
            fp_rate_with_margin
        );
    }
```