### PR TITLE
Fixing bug in bloom defrag, adding digest checks to integration test, create new unit test that catches before mentioned bug

### DIFF
--- a/src/wrapper/bloom_callback.rs
+++ b/src/wrapper/bloom_callback.rs
@@ -167,15 +167,15 @@ lazy_static! {
 fn external_vec_defrag(vec: Vec<u8>) -> Vec<u8> {
     let defrag = Defrag::new(core::ptr::null_mut());
     let len = vec.len();
-    let capacity = vec.capacity();
+    // into_boxed_slice will remove any excess capacity which means we need to recreate the Vec with the correct capacity of len
     let vec_ptr = Box::into_raw(vec.into_boxed_slice()) as *mut c_void;
     let defragged_filters_ptr = unsafe { defrag.alloc(vec_ptr) };
     if !defragged_filters_ptr.is_null() {
         metrics::BLOOM_DEFRAG_HITS.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
-        unsafe { Vec::from_raw_parts(defragged_filters_ptr as *mut u8, len, capacity) }
+        unsafe { Vec::from_raw_parts(defragged_filters_ptr as *mut u8, len, len) }
     } else {
         metrics::BLOOM_DEFRAG_MISSES.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
-        unsafe { Vec::from_raw_parts(vec_ptr as *mut u8, len, capacity) }
+        unsafe { Vec::from_raw_parts(vec_ptr as *mut u8, len, len) }
     }
 }
 
@@ -229,7 +229,6 @@ pub unsafe extern "C" fn bloom_defrag(
     let bloom_object: &mut BloomObject = &mut *(*value).cast::<BloomObject>();
 
     let num_filters = bloom_object.num_filters();
-    let filters_capacity = bloom_object.filters().capacity();
 
     // While we are within a timeframe decided from should_stop_defrag and not over the number of filters defrag the next filter
     while !defrag.should_stop_defrag() && cursor < num_filters as u64 {
@@ -293,6 +292,7 @@ pub unsafe extern "C" fn bloom_defrag(
     }
     // Defragment the Vec of BloomFilter/s itself
     let filters_vec = mem::take(bloom_object.filters_mut());
+    // into_boxed_slice will remove any excess capacity which means we need to recreate the Vec with the correct capacity of len
     let filters_ptr = Box::into_raw(filters_vec.into_boxed_slice()) as *mut c_void;
     let defragged_filters_ptr = defrag.alloc(filters_ptr);
     if !defragged_filters_ptr.is_null() {
@@ -301,16 +301,16 @@ pub unsafe extern "C" fn bloom_defrag(
             Vec::from_raw_parts(
                 defragged_filters_ptr as *mut Box<BloomFilter>,
                 num_filters,
-                filters_capacity,
+                num_filters,
             )
         };
     } else {
-        metrics::BLOOM_DEFRAG_HITS.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+        metrics::BLOOM_DEFRAG_MISSES.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
         *bloom_object.filters_mut() = unsafe {
             Vec::from_raw_parts(
                 filters_ptr as *mut Box<BloomFilter>,
                 num_filters,
-                filters_capacity,
+                num_filters,
             )
         };
     }

--- a/tests/test_bloom_defrag.py
+++ b/tests/test_bloom_defrag.py
@@ -32,8 +32,9 @@ class TestBloomDefrag(ValkeyBloomTestCaseBase):
         # Insert data
         for index, scale in enumerate(scale_names):
             self.client.execute_command(f'bf.reserve {scale} 0.001 {initial_capacity} EXPANSION 2')
+            # Use the key name as item prefix so each filter gets a unique digest
             # The new_add_operation_idx means all numbers from 1 to it should all return 1 when called with bf.exists
-            _, new_add_operation_idx = self.add_items_till_capacity(self.client, scale, 100,  1, "")
+            _, new_add_operation_idx = self.add_items_till_capacity(self.client, scale, 100,  1, f"{scale}_")
             # We delete every other object so only need to keep the ones with a odd index
             if index % 2 == 1:
                 num_items_inserted_per_object.append(new_add_operation_idx)
@@ -41,6 +42,9 @@ class TestBloomDefrag(ValkeyBloomTestCaseBase):
         # Delete every other item to create fragmentation
         for scale in scale_names[::2]:
             self.client.execute_command(f'DEL {scale}')
+        remaining_keys = scale_names[1::2]
+        digests_before_defrag = {scale: self.client.execute_command(f'DEBUG DIGEST-VALUE {scale}') for scale in remaining_keys}
+
         # Add a wait due to lazy delete where if we call info to early we wont get the correct memory info
         time.sleep(5)
 
@@ -63,7 +67,11 @@ class TestBloomDefrag(ValkeyBloomTestCaseBase):
         assert first_defrag_hits > initial_defrag_hits and first_defrag_misses > initial_defrag_misses
         assert float(memory_info_after_defrag.get('allocator_frag_ratio', 0)) < float(memory_info_non_defragged.get('allocator_frag_ratio', 0))
         # Check that items we added still exist in the respective bloom objects
-        self.check_values_present(scale_names, num_items_inserted_per_object)
+        self.check_values_present(remaining_keys, num_items_inserted_per_object)
+
+        digests_after_defrag = {scale: self.client.execute_command(f'DEBUG DIGEST-VALUE {scale}') for scale in remaining_keys}
+        assert digests_before_defrag == digests_after_defrag, "Digest mismatch after defrag"
+
         info_results = self.client.info("bf")
         assert info_results['bf_bloom_defrag_hits'] + info_results['bf_bloom_defrag_misses'] > 0
         self.client.execute_command('BGSAVE')
@@ -87,19 +95,108 @@ class TestBloomDefrag(ValkeyBloomTestCaseBase):
         final_defrag_misses = int(final_stats.get('active_defrag_misses', 0))
         assert  final_defrag_hits > initial_defrag_hits or final_defrag_misses > initial_defrag_misses, "No defragmentation occurred after RDB load"
         # Check that items we added still exist in the respective bloom objects
-        self.check_values_present(scale_names, num_items_inserted_per_object)
+        self.check_values_present(remaining_keys, num_items_inserted_per_object)
+
+        digests_after_rdb_load = {scale: self.client.execute_command(f'DEBUG DIGEST-VALUE {scale}') for scale in remaining_keys}
+        assert digests_before_defrag == digests_after_rdb_load, "Digest mismatch after RDB load and defrag"
         info_results = self.client.info("bf")
         assert info_results['bf_bloom_defrag_hits'] + info_results['bf_bloom_defrag_misses'] > 0
  
-    def check_values_present(self, scale_names, num_items_inserted_per_object):
-        for index, scale in enumerate(scale_names[1::2]):
-            # Create a list of numbers of 1 to number of items inserted into the current bloomfilter
-            num_items = num_items_inserted_per_object[index]
-            items = list(range(1, num_items + 1))
-            
-            # Perform a mexists for all the numbers 1 to num_items
-            command = f'bf.mexists {scale} ' + ' '.join(map(str, items))
-            results = self.client.execute_command(command)
-            # All items should be present so we compare with an array of length num items where all items are 1
+    def test_bloom_defrag_then_scale(self):
+        # Set defragmentation thresholds
+        self.client.config_set('activedefrag', 'no')
+        self.client.config_set('active-defrag-ignore-bytes', '1')
+        self.client.config_set('active-defrag-threshold-lower', '2')
+
+        max_memory = 40 * 1024 * 1024
+        self.client.config_set('maxmemory', str(max_memory))
+
+        # Each bloom object is (reserve arguments, items before defrag, items after defrag).
+        BLOOM_OBJECTS = [
+            # Non-scaling: 1 filter
+            ("0.01 100 NONSCALING", 80,  90),
+            ("0.001 200 NONSCALING", 150, 180),
+            ("0.05 50 NONSCALING", 40,  45),
+            # Expansion 1:
+            # 3 filters -> scale to 5
+            ("0.01 100 EXPANSION 1", 300, 500),
+            # 1 filter -> scale to 3
+            ("0.001 200 EXPANSION 1", 200, 600),
+            # 7 filters -> scale to 8
+            ("0.01 50 EXPANSION 1", 350, 400),
+            # 2 filters -> scale to 5
+            ("0.001 150 EXPANSION 1", 300, 750),
+            # Expansion 2:
+            # 1 filter -> scale to 3
+            ("0.01 100 EXPANSION 2", 100, 400),
+            # 3 filters -> scale to 5
+            ("0.001 50 EXPANSION 2", 200, 800),
+            # Expansion 3:
+            # 1 filter -> scale to 3 
+            ("0.01 30 EXPANSION 3", 30,  200),
+        ]
+
+        all_keys = []
+
+        # Create 200 bloom filters of each parameter above (2400 total)
+        for bloom_example in range(len(BLOOM_OBJECTS)):
+            for i in range(200):
+                reserve_args, items_before, _ = BLOOM_OBJECTS[bloom_example]
+                key = f'defrag_test_{bloom_example}_{i}'
+                all_keys.append(key)
+                self.client.execute_command(f'BF.RESERVE {key} {reserve_args}')
+                self.add_items_till_capacity(self.client, key, items_before, 1, f"{key}_")
+
+        # Delete half the keys of each different bloom object parameters
+        for key in all_keys[::2]:
+            self.client.execute_command(f'DEL {key}')
+        remaining_keys = all_keys[1::2]
+
+        digests_before_defrag = {
+            key: self.client.execute_command(f'DEBUG DIGEST-VALUE {key}')
+            for key in remaining_keys
+        }
+
+        # Enable defragmentation and defrag items.
+        self.client.config_set('activedefrag', 'yes')
+        wait_for_equal(lambda: int(self.parse_valkey_info("STATS").get('total_active_defrag_time')) > 5000, True)
+
+        items_before_per_key = [BLOOM_OBJECTS[int(key.split('_')[2])][1] for key in remaining_keys]
+        self.check_values_present(remaining_keys, items_before_per_key)
+
+        digests_after_defrag = {
+            key: self.client.execute_command(f'DEBUG DIGEST-VALUE {key}')
+            for key in remaining_keys
+        }
+        assert digests_before_defrag == digests_after_defrag, "Digest mismatch after defrag"
+
+        for key in remaining_keys:
+            bloom_object_index = int(key.split('_')[2])
+            _, items_before, items_after = BLOOM_OBJECTS[bloom_object_index]
+            self.add_items_till_capacity(self.client, key, items_after, items_before + 1, f"{key}_")
+
+        # Create a list of number of keys left after defrag and scaling
+        items_after_per_key = [BLOOM_OBJECTS[int(key.split('_')[2])][2] for key in remaining_keys]
+        self.check_values_present(remaining_keys, items_after_per_key)
+
+        self.client.execute_command('BGSAVE')
+        self.server.wait_for_save_done()
+
+        self.server.restart(remove_rdb=False, remove_nodes_conf=False, connect_client=True)
+        assert self.server.is_alive()
+        wait_for_equal(lambda: self.server.is_rdb_done_loading(), True)
+
+        self.check_values_present(remaining_keys, items_after_per_key)
+
+    def check_values_present(self, keys, num_items_per_key):
+        """Verify all items are present in each bloom filter. No false negatives allowed.
+        keys: list of key names
+        num_items_per_key: list of item counts (same length as keys), or a single int for all keys
+        """
+        if isinstance(num_items_per_key, int):
+            num_items_per_key = [num_items_per_key] * len(keys)
+        for key, num_items in zip(keys, num_items_per_key):
+            items = [f'{key}_{i}' for i in range(1, num_items + 1)]
+            results = self.client.execute_command(f'BF.MEXISTS {key} ' + ' '.join(items))
             expected_results = [1] * num_items
-            assert results == expected_results, f"Unexpected results for scale {scale}: {results}"
+            assert results == expected_results, f"Unexpected results for {key}: {results}"


### PR DESCRIPTION
## Defrag issue fix
One of the last steps we do in defragmention is a `into_boxed_slice` specifically `let filters_ptr = Box::into_raw(filters_vec.into_boxed_slice()) as *mut c_void;`. This function will drop excess capacity based on documentation [listed here](https://doc.rust-lang.org/std/vec/struct.Vec.html#method.into_boxed_slice). However as rust vec's scale they don't always have capacity equal to length so at some point if we scale enough we could hit where capacity > len. For example lets say length of 3 but capacity of 4 this will drop the extra 1 capacity that we had and just make a vec of 3. This becomes an issue as after this we then recreate the vec with the following:
```
        *bloom_object.filters_mut() = unsafe {
            Vec::from_raw_parts(
                defragged_filters_ptr as *mut Box<BloomFilter>,
                num_filters,
                filters_capacity,
            )
        }; 
``` 
This recreates the vec but with the original capacity. However our `let defragged_filters_ptr = defrag.alloc(filters_ptr);` will only take memory of length not capacity. This could lead to the bloom filter Vec thinking that it owned more memory than it actually did potentially causing memory corruptions on future scale outs. The fix for this is simple we instead want to recreate the Vec with the length as capacity instead of capacity. Which would give us the new code of:
```
        *bloom_object.filters_mut() = unsafe {
            Vec::from_raw_parts(
                filters_ptr as *mut Box<BloomFilter>,
                num_filters,
                num_filters,
            )
        };
```


## Bloom testing

Amended the original bloom test to also include digest checks

Also adds `test_bloom_defrag_then_scale` to show the defrag callback across a variety of bloom filter configurations in a single run:

1. Non-scaling filters (NONSCALING)
2. Scaling with expansion 1, 2, and 3
3. Varying capacity (30, 50, 100, 150, 200)
4. fp_rate (0.05, 0.01, 0.001)

The test creates 200 keys per configuration, deletes half to create fragmentation, runs defrag, verifies data integrity via digests and BF.MEXISTS, then adds more items to force further scale-out. This targets the potential corruption path where defrag's use of into_boxed_slice() could produce a Vec with an incorrect capacity. Finally, BGSAVE + restart verifies the data survives RDB persistence as well.


Latest push:
~~Added two more production style filters, which have large capacity and lower false positive rate. Will not scale the scaling filter one as it will increase test running time significantly if we have to add and check multiple times~~ Removed due to OOM issues, large capacity compared to smaller capacity should have no effect on defrag logic, and we have a range of capacities checked 