### PR TITLE
remove 'validate_scale_to' check in replica

### DIFF
--- a/src/bloom/command_handler.rs
+++ b/src/bloom/command_handler.rs
@@ -595,18 +595,25 @@ pub fn bloom_filter_insert(ctx: &Context, input_args: &[ValkeyString]) -> Valkey
                 utils::NON_SCALING_AND_VALIDATE_SCALE_TO_IS_INVALID,
             ));
         }
-        match utils::BloomObject::calculate_max_scaled_capacity(
-            capacity,
-            fp_rate,
-            scale_to,
-            tightening_ratio,
-            expansion,
-        ) {
-            Ok(_) => (),
-            Err(err) => {
-                return Err(ValkeyError::Str(err.as_str()));
-            }
-        };
+        // Skip the size projection on must-obey clients (replication, AOF replay,
+        // import slot migration). The source already validated against its own
+        // bloom-memory-usage-limit; re-running the check on this node may
+        // produce a different verdict and silently drop a write that succeeded
+        // on the primary, causing primary/replica divergence.
+        if !must_obey_client(ctx) {
+            match utils::BloomObject::calculate_max_scaled_capacity(
+                capacity,
+                fp_rate,
+                scale_to,
+                tightening_ratio,
+                expansion,
+            ) {
+                Ok(_) => (),
+                Err(err) => {
+                    return Err(ValkeyError::Str(err.as_str()));
+                }
+            };
+        }
     }
     // If the filter does not exist, create one
     let filter_key = ctx.open_key_writable(filter_name);

--- a/src/bloom/command_handler.rs
+++ b/src/bloom/command_handler.rs
@@ -588,19 +588,17 @@ pub fn bloom_filter_insert(ctx: &Context, input_args: &[ValkeyString]) -> Valkey
         // When the `ITEMS` argument is provided, we expect additional item arg/s to be provided.
         return Err(ValkeyError::WrongArity);
     }
-    // Check if we have a wanted capacity and calculate if we can reach that capacity. Using VALIDATESCALETO and NONSCALING options together is invalid.
+    // Check if we have a wanted capacity and calculate if we can reach that capacity.
+    // Using VALIDATESCALETO and NONSCALING options together is invalid.
+    // Skip on replicated cmds.
+    let validate_size_limit = !must_obey_client(ctx);
     if let Some(scale_to) = validate_scale_to {
         if expansion == 0 {
             return Err(ValkeyError::Str(
                 utils::NON_SCALING_AND_VALIDATE_SCALE_TO_IS_INVALID,
             ));
         }
-        // Skip the size projection on must-obey clients (replication, AOF replay,
-        // import slot migration). The source already validated against its own
-        // bloom-memory-usage-limit; re-running the check on this node may
-        // produce a different verdict and silently drop a write that succeeded
-        // on the primary, causing primary/replica divergence.
-        if !must_obey_client(ctx) {
+        if validate_size_limit {
             match utils::BloomObject::calculate_max_scaled_capacity(
                 capacity,
                 fp_rate,
@@ -623,8 +621,6 @@ pub fn bloom_filter_insert(ctx: &Context, input_args: &[ValkeyString]) -> Valkey
             return Err(ValkeyError::WrongType);
         }
     };
-    // Skip bloom filter size validation on replicated cmds.
-    let validate_size_limit = !must_obey_client(ctx);
     let mut add_succeeded = false;
     match value {
         Some(bloom) => {

--- a/src/bloom/utils.rs
+++ b/src/bloom/utils.rs
@@ -56,6 +56,7 @@ pub enum BloomError {
     DecodeBloomFilterFailed,
     DecodeUnsupportedVersion,
     ErrorRateRange,
+    TighteningRatioRange,
     BadExpansion,
     FalsePositiveReachesZero,
     BadCapacity,
@@ -73,6 +74,7 @@ impl BloomError {
             BloomError::DecodeBloomFilterFailed => DECODE_BLOOM_OBJECT_FAILED,
             BloomError::DecodeUnsupportedVersion => DECODE_UNSUPPORTED_VERSION,
             BloomError::ErrorRateRange => ERROR_RATE_RANGE,
+            BloomError::TighteningRatioRange => TIGHTENING_RATIO_RANGE,
             BloomError::BadExpansion => BAD_EXPANSION,
             BloomError::FalsePositiveReachesZero => FALSE_POSITIVE_DEGRADES_TO_O,
             BloomError::BadCapacity => BAD_CAPACITY,
@@ -446,7 +448,7 @@ impl BloomObject {
                         if !(values.2 > BLOOM_TIGHTENING_RATIO_MIN
                             && values.2 < BLOOM_TIGHTENING_RATIO_MAX)
                         {
-                            return Err(BloomError::ErrorRateRange);
+                            return Err(BloomError::TighteningRatioRange);
                         }
                         if values.4.len()
                             >= configs::BLOOM_NUM_FILTERS_PER_OBJECT_LIMIT_MAX as usize
@@ -1228,6 +1230,7 @@ mod tests {
         let key = "key";
         let _ = bf.add_item(key.as_bytes(), true);
         let origin_fp_rate = bf.fp_rate;
+        let origin_tightening_ratio = bf.tightening_ratio;
 
         // unsupport fp_rate
         bf.fp_rate = -0.5;
@@ -1238,6 +1241,22 @@ mod tests {
             Some(BloomError::ErrorRateRange)
         );
         bf.fp_rate = origin_fp_rate;
+
+        // out-of-range tightening_ratio (must surface as TighteningRatioRange,
+        // not ErrorRateRange).
+        bf.tightening_ratio = -0.5;
+        let vec = bf.encode_object().unwrap();
+        assert_eq!(
+            BloomObject::decode_object(&vec, true).err(),
+            Some(BloomError::TighteningRatioRange)
+        );
+        bf.tightening_ratio = 1.5;
+        let vec = bf.encode_object().unwrap();
+        assert_eq!(
+            BloomObject::decode_object(&vec, true).err(),
+            Some(BloomError::TighteningRatioRange)
+        );
+        bf.tightening_ratio = origin_tightening_ratio;
 
         // build a larger than 64mb filter
         let extra_large_filter =

--- a/tests/test_bloom_replication.py
+++ b/tests/test_bloom_replication.py
@@ -219,3 +219,65 @@ class TestBloomReplication(ReplicationTestCase):
             assert self.replicas[0].client.execute_command('CONFIG GET bf.bloom-expansion')[1] == b'2'
             assert self.replicas[0].client.execute_command('CONFIG GET bf.bloom-fp-rate')[1] == b'0.01'
             assert self.replicas[0].client.execute_command('CONFIG GET bf.bloom-tightening-ratio')[1] == b'0.5'
+
+    def test_validatescaleto_skipped_on_replica(self):
+        # When `BF.INSERT ... VALIDATESCALETO ...` adds items to an existing
+        # bloom, the original command is replicated verbatim. If the replica
+        # has a smaller bloom-memory-usage-limit than the primary, re-running
+        # the VALIDATESCALETO projection on the replica with its own limit can
+        # reject a write that succeeded on the primary, silently diverging
+        # primary/replica state.
+        #
+        # Must-obey clients (replication, AOF replay, slot-migration import)
+        # must therefore skip the VALIDATESCALETO projection — the source
+        # already validated against its own configured limit.
+        use_external = os.environ.get("VALKEY_EXTERNAL_SERVER", "false").lower() == "true"
+        if use_external:
+            self.wait_for_primary_link_up_all_replicas()
+        else:
+            self.setup_replication(num_replicas=1)
+
+        # Tighten the replica's per-object memory limit so a VALIDATESCALETO
+        # projection that passes on the primary (default 128MB) would be
+        # rejected here if it ran.
+        assert self.replicas[0].client.execute_command(
+            'CONFIG SET bf.bloom-memory-usage-limit 1024') == b'OK'
+
+        # Step 1: create the bloom. Reserve replicates as a deterministic
+        # BF.INSERT *without* VALIDATESCALETO, so this step always succeeds.
+        assert self.client.execute_command(
+            'BF.INSERT key CAPACITY 100 ERROR 0.01 EXPANSION 2 '
+            'VALIDATESCALETO 1000000 ITEMS a') == [1]
+        self.waitForReplicaToSyncUp(self.replicas[0])
+        assert self.replicas[0].client.execute_command('BF.EXISTS key a') == 1
+
+        # Step 2: add to the existing bloom. This is the divergence-prone path:
+        # `add_operation` triggers replicate_verbatim(), so the replica
+        # receives the original command including VALIDATESCALETO and re-runs
+        # the projection against its 64KB limit.
+        assert self.client.execute_command(
+            'BF.INSERT key CAPACITY 100 ERROR 0.01 EXPANSION 2 '
+            'VALIDATESCALETO 1000000 ITEMS b') == [1]
+        self.waitForReplicaToSyncUp(self.replicas[0])
+
+        # Replica must have applied the add, not silently dropped it.
+        assert self.replicas[0].client.execute_command('BF.EXISTS key b') == 1
+        assert self.client.execute_command('BF.INFO key ITEMS') == \
+            self.replicas[0].client.execute_command('BF.INFO key ITEMS')
+
+        # And digests must agree end-to-end.
+        primary_object_digest = self.client.execute_command('DEBUG DIGEST-VALUE key')
+        replica_object_digest = self.replicas[0].client.execute_command('DEBUG DIGEST-VALUE key')
+        assert primary_object_digest == replica_object_digest
+
+        # User-issued writes on the primary that genuinely exceed *its* limit
+        # are still rejected — the must-obey skip is replica-side only.
+        assert self.client.execute_command(
+            'CONFIG SET bf.bloom-memory-usage-limit 1024') == b'OK'
+        try:
+            self.client.execute_command(
+                'BF.INSERT user_key CAPACITY 100 ERROR 0.01 EXPANSION 2 '
+                'VALIDATESCALETO 1000000 ITEMS x')
+            assert False, "expected VALIDATESCALETO error on primary"
+        except ResponseError as e:
+            assert "VALIDATESCALETO" in str(e)


### PR DESCRIPTION
`BF.INSERT ... VALIDATESCALETO ...` against an existing bloom uses `replicate_verbatim()`, so the replica re-runs the projection against its own `bloom-memory-usage-limit`. 
If the replica's limit is lower than the primary's, the same command is silently rejected on the replica only — the item is written on the primary but not on the replica → primary/replica divergence.

The error message when `tightening_ratio` is out of range has been fixed, by the way.