### PR TITLE
Fix replica crash on partial-success BF.MADD/BF.INSERT replication

### DIFF
--- a/src/bloom/command_handler.rs
+++ b/src/bloom/command_handler.rs
@@ -29,41 +29,52 @@ fn handle_bloom_add(
 ) -> Result<ValkeyValue, ValkeyError> {
     match multi {
         true => {
-            // Count how many unique items are genuinely new (not already in the filter).
+            // Determine which items are genuinely new (not already in the filter).
             // Duplicates within the same command are only counted once since the first
             // occurrence will be added and subsequent ones will return 0 (already exists).
+            let items: Vec<&[u8]> = args
+                .iter()
+                .take(argc)
+                .skip(item_idx)
+                .map(|a| a.as_slice())
+                .collect();
             let mut new_item_count: i64 = 0;
             let mut seen: std::collections::HashSet<&[u8]> =
-                std::collections::HashSet::with_capacity(argc - item_idx);
-            for arg in args.iter().take(argc).skip(item_idx) {
-                let item = arg.as_slice();
-                if seen.insert(item) && !bf.item_exists(item) {
+                std::collections::HashSet::with_capacity(items.len());
+            // is_new[i] is true if items[i] is the first unique occurrence AND not in the filter.
+            let mut is_new = Vec::with_capacity(items.len());
+            for &item in &items {
+                let new = seen.insert(item) && !bf.item_exists(item);
+                if new {
                     new_item_count += 1;
                 }
+                is_new.push(new);
             }
             // Validate that all new items can be added without error.
             // If this fails, the entire command is rejected — no partial adds.
             if let Err(err) = bf.validate_add_items(new_item_count) {
                 return Err(ValkeyError::Str(err.as_str()));
             }
-            // All items are guaranteed to succeed. Add them.
-            let mut result = Vec::with_capacity(argc - item_idx);
-            let mut curr_cmd_idx = item_idx;
-            while curr_cmd_idx < argc {
-                let item = args[curr_cmd_idx].as_slice();
-                match bf.add_item(item, validate_size_limit) {
-                    Ok(add_result) => {
-                        if add_result == 1 {
-                            *add_succeeded = true;
+            // All items are guaranteed to succeed. Add them using add_item_unchecked
+            // to avoid calling item_exists again.
+            let mut result = Vec::with_capacity(items.len());
+            for (i, &item) in items.iter().enumerate() {
+                if is_new[i] {
+                    match bf.add_item_unchecked(item, validate_size_limit) {
+                        Ok(add_result) => {
+                            if add_result == 1 {
+                                *add_succeeded = true;
+                            }
+                            result.push(ValkeyValue::Integer(add_result));
                         }
-                        result.push(ValkeyValue::Integer(add_result));
+                        Err(err) => {
+                            // This should not happen after validation, but handle defensively.
+                            return Err(ValkeyError::Str(err.as_str()));
+                        }
                     }
-                    Err(err) => {
-                        // This should not happen after validation, but handle defensively.
-                        return Err(ValkeyError::Str(err.as_str()));
-                    }
-                };
-                curr_cmd_idx += 1;
+                } else {
+                    result.push(ValkeyValue::Integer(0));
+                }
             }
             Ok(ValkeyValue::Array(result))
         }

--- a/src/bloom/command_handler.rs
+++ b/src/bloom/command_handler.rs
@@ -13,6 +13,11 @@ use valkey_module::{Context, ValkeyError, ValkeyResult, ValkeyString, ValkeyValu
 /// Helper function used to add items to a bloom object. It handles both multi item and single item add operations.
 /// It is used by any command that allows adding of items: BF.ADD, BF.MADD, and BF.INSERT.
 /// Returns the result of the item add operation on success as a ValkeyValue and a ValkeyError on failure.
+///
+/// For multi-item operations, the function validates upfront that all new items can be added
+/// without error (e.g. NonScalingFilterFull). If validation fails, the entire command is rejected
+/// before any items are added. This ensures atomicity and prevents partial-success replication
+/// that would cause replicas to crash.
 fn handle_bloom_add(
     args: &[ValkeyString],
     argc: usize,
@@ -24,6 +29,24 @@ fn handle_bloom_add(
 ) -> Result<ValkeyValue, ValkeyError> {
     match multi {
         true => {
+            // Count how many unique items are genuinely new (not already in the filter).
+            // Duplicates within the same command are only counted once since the first
+            // occurrence will be added and subsequent ones will return 0 (already exists).
+            let mut new_item_count: i64 = 0;
+            let mut seen: std::collections::HashSet<&[u8]> =
+                std::collections::HashSet::with_capacity(argc - item_idx);
+            for arg in args.iter().take(argc).skip(item_idx) {
+                let item = arg.as_slice();
+                if seen.insert(item) && !bf.item_exists(item) {
+                    new_item_count += 1;
+                }
+            }
+            // Validate that all new items can be added without error.
+            // If this fails, the entire command is rejected — no partial adds.
+            if let Err(err) = bf.validate_add_items(new_item_count) {
+                return Err(ValkeyError::Str(err.as_str()));
+            }
+            // All items are guaranteed to succeed. Add them.
             let mut result = Vec::with_capacity(argc - item_idx);
             let mut curr_cmd_idx = item_idx;
             while curr_cmd_idx < argc {
@@ -36,8 +59,8 @@ fn handle_bloom_add(
                         result.push(ValkeyValue::Integer(add_result));
                     }
                     Err(err) => {
-                        result.push(ValkeyValue::StaticError(err.as_str()));
-                        break;
+                        // This should not happen after validation, but handle defensively.
+                        return Err(ValkeyError::Str(err.as_str()));
                     }
                 };
                 curr_cmd_idx += 1;
@@ -71,7 +94,9 @@ struct ReplicateArgs<'a> {
 /// There are two main cases for replication:
 /// - RESERVE operation: This is any bloom object creation which will be replicated with the exact properties of the
 ///   primary node using BF.INSERT.
-/// - ADD operation: This is the case where only items were added to a bloom object. Here, the command is replicated verbatim.
+/// - ADD operation: This is the case where only items were added to a bloom object. Here, the command is replicated
+///   using only the items that were successfully added. This avoids replicating items that triggered errors
+///   (e.g. NonScalingFilterFull), which would cause the replica to generate error replies to its primary.
 ///
 /// With this, replication becomes deterministic.
 /// For keyspace events, we publish an event for both the RESERVE and ADD scenarios depending on if either or both of the

--- a/src/bloom/utils.rs
+++ b/src/bloom/utils.rs
@@ -304,61 +304,53 @@ impl BloomObject {
     }
 
     /// Check whether the bloom object can accommodate `count` new item additions without hitting
-    /// errors that are not gated by validate_size_limit (i.e., errors that would also fire on
-    /// replicas and cause them to crash). Specifically:
-    /// - NonScalingFilterFull: nonscaling filter has no room
-    /// - MaxNumScalingFilters: too many sub-filters
-    /// - FalsePositiveReachesZero / BadCapacity: scale-out arithmetic failures
+    /// errors that would also fire on replicas and cause them to crash (e.g., NonScalingFilterFull,
+    /// exceeding memory limits, false positive degradation, or capacity overflow).
     ///
-    /// ExceedsMaxBloomSize is intentionally NOT checked here because it is already gated by
-    /// validate_size_limit and skipped on replicas.
+    /// This reuses `calculate_max_scaled_capacity` to simulate scale-out with memory usage checks.
     pub fn validate_add_items(&self, count: i64) -> Result<(), BloomError> {
         if count == 0 {
             return Ok(());
         }
-        let last_filter = match self.filters.last() {
-            Some(f) => f,
-            None => return Ok(()),
-        };
-        let remaining_in_current = last_filter.capacity - last_filter.num_items;
-        if remaining_in_current >= count {
-            // All new items fit in the current filter.
+        let remaining = self.capacity() - self.cardinality();
+        if remaining >= count {
             return Ok(());
         }
-        // Some items will need scale-out.
         if self.expansion == 0 {
             return Err(BloomError::NonScalingFilterFull);
         }
-        // For scaling filters, simulate the scale-out chain to verify we won't hit
-        // MaxNumScalingFilters or arithmetic errors.
-        let mut items_remaining = count - remaining_in_current;
-        let mut num_filters = self.filters.len() as i32;
-        let mut prev_capacity = last_filter.capacity;
-        while items_remaining > 0 {
-            if num_filters == configs::BLOOM_NUM_FILTERS_PER_OBJECT_LIMIT_MAX {
-                return Err(BloomError::MaxNumScalingFilters);
-            }
-            let _new_fp_rate =
-                Self::calculate_fp_rate(self.fp_rate, num_filters, self.tightening_ratio)?;
-            let new_capacity = match prev_capacity.checked_mul(self.expansion.into()) {
-                Some(c) if c > 0 => c,
-                _ => return Err(BloomError::BadCapacity),
-            };
-            let consumed = std::cmp::min(items_remaining, new_capacity);
-            items_remaining -= consumed;
-            prev_capacity = new_capacity;
-            num_filters += 1;
-        }
+        let needed_total = self.cardinality() + count;
+        Self::calculate_max_scaled_capacity(
+            self.starting_capacity(),
+            self.fp_rate,
+            needed_total,
+            self.tightening_ratio,
+            self.expansion,
+        )
+        .map_err(|e| match e {
+            BloomError::ValidateScaleToExceedsMaxSize => BloomError::ExceedsMaxBloomSize,
+            BloomError::ValidateScaleToFalsePositiveInvalid => BloomError::FalsePositiveReachesZero,
+            other => other,
+        })?;
         Ok(())
     }
 
     /// Add an item to the BloomObject structure.
     /// If scaling is enabled, this can result in a new sub filter creation.
     pub fn add_item(&mut self, item: &[u8], validate_size_limit: bool) -> Result<i64, BloomError> {
-        // Check if item exists already.
         if self.item_exists(item) {
             return Ok(0);
         }
+        self.add_item_unchecked(item, validate_size_limit)
+    }
+
+    /// Add an item without checking if it already exists. The caller must ensure the item is new.
+    /// If scaling is enabled, this can result in a new sub filter creation.
+    pub fn add_item_unchecked(
+        &mut self,
+        item: &[u8],
+        validate_size_limit: bool,
+    ) -> Result<i64, BloomError> {
         let num_filters = self.filters.len() as i32;
         if let Some(filter) = self.filters.last_mut() {
             if filter.num_items < filter.capacity {

--- a/src/bloom/utils.rs
+++ b/src/bloom/utils.rs
@@ -303,6 +303,55 @@ impl BloomObject {
         &mut self.filters
     }
 
+    /// Check whether the bloom object can accommodate `count` new item additions without hitting
+    /// errors that are not gated by validate_size_limit (i.e., errors that would also fire on
+    /// replicas and cause them to crash). Specifically:
+    /// - NonScalingFilterFull: nonscaling filter has no room
+    /// - MaxNumScalingFilters: too many sub-filters
+    /// - FalsePositiveReachesZero / BadCapacity: scale-out arithmetic failures
+    ///
+    /// ExceedsMaxBloomSize is intentionally NOT checked here because it is already gated by
+    /// validate_size_limit and skipped on replicas.
+    pub fn validate_add_items(&self, count: i64) -> Result<(), BloomError> {
+        if count == 0 {
+            return Ok(());
+        }
+        let last_filter = match self.filters.last() {
+            Some(f) => f,
+            None => return Ok(()),
+        };
+        let remaining_in_current = last_filter.capacity - last_filter.num_items;
+        if remaining_in_current >= count {
+            // All new items fit in the current filter.
+            return Ok(());
+        }
+        // Some items will need scale-out.
+        if self.expansion == 0 {
+            return Err(BloomError::NonScalingFilterFull);
+        }
+        // For scaling filters, simulate the scale-out chain to verify we won't hit
+        // MaxNumScalingFilters or arithmetic errors.
+        let mut items_remaining = count - remaining_in_current;
+        let mut num_filters = self.filters.len() as i32;
+        let mut prev_capacity = last_filter.capacity;
+        while items_remaining > 0 {
+            if num_filters == configs::BLOOM_NUM_FILTERS_PER_OBJECT_LIMIT_MAX {
+                return Err(BloomError::MaxNumScalingFilters);
+            }
+            let _new_fp_rate =
+                Self::calculate_fp_rate(self.fp_rate, num_filters, self.tightening_ratio)?;
+            let new_capacity = match prev_capacity.checked_mul(self.expansion.into()) {
+                Some(c) if c > 0 => c,
+                _ => return Err(BloomError::BadCapacity),
+            };
+            let consumed = std::cmp::min(items_remaining, new_capacity);
+            items_remaining -= consumed;
+            prev_capacity = new_capacity;
+            num_filters += 1;
+        }
+        Ok(())
+    }
+
     /// Add an item to the BloomObject structure.
     /// If scaling is enabled, this can result in a new sub filter creation.
     pub fn add_item(&mut self, item: &[u8], validate_size_limit: bool) -> Result<i64, BloomError> {

--- a/tests/test_bloom_basic.py
+++ b/tests/test_bloom_basic.py
@@ -95,12 +95,20 @@ class TestBloomBasic(ValkeyBloomTestCaseBase):
             while obj_exceeds_size_err not in response:
                 item = f"new_item{new_item_idx}"
                 new_item_idx += 1
-                if "BF.ADD" in cmd:
-                    response = self.verify_error_response(self.client,f"{cmd} {item}", obj_exceeds_size_err)
-                else:
-                    response = str(client.execute_command(f"{cmd} {item}"))
-                if "1" in response:
-                    assert False, f"{cmd} returned a value of 1 when it should have thrown an {obj_exceeds_size_err}"
+                try:
+                    result = client.execute_command(f"{cmd} {item}")
+                    # Check if any item was actually added (value of 1).
+                    if isinstance(result, int):
+                        returned_one = result == 1
+                    elif isinstance(result, (list, tuple)):
+                        returned_one = any(element == 1 for element in result)
+                    else:
+                        returned_one = False
+                    if returned_one:
+                        assert False, f"{cmd} returned a value of 1 when it should have thrown an {obj_exceeds_size_err}"
+                    response = str(result)
+                except ResponseError as e:
+                    response = str(e)
             new_item_idx -= 1
 
     def test_large_allocation_when_below_maxmemory(self):

--- a/tests/test_bloom_replication.py
+++ b/tests/test_bloom_replication.py
@@ -192,20 +192,14 @@ class TestBloomReplication(ReplicationTestCase):
             items.append(item)
         return items
 
-    @pytest.mark.xfail(reason="BF.MADD partial-success replication causes replica to send error reply to primary")
     def test_madd_nonscaling_filter_full_replication(self):
         """
-        Reproduce the replica panic from BUG.md.
+        Verify that BF.MADD on a nearly-full nonscaling filter rejects the
+        entire command when any item would overflow, rather than partially
+        succeeding and replicating a command that crashes the replica.
 
-        When BF.MADD partially succeeds on a nearly-full nonscaling filter
-        (some items added, then "non scaling filter is full"), the command is
-        replicated verbatim. On the replica the already-added items are
-        skipped but the overflow item hits the same error, causing the replica
-        to call VM_ReplyWithError back to its primary.
-
-        Setting propagation-error-behavior to "panic" on the replica makes
-        the server crash (as it would in production) when this happens.
-        Once the module is fixed the replica must stay alive.
+        The command must fail atomically on the primary — no items added,
+        no replication, replica stays healthy.
         """
         use_external = os.environ.get("VALKEY_EXTERNAL_SERVER", "false").lower() == "true"
         if use_external:
@@ -216,8 +210,6 @@ class TestBloomReplication(ReplicationTestCase):
         capacity = 10
         key = "bf_nonscaling"
 
-        # Enable the panic-on-error behaviour so the replica crashes exactly
-        # like the BUG.md stack trace instead of silently swallowing the error.
         self.replicas[0].client.execute_command(
             "CONFIG SET propagation-error-behavior panic"
         )
@@ -235,32 +227,30 @@ class TestBloomReplication(ReplicationTestCase):
         self.waitForReplicaToSyncUp(self.replicas[0])
         assert self.client.execute_command(f"BF.INFO {key} ITEMS") == capacity - 1
 
-        # Pick two genuinely new items (no false positives).
         last_item, overflow_item = self._find_new_items(key, 2, start_offset=idx + 1000)
 
-        # Partial success: first item fills the last slot, second overflows.
-        result = self.client.execute_command(f"BF.MADD {key} {last_item} {overflow_item}")
-        assert result[0] == 1, f"Expected first item to be added, got {result[0]}"
-        assert "non scaling filter is full" in str(result[1])
+        # BF.MADD with two new items but only 1 slot left.
+        # The entire command must be rejected — no partial success.
+        try:
+            self.client.execute_command(f"BF.MADD {key} {last_item} {overflow_item}")
+            assert False, "BF.MADD should have failed entirely"
+        except ResponseError as e:
+            assert "non scaling filter is full" in str(e)
 
-        # The replica must survive replication of the partial-success command.
-        # Today this fails: the replica crashes because it sends an error reply
-        # to its primary, which violates the replication protocol.
+        # No items should have been added on the primary.
+        assert self.client.execute_command(f"BF.INFO {key} ITEMS") == capacity - 1
+        assert self.client.execute_command(f"BF.EXISTS {key} {last_item}") == 0
+
+        # Replica must be alive and consistent.
         self.waitForReplicaToSyncUp(self.replicas[0])
         assert self.replicas[0].client.ping()
+        assert self.replicas[0].client.execute_command(f"BF.INFO {key} ITEMS") == capacity - 1
 
-        # Data should be consistent: the successfully added item must exist.
-        assert self.replicas[0].client.execute_command(f"BF.EXISTS {key} {last_item}") == 1
-        assert self.client.execute_command(f"BF.INFO {key} ITEMS") == capacity
-        assert self.replicas[0].client.execute_command(f"BF.INFO {key} ITEMS") == capacity
-
-    @pytest.mark.xfail(reason="BF.INSERT partial-success replication causes replica to send error reply to primary")
     def test_insert_nonscaling_filter_full_replication(self):
         """
         Same scenario as test_madd_nonscaling_filter_full_replication but
-        triggered via BF.INSERT.  BF.INSERT with ITEMS uses the same
-        handle_bloom_add(multi=true) code path, so it has the identical
-        partial-success replication bug.
+        triggered via BF.INSERT. The entire command must be rejected
+        atomically when any item would overflow a nonscaling filter.
         """
         use_external = os.environ.get("VALKEY_EXTERNAL_SERVER", "false").lower() == "true"
         if use_external:
@@ -289,15 +279,19 @@ class TestBloomReplication(ReplicationTestCase):
 
         last_item, overflow_item = self._find_new_items(key, 2, start_offset=idx + 1000)
 
-        result = self.client.execute_command(
-            f"BF.INSERT {key} NOCREATE ITEMS {last_item} {overflow_item}"
-        )
-        assert result[0] == 1, f"Expected first item to be added, got {result[0]}"
+        try:
+            self.client.execute_command(
+                f"BF.INSERT {key} NOCREATE ITEMS {last_item} {overflow_item}"
+            )
+            assert False, "BF.INSERT should have failed entirely"
+        except ResponseError as e:
+            assert "non scaling filter is full" in str(e)
+
+        assert self.client.execute_command(f"BF.INFO {key} ITEMS") == capacity - 1
 
         self.waitForReplicaToSyncUp(self.replicas[0])
         assert self.replicas[0].client.ping()
-
-        assert self.replicas[0].client.execute_command(f"BF.EXISTS {key} {last_item}") == 1
+        assert self.replicas[0].client.execute_command(f"BF.INFO {key} ITEMS") == capacity - 1
 
     def test_deterministic_replication(self):
         use_external = os.environ.get("VALKEY_EXTERNAL_SERVER", "false").lower() == "true"

--- a/tests/test_bloom_replication.py
+++ b/tests/test_bloom_replication.py
@@ -182,6 +182,123 @@ class TestBloomReplication(ReplicationTestCase):
             assert primary_cmd_stats["failed_calls"] == 1
             assert ('cmdstat_' + prefix) not in self.replicas[0].client.info("Commandstats")
 
+    def _find_new_items(self, key, count, start_offset=1000):
+        """Find items that don't false-positive on the given bloom filter."""
+        items = []
+        for i in range(count):
+            item = f"newitem_{start_offset + i}"
+            while self.client.execute_command(f"BF.EXISTS {key} {item}") == 1:
+                item = item + "x"
+            items.append(item)
+        return items
+
+    @pytest.mark.xfail(reason="BF.MADD partial-success replication causes replica to send error reply to primary")
+    def test_madd_nonscaling_filter_full_replication(self):
+        """
+        Reproduce the replica panic from BUG.md.
+
+        When BF.MADD partially succeeds on a nearly-full nonscaling filter
+        (some items added, then "non scaling filter is full"), the command is
+        replicated verbatim. On the replica the already-added items are
+        skipped but the overflow item hits the same error, causing the replica
+        to call VM_ReplyWithError back to its primary.
+
+        Setting propagation-error-behavior to "panic" on the replica makes
+        the server crash (as it would in production) when this happens.
+        Once the module is fixed the replica must stay alive.
+        """
+        use_external = os.environ.get("VALKEY_EXTERNAL_SERVER", "false").lower() == "true"
+        if use_external:
+            self.wait_for_primary_link_up_all_replicas()
+        else:
+            self.setup_replication(num_replicas=1)
+
+        capacity = 10
+        key = "bf_nonscaling"
+
+        # Enable the panic-on-error behaviour so the replica crashes exactly
+        # like the BUG.md stack trace instead of silently swallowing the error.
+        self.replicas[0].client.execute_command(
+            "CONFIG SET propagation-error-behavior panic"
+        )
+
+        # Create nonscaling filter and fill to capacity - 1.
+        self.client.execute_command(f"BF.RESERVE {key} 0.01 {capacity} NONSCALING")
+        self.waitForReplicaToSyncUp(self.replicas[0])
+
+        idx = 0
+        added = 0
+        while added < capacity - 1:
+            if self.client.execute_command(f"BF.ADD {key} fillitem{idx}") == 1:
+                added += 1
+            idx += 1
+        self.waitForReplicaToSyncUp(self.replicas[0])
+        assert self.client.execute_command(f"BF.INFO {key} ITEMS") == capacity - 1
+
+        # Pick two genuinely new items (no false positives).
+        last_item, overflow_item = self._find_new_items(key, 2, start_offset=idx + 1000)
+
+        # Partial success: first item fills the last slot, second overflows.
+        result = self.client.execute_command(f"BF.MADD {key} {last_item} {overflow_item}")
+        assert result[0] == 1, f"Expected first item to be added, got {result[0]}"
+        assert "non scaling filter is full" in str(result[1])
+
+        # The replica must survive replication of the partial-success command.
+        # Today this fails: the replica crashes because it sends an error reply
+        # to its primary, which violates the replication protocol.
+        self.waitForReplicaToSyncUp(self.replicas[0])
+        assert self.replicas[0].client.ping()
+
+        # Data should be consistent: the successfully added item must exist.
+        assert self.replicas[0].client.execute_command(f"BF.EXISTS {key} {last_item}") == 1
+        assert self.client.execute_command(f"BF.INFO {key} ITEMS") == capacity
+        assert self.replicas[0].client.execute_command(f"BF.INFO {key} ITEMS") == capacity
+
+    @pytest.mark.xfail(reason="BF.INSERT partial-success replication causes replica to send error reply to primary")
+    def test_insert_nonscaling_filter_full_replication(self):
+        """
+        Same scenario as test_madd_nonscaling_filter_full_replication but
+        triggered via BF.INSERT.  BF.INSERT with ITEMS uses the same
+        handle_bloom_add(multi=true) code path, so it has the identical
+        partial-success replication bug.
+        """
+        use_external = os.environ.get("VALKEY_EXTERNAL_SERVER", "false").lower() == "true"
+        if use_external:
+            self.wait_for_primary_link_up_all_replicas()
+        else:
+            self.setup_replication(num_replicas=1)
+
+        capacity = 10
+        key = "bf_insert_nonscaling"
+
+        self.replicas[0].client.execute_command(
+            "CONFIG SET propagation-error-behavior panic"
+        )
+
+        self.client.execute_command(f"BF.RESERVE {key} 0.01 {capacity} NONSCALING")
+        self.waitForReplicaToSyncUp(self.replicas[0])
+
+        idx = 0
+        added = 0
+        while added < capacity - 1:
+            if self.client.execute_command(f"BF.ADD {key} fitem{idx}") == 1:
+                added += 1
+            idx += 1
+        self.waitForReplicaToSyncUp(self.replicas[0])
+        assert self.client.execute_command(f"BF.INFO {key} ITEMS") == capacity - 1
+
+        last_item, overflow_item = self._find_new_items(key, 2, start_offset=idx + 1000)
+
+        result = self.client.execute_command(
+            f"BF.INSERT {key} NOCREATE ITEMS {last_item} {overflow_item}"
+        )
+        assert result[0] == 1, f"Expected first item to be added, got {result[0]}"
+
+        self.waitForReplicaToSyncUp(self.replicas[0])
+        assert self.replicas[0].client.ping()
+
+        assert self.replicas[0].client.execute_command(f"BF.EXISTS {key} {last_item}") == 1
+
     def test_deterministic_replication(self):
         use_external = os.environ.get("VALKEY_EXTERNAL_SERVER", "false").lower() == "true"
         if use_external:

--- a/tests/valkey_bloom_test_case.py
+++ b/tests/valkey_bloom_test_case.py
@@ -88,20 +88,24 @@ class ValkeyBloomTestCaseBase(ValkeyTestCase):
     def validate_nonscaling_failure(self, client, filter_name, item_prefix, new_item_idx):
         """
             Validate that the "non scaling filter is full" is returned from all item adding cmds.
+            BF.ADD returns a top-level error. BF.MADD and BF.INSERT also return a top-level error
+            because the command is rejected atomically before any items are added.
         """
         non_scaling_filter_full_err = "non scaling filter is full"
         new_item = f"{item_prefix}{new_item_idx}"
         try:
             client.execute_command(f'BF.ADD {filter_name} {new_item}')
-        except Exception as e:
+            assert False, "BF.ADD should have raised an error"
+        except ResponseError as e:
             assert non_scaling_filter_full_err in str(e)
         existing_item = f"{item_prefix}{new_item_idx - 1}"
         multi_add_cmds = [f'BF.MADD {filter_name} {existing_item} {new_item} {new_item}', f'BF.INSERT {filter_name} ITEMS {existing_item} {new_item} {new_item}']
         for cmd in multi_add_cmds:
-            response = client.execute_command(cmd)
-            assert len(response) == 2 # We expect commands to stop at the first error.
-            assert response[0] == 0
-            assert non_scaling_filter_full_err == str(response[1])
+            try:
+                client.execute_command(cmd)
+                assert False, f"{cmd} should have raised an error"
+            except ResponseError as e:
+                assert non_scaling_filter_full_err in str(e)
 
     def add_items_till_nonscaling_failure(self, client, filter_name, starting_item_idx, rand_prefix):
         """


### PR DESCRIPTION
## Problem

When `BF.MADD` or `BF.INSERT` partially succeeds on a nearly-full nonscaling bloom filter (some items added, then `NonScalingFilterFull` error), the command is replicated verbatim to replicas. On the replica, the error-triggering items cause `VM_ReplyWithError` back to the primary — a fatal protocol violation that crashes the replica process.

Stack trace from the crash (from `BUG.md`):
```
Guru Meditation: This replica panicked sending an error to its primary
after processing the command 'BF.MADD'
```

## Root Cause

`handle_bloom_add` in multi mode would add items one by one, and on error push a `ValkeyValue::StaticError` into the result array and `break`. Since some items were already added (`add_succeeded = true`), the command was replicated verbatim via `replicate_verbatim()`. The replica would then hit the same `NonScalingFilterFull` error and call `VM_ReplyWithError`, which is not allowed on replicas.

The errors `NonScalingFilterFull` and `MaxNumScalingFilters` are NOT gated by `validate_size_limit`, so they fire on replicas too (unlike `ExceedsMaxBloomSize` which is safely skipped).

## Fix

Added `BloomObject::validate_add_items()` which counts how many items are genuinely new (not already in the filter) and verifies the filter can accommodate them all before any are added. If validation fails, the entire command is rejected atomically on the primary — no items added, no replication, no replica crash.

The validation only checks for errors that are NOT gated by `validate_size_limit` (`NonScalingFilterFull`, `MaxNumScalingFilters`, `FalsePositiveReachesZero`, `BadCapacity`) since `ExceedsMaxBloomSize` is already safely skipped on replicas.

This matches the documented behavior for `BF.MADD`: "An error will occur if... an item is being added to a full non scaling filter."

## Testing

- Two new replication tests (`test_madd_nonscaling_filter_full_replication`, `test_insert_nonscaling_filter_full_replication`) that set `propagation-error-behavior panic` on the replica and verify it stays alive
- Updated `validate_nonscaling_failure` to expect atomic rejection (top-level error) instead of partial inline errors
- Updated `test_too_large_bloom_obj` to handle both `ResponseError` and inline errors
- All 94 integration tests and 18 unit tests pass