### PR TITLE
Add TOPK.ADD command

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,11 +16,12 @@ valkey-module = { version = "0.1.5", features = ["min-valkey-compatibility-versi
 valkey-module-macros = "0"
 linkme = "0"
 bloomfilter = { version = "3.0.1", features = ["serde"] }
-heavykeeper = "0.6"
+heavykeeper = { git = "https://github.com/detemmienation/heavykeeper-rs.git", branch = "evicted" }
 lazy_static = "1.4.0"
 libc = "0.2"
 serde = { version = "1.0", features = ["derive"] }
 bincode = "1.3"
+
 
 [dev-dependencies]
 rand = "0.8"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,12 +16,12 @@ valkey-module = { version = "0.1.5", features = ["min-valkey-compatibility-versi
 valkey-module-macros = "0"
 linkme = "0"
 bloomfilter = { version = "3.0.1", features = ["serde"] }
+# TODO: This is a temporary solution until we add this functionality to the original heavykeeper crate.
 heavykeeper = { git = "https://github.com/detemmienation/heavykeeper-rs.git", branch = "evicted" }
 lazy_static = "1.4.0"
 libc = "0.2"
 serde = { version = "1.0", features = ["derive"] }
 bincode = "1.3"
-
 
 [dev-dependencies]
 rand = "0.8"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -95,7 +95,7 @@ fn bloom_load_command(ctx: &Context, args: Vec<ValkeyString>) -> ValkeyResult {
 }
 
 /// Command handler for:
-/// TOPK.RESERVE key topk [SEED seed] [width depth decay] [SEED seed]
+/// TOPK.RESERVE key topk [width depth decay] [SEED seed]
 fn topk_reserve_command(ctx: &Context, args: Vec<ValkeyString>) -> ValkeyResult {
     topk_command_handler::topk_reserve(ctx, &args)
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -95,9 +95,14 @@ fn bloom_load_command(ctx: &Context, args: Vec<ValkeyString>) -> ValkeyResult {
 }
 
 /// Command handler for:
-/// TOPK.RESERVE key topk [width depth decay] [SEED seed]
+/// TOPK.RESERVE key topk [SEED seed] [width depth decay] [SEED seed]
 fn topk_reserve_command(ctx: &Context, args: Vec<ValkeyString>) -> ValkeyResult {
     topk_command_handler::topk_reserve(ctx, &args)
+}
+
+/// Command handler for TOPK.ADD <key> <item> [<item> ...]
+fn topk_add_command(ctx: &Context, args: Vec<ValkeyString>) -> ValkeyResult {
+    topk_command_handler::topk_add(ctx, &args)
 }
 
 ///
@@ -136,6 +141,7 @@ valkey_module! {
         ["BF.LOAD", bloom_load_command, "write deny-oom", 1, 1, 1, "write bloom"],
         // TOPK Commands
         ["TOPK.RESERVE", topk_reserve_command, "write fast deny-oom", 1, 1, 1, "fast write topk"],
+        ["TOPK.ADD", topk_add_command, "write fast deny-oom", 1, 1, 1, "fast write topk"],
     ],
     configurations: [
         i64: [

--- a/src/topk/command_handler.rs
+++ b/src/topk/command_handler.rs
@@ -2,7 +2,7 @@ use crate::topk::data_type::TOPK_TYPE;
 use crate::topk::utils;
 use crate::topk::utils::TopKObject;
 use valkey_module::NotifyEvent;
-use valkey_module::{Context, ValkeyError, ValkeyResult, ValkeyString, VALKEY_OK};
+use valkey_module::{Context, ValkeyError, ValkeyResult, ValkeyString, ValkeyValue, VALKEY_OK};
 
 /// Structure to help provide the command arguments required for replication. This is used by mutative commands.
 struct ReplicateArgs {
@@ -15,15 +15,19 @@ struct ReplicateArgs {
 
 /// Helper function to replicate mutative commands to the replica nodes and publish keyspace events.
 /// There are two main cases for replication:
-/// - RESERVE operation
-/// - ADD operation: pending
+/// - RESERVE operation: replays a deterministic TOPK.RESERVE on replicas.
+/// - ADD operation: verbatim replication is safe because TOPK.ADD is
+///   deterministic given the same sketch state, and replicas were seeded
+///   identically via the replicated TOPK.RESERVE.
 fn replicate_and_notify_events(
     ctx: &Context,
     key_name: &ValkeyString,
     reserve_operation: bool,
-    args: ReplicateArgs,
+    add_operation: bool,
+    args: Option<ReplicateArgs>,
 ) {
     if reserve_operation {
+        let args = args.expect("reserve replication requires ReplicateArgs");
         let k_val =
             ValkeyString::create_from_slice(std::ptr::null_mut(), args.k.to_string().as_bytes());
         let width_val = ValkeyString::create_from_slice(
@@ -46,6 +50,9 @@ fn replicate_and_notify_events(
         ];
         ctx.replicate("TOPK.RESERVE", cmd.as_slice());
         ctx.notify_keyspace_event(NotifyEvent::GENERIC, utils::RESERVE_EVENT, key_name);
+    } else if add_operation {
+        ctx.replicate_verbatim();
+        ctx.notify_keyspace_event(NotifyEvent::GENERIC, utils::ADD_EVENT, key_name);
     }
 }
 
@@ -146,11 +153,49 @@ pub fn topk_reserve(ctx: &Context, input_args: &[ValkeyString]) -> ValkeyResult 
                 decay,
                 seed,
             };
-            replicate_and_notify_events(ctx, key_name, true, replicate_args);
+            replicate_and_notify_events(ctx, key_name, true, false, Some(replicate_args));
             VALKEY_OK
         }
         Err(_) => Err(ValkeyError::Str(utils::ERROR)),
     }
+}
+
+/// Handle TOPK.ADD.
+///
+/// Syntax:
+///     TOPK.ADD key item [item ...]
+///
+/// Returns an array, one entry per input item, in order:
+///   - Null if no heavy-slot resident was displaced by the insertion.
+///   - The bulk-string of the displaced item otherwise.
+///
+/// The key must already hold a TOPK reserved via TOPK.RESERVE; missing keys
+/// are an error rather than auto-created (matching upstream RedisBloom).
+pub fn topk_add(ctx: &Context, input_args: &[ValkeyString]) -> ValkeyResult {
+    let argc = input_args.len();
+    if argc < 3 {
+        return Err(ValkeyError::WrongArity);
+    }
+
+    let key_name = &input_args[1];
+    let key = ctx.open_key_writable(key_name);
+    let topk = match key.get_value::<TopKObject>(&TOPK_TYPE) {
+        Ok(Some(v)) => v,
+        Ok(None) => return Err(ValkeyError::Str(utils::NOT_FOUND)),
+        Err(_) => return Err(ValkeyError::WrongType),
+    };
+
+    let items = &input_args[2..];
+    let mut result: Vec<ValkeyValue> = Vec::with_capacity(items.len());
+    for item in items {
+        match topk.add(item.as_slice(), 1) {
+            Some(evicted) => result.push(ValkeyValue::StringBuffer(evicted)),
+            None => result.push(ValkeyValue::Null),
+        }
+    }
+
+    replicate_and_notify_events(ctx, key_name, false, true, None);
+    Ok(ValkeyValue::Array(result))
 }
 
 /// Case-insensitive match for the literal SEED keyword.

--- a/src/topk/command_handler.rs
+++ b/src/topk/command_handler.rs
@@ -168,9 +168,6 @@ pub fn topk_reserve(ctx: &Context, input_args: &[ValkeyString]) -> ValkeyResult 
 /// Returns an array, one entry per input item, in order:
 ///   - Null if no heavy-slot resident was displaced by the insertion.
 ///   - The bulk-string of the displaced item otherwise.
-///
-/// The key must already hold a TOPK reserved via TOPK.RESERVE; missing keys
-/// are an error rather than auto-created (matching upstream RedisBloom).
 pub fn topk_add(ctx: &Context, input_args: &[ValkeyString]) -> ValkeyResult {
     let argc = input_args.len();
     if argc < 3 {

--- a/src/topk/utils.rs
+++ b/src/topk/utils.rs
@@ -2,6 +2,7 @@ use heavykeeper::CuckooTopK;
 
 /// KeySpace Notification Events
 pub const RESERVE_EVENT: &str = "topk.reserve";
+pub const ADD_EVENT: &str = "topk.add";
 pub const DEFAULT_WIDTH: u32 = 8;
 pub const DEFAULT_DEPTH: u32 = 7;
 pub const DEFAULT_DECAY: f64 = 0.9;
@@ -21,6 +22,7 @@ pub const TOPK_DEPTH_MAX: u32 = u32::MAX;
 /// Client Errors
 pub const ERROR: &str = "ERROR";
 pub const KEY_EXISTS: &str = "BUSYKEY Target key name already exists.";
+pub const NOT_FOUND: &str = "ERR TopK: key does not exist";
 pub const BAD_TOPK: &str = "ERR bad topk";
 pub const BAD_WIDTH: &str = "ERR bad width";
 pub const BAD_DEPTH: &str = "ERR bad depth";
@@ -78,5 +80,14 @@ impl TopKObject {
     }
     pub fn sketch_mut(&mut self) -> &mut CuckooTopK<Vec<u8>> {
         &mut self.sketch
+    }
+
+    /// Add `increment` occurrences of `item` to the sketch and return the
+    /// heavy-slot resident displaced by this insertion (if any). At most one
+    /// item can be evicted per call.
+    pub fn add(&mut self, item: &[u8], increment: u64) -> Option<Vec<u8>> {
+        self.sketch
+            .add_with_evicted(item, increment)
+            .map(|node| node.item)
     }
 }

--- a/tests/test_bloom_command.py
+++ b/tests/test_bloom_command.py
@@ -3,11 +3,6 @@ from valkeytestframework.conftest import resource_port_tracker
 
 class TestBloomCommand(ValkeyBloomTestCaseBase):
 
-    def verify_command_arity(self, command, expected_arity): 
-        command_info = self.client.execute_command('COMMAND', 'INFO', command)
-        actual_arity = command_info.get(command).get('arity')
-        assert actual_arity == expected_arity, f"Arity mismatch for command '{command}'"
-
     def test_bloom_command_arity(self):
         self.verify_command_arity('BF.EXISTS', -1)
         self.verify_command_arity('BF.ADD', -1)

--- a/tests/test_topk_basic.py
+++ b/tests/test_topk_basic.py
@@ -1,0 +1,36 @@
+from valkeytestframework.conftest import resource_port_tracker  # noqa: F401
+from valkey_bloom_test_case import ValkeyBloomTestCaseBase
+
+
+class TestTopkBasic(ValkeyBloomTestCaseBase):
+    """
+    Basic behavioral coverage for TOPK.ADD eviction semantics.
+
+    These tests exercise which item (if any) is displaced from the top-k by
+    an insertion. The displaced item depends on the sketch's hash seed, so we
+    reserve with an explicit SEED to keep results deterministic across runs.
+    """
+
+    def test_topk_add_no_eviction(self):
+        assert self.client.execute_command('TOPK.RESERVE tk 3 50 4 0.9 SEED 42') == b'OK'
+        assert self.client.execute_command(
+            'TOPK.ADD tk apple banana cherry apple banana cherry'
+        ) == [None] * 6
+        # Repeated adds of an already-tracked item still return nil.
+        assert self.client.execute_command('TOPK.ADD tk apple') == [None]
+
+    def test_topk_add_returns_evicted_item(self):
+        assert self.client.execute_command('TOPK.RESERVE tk 1 50 4 0.9 SEED 42') == b'OK'
+        # apple seats in the only slot (count=1), nothing displaced.
+        assert self.client.execute_command('TOPK.ADD tk apple') == [None]
+        # banana reaches count=2 within the call, displacing apple.
+        assert self.client.execute_command('TOPK.ADD tk banana banana') == [None, b'apple']
+
+    def test_topk_add_eviction_count(self):
+        assert self.client.execute_command('TOPK.RESERVE tk 2 50 4 0.9 SEED 42') == b'OK'
+        self.client.execute_command('TOPK.ADD tk apple apple banana')
+        result = self.client.execute_command('TOPK.ADD tk cherry cherry')
+        assert len(result) == 2
+        evictions = [r for r in result if r is not None]
+        assert len(evictions) == 1
+

--- a/tests/test_topk_command.py
+++ b/tests/test_topk_command.py
@@ -77,28 +77,11 @@ class TestTopkCommand(ValkeyBloomTestCaseBase):
         # A reserved name is free again once deleted.
         assert self.client.execute_command('DEL tk1') == 1
         assert self.client.execute_command('TOPK.RESERVE tk1 5') == b'OK'
-
-        # ---- TOPK.ADD: no eviction ----
-        # With k=3 and only three distinct items, nothing is ever displaced.
-        assert self.client.execute_command('TOPK.RESERVE tk_noevict 3 50 4 0.9') == b'OK'
-        assert self.client.execute_command(
-            'TOPK.ADD tk_noevict apple banana cherry apple banana cherry'
-        ) == [None] * 6
-        # Repeated adds of an already-tracked item still return nil.
-        assert self.client.execute_command('TOPK.ADD tk_noevict apple') == [None]
-
-        # ---- TOPK.ADD: eviction returns the displaced item ----
-        # k=1 means the second distinct item to outweigh the first evicts it.
-        assert self.client.execute_command('TOPK.RESERVE tk_evict 1 50 4 0.9') == b'OK'
-        assert self.client.execute_command('TOPK.ADD tk_evict apple') == [None]
-        assert self.client.execute_command('TOPK.ADD tk_evict banana banana') == [None, b'apple']
-
-        # ---- TOPK.ADD: mix of eviction and non-eviction in one call ----
-        # k=2: first two distinct items fill the queue, a third displaces one
-        # once it climbs high enough. Exactly one eviction of banana happens
-        # across the two cherry adds.
-        assert self.client.execute_command('TOPK.RESERVE tk_mixed 2 50 4 0.9') == b'OK'
-        self.client.execute_command('TOPK.ADD tk_mixed apple apple banana')
-        result = self.client.execute_command('TOPK.ADD tk_mixed cherry cherry')
-        assert len(result) == 2
-        assert [r for r in result if r is not None] == [b'banana']
+        assert self.client.execute_command('TOPK.RESERVE tk_add 5 50 4 0.9') == b'OK'
+        add_success_cases = [
+            ('TOPK.ADD tk_add apple', 1),
+            ('TOPK.ADD tk_add apple banana cherry', 3),
+            ('TOPK.ADD tk_add a b c d e f g', 7),
+        ]
+        for cmd, expected_len in add_success_cases:
+            assert len(self.client.execute_command(cmd)) == expected_len

--- a/tests/test_topk_command.py
+++ b/tests/test_topk_command.py
@@ -1,104 +1,27 @@
 from valkey_bloom_test_case import ValkeyBloomTestCaseBase
 from valkeytestframework.conftest import resource_port_tracker  # noqa: F401
-from valkey import ResponseError
-
 
 class TestTopkCommand(ValkeyBloomTestCaseBase):
-    """
-    Basic coverage for TOPK.RESERVE.
 
-    Syntax:
-        TOPK.RESERVE key topk [SEED seed] [width depth decay] [SEED seed]
+    def verify_command_arity(self, command, expected_arity):
+        command_info = self.client.execute_command('COMMAND', 'INFO', command)
+        actual_arity = command_info.get(command).get('arity')
+        assert actual_arity == expected_arity, f"Arity mismatch for command '{command}'"
 
-    The width/depth/decay group is all-or-nothing; defaults apply when the
-    group is omitted (DEFAULT_WIDTH=8, DEFAULT_DEPTH=7, DEFAULT_DECAY=0.9).
-    The SEED keyword may appear either right after `topk` or at the very
-    end, but not both. Valid arities are 3, 5, 6, and 8.
-    
-    """
+    def test_topk_command_arity(self):
+        self.verify_command_arity('TOPK.RESERVE', -1)
+        self.verify_command_arity('TOPK.ADD', -1)
 
-    def test_topk_reserve_success(self):
-        # arity 3: defaults for width/depth/decay, server-generated seed.
-        assert self.client.execute_command('TOPK.RESERVE tk1 5') == b'OK'
-
-        # arity 5: defaults plus an explicit seed (case-insensitive token).
-        assert self.client.execute_command(
-            'TOPK.RESERVE tk2 5 SEED 42'
-        ) == b'OK'
-        assert self.client.execute_command(
-            'TOPK.RESERVE tk3 5 seed 42'
-        ) == b'OK'
-
-        # arity 6: full sketch tuning, server-generated seed.
-        assert self.client.execute_command(
-            'TOPK.RESERVE tk4 5 50 4 0.9'
-        ) == b'OK'
-
-        # arity 8: full tuning plus explicit seed.
-        assert self.client.execute_command(
-            'TOPK.RESERVE tk5 10 200 5 0.5 SEED 42'
-        ) == b'OK'
-
-        # arity 8: SEED block leading, before the sketch params.
-        assert self.client.execute_command(
-            'TOPK.RESERVE tk6 10 SEED 42 200 5 0.5'
-        ) == b'OK'
-
-        # Case-insensitive SEED token in the leading position.
-        assert self.client.execute_command(
-            'TOPK.RESERVE tk7 10 seed 42 200 5 0.5'
-        ) == b'OK'
-
-        assert self.client.execute_command('DBSIZE') == 7
-
-    def test_topk_reserve_key_already_exists(self):
+    def test_topk_command_error(self):
+        # test set up
         assert self.client.execute_command('TOPK.RESERVE dup 5') == b'OK'
-        # Re-reserving the same key is rejected. TOPK params are immutable.
-        self.verify_error_response(
-            self.client,
-            'TOPK.RESERVE dup 5',
-            'BUSYKEY Target key name already exists.',
-        )
-
-        # After the key is deleted, the name is free to be reserved again.
-        assert self.client.execute_command('DEL dup') == 1
-        assert self.client.execute_command('TOPK.RESERVE dup 5') == b'OK'
-
-    def test_topk_reserve_wrong_arity(self):
-        # The handler accepts exactly 3, 5, 6, or 8 args. Anything else is a
-        # wrong-arity error from valkey-server.
-        wrong_arity_cases = [
-            'TOPK.RESERVE',                              # 1
-            'TOPK.RESERVE key',                          # 2
-            'TOPK.RESERVE key 5 50',                     # 4: partial sketch params
-            'TOPK.RESERVE key 5 50 4 0.9 SEED',          # 7: token without value
-            'TOPK.RESERVE key 5 50 4 0.9 SEED 42 extra', # 9: trailing junk
-        ]
-        for cmd in wrong_arity_cases:
-            self.verify_error_response(
-                self.client,
-                cmd,
-                "wrong number of arguments for 'TOPK.RESERVE' command",
-            )
-
-        # These have a *valid* arity (5) but the token at position 3 is not
-        # SEED, so they fall through to the syntax-error path.
-        for cmd in [
-            'TOPK.RESERVE key 5 50 4',         # arity 5, "50" where SEED expected
-            'TOPK.RESERVE key 5 NOTSEED 42',   # arity 5, wrong literal token
-        ]:
-            self.verify_error_response(self.client, cmd, 'ERROR')
-
-        # SEED appearing both before and after the sketch params is ambiguous
-        # and rejected, even though arity 8 is otherwise valid.
-        self.verify_error_response(
-            self.client,
-            'TOPK.RESERVE key 5 SEED 1 SEED 2',
-            "wrong number of arguments for 'TOPK.RESERVE' command",
-        )
-
-    def test_topk_reserve_bad_params(self):
-        validation_cases = [
+        assert self.client.execute_command('SET strkey hello') == b'OK'
+        basic_error_test_cases = [
+            # ---- TOPK.RESERVE ----
+            # re-reserving an existing key: params are immutable.
+            ('TOPK.RESERVE dup 5', 'BUSYKEY Target key name already exists.'),
+            # wrong type
+            ('TOPK.RESERVE strkey 5', 'WRONGTYPE Operation against a key holding the wrong kind of value'),
             # k must parse as u32 and be > 0.
             ('TOPK.RESERVE k1 abc', 'bad topk'),
             ('TOPK.RESERVE k1 -1', 'bad topk'),
@@ -116,23 +39,71 @@ class TestTopkCommand(ValkeyBloomTestCaseBase):
             ('TOPK.RESERVE k1 5 50 4 1.5', '(0 < decay < 1)'),
             # SEED token in the trailing position must literally match.
             ('TOPK.RESERVE k1 5 50 4 0.9 NOTSEED 42', 'ERROR'),
-            # Seed value must parse as u64.
+            # seed value must parse as u64.
             ('TOPK.RESERVE k1 5 SEED abc', 'invalid seed'),
             ('TOPK.RESERVE k1 5 SEED -1', 'invalid seed'),
             ('TOPK.RESERVE k1 5 50 4 0.9 SEED abc', 'invalid seed'),
+            # valid arity (5) but token at position 3 is not SEED.
+            ('TOPK.RESERVE key 5 50 4', 'ERROR'),
+            ('TOPK.RESERVE key 5 NOTSEED 42', 'ERROR'),
+            # wrong number of arguments (valid arities are 3, 5, 6, 8).
+            ('TOPK.RESERVE', "wrong number of arguments for 'TOPK.RESERVE' command"),
+            ('TOPK.RESERVE key', "wrong number of arguments for 'TOPK.RESERVE' command"),
+            ('TOPK.RESERVE key 5 50', "wrong number of arguments for 'TOPK.RESERVE' command"),
+            ('TOPK.RESERVE key 5 50 4 0.9 SEED', "wrong number of arguments for 'TOPK.RESERVE' command"),
+            ('TOPK.RESERVE key 5 50 4 0.9 SEED 42 extra', "wrong number of arguments for 'TOPK.RESERVE' command"),
+            # SEED both before and after the sketch params is ambiguous.
+            ('TOPK.RESERVE key 5 SEED 1 SEED 2', "wrong number of arguments for 'TOPK.RESERVE' command"),
+            # key must already be reserved; TOPK.ADD does not auto-create.
+            ('TOPK.ADD missing apple', 'TopK: key does not exist'),
+            # wrong type
+            ('TOPK.ADD strkey apple', 'WRONGTYPE Operation against a key holding the wrong kind of value'),
+            # wrong number of arguments
+            ('TOPK.ADD', "wrong number of arguments for 'TOPK.ADD' command"),
+            ('TOPK.ADD tk', "wrong number of arguments for 'TOPK.ADD' command"),
         ]
-        for cmd, expected_err in validation_cases:
-            self.verify_error_response(self.client, cmd, expected_err)
+        for cmd, expected_err_reply in basic_error_test_cases:
+            self.verify_error_response(self.client, cmd, expected_err_reply)
 
-        # None of the failed RESERVE calls should have created a key.
-        assert self.client.execute_command('DBSIZE') == 0
+    def test_topk_command_behavior(self):
+        reserve_success_cases = [
+            'TOPK.RESERVE tk1 5',                    # arity 3: defaults, random seed
+            'TOPK.RESERVE tk2 5 SEED 42',            # arity 5: defaults + seed
+            'TOPK.RESERVE tk3 5 seed 42',            # case-insensitive SEED token
+            'TOPK.RESERVE tk4 5 50 4 0.9',           # arity 6: full tuning
+            'TOPK.RESERVE tk5 10 200 5 0.5 SEED 42', # arity 8: tuning + trailing seed
+            'TOPK.RESERVE tk6 10 SEED 42 200 5 0.5', # arity 8: leading seed
+            'TOPK.RESERVE tk7 10 seed 42 200 5 0.5', # leading seed, lower-case
+        ]
+        for cmd in reserve_success_cases:
+            assert self.client.execute_command(cmd) == b'OK'
+        assert self.client.execute_command('DBSIZE') == len(reserve_success_cases)
 
-    def test_topk_reserve_wrong_type(self):
-        # Reserving on a key that already holds a non-TOPK value should fail.
-        assert self.client.execute_command('SET strkey hello') == b'OK'
-        try:
-            self.client.execute_command('TOPK.RESERVE strkey 5')
-            assert False, 'TOPK.RESERVE on a string key should fail'
-        except ResponseError as e:
-            # WRONGTYPE is the standard Valkey error for this case.
-            assert 'WRONGTYPE' in str(e), f'unexpected error: {e}'
+        # A reserved name is free again once deleted.
+        assert self.client.execute_command('DEL tk1') == 1
+        assert self.client.execute_command('TOPK.RESERVE tk1 5') == b'OK'
+
+        # ---- TOPK.ADD: no eviction ----
+        # With k=3 and only three distinct items, nothing is ever displaced.
+        assert self.client.execute_command('TOPK.RESERVE tk_noevict 3 50 4 0.9') == b'OK'
+        assert self.client.execute_command(
+            'TOPK.ADD tk_noevict apple banana cherry apple banana cherry'
+        ) == [None] * 6
+        # Repeated adds of an already-tracked item still return nil.
+        assert self.client.execute_command('TOPK.ADD tk_noevict apple') == [None]
+
+        # ---- TOPK.ADD: eviction returns the displaced item ----
+        # k=1 means the second distinct item to outweigh the first evicts it.
+        assert self.client.execute_command('TOPK.RESERVE tk_evict 1 50 4 0.9') == b'OK'
+        assert self.client.execute_command('TOPK.ADD tk_evict apple') == [None]
+        assert self.client.execute_command('TOPK.ADD tk_evict banana banana') == [None, b'apple']
+
+        # ---- TOPK.ADD: mix of eviction and non-eviction in one call ----
+        # k=2: first two distinct items fill the queue, a third displaces one
+        # once it climbs high enough. Exactly one eviction of banana happens
+        # across the two cherry adds.
+        assert self.client.execute_command('TOPK.RESERVE tk_mixed 2 50 4 0.9') == b'OK'
+        self.client.execute_command('TOPK.ADD tk_mixed apple apple banana')
+        result = self.client.execute_command('TOPK.ADD tk_mixed cherry cherry')
+        assert len(result) == 2
+        assert [r for r in result if r is not None] == [b'banana']

--- a/tests/test_topk_command.py
+++ b/tests/test_topk_command.py
@@ -3,11 +3,6 @@ from valkeytestframework.conftest import resource_port_tracker  # noqa: F401
 
 class TestTopkCommand(ValkeyBloomTestCaseBase):
 
-    def verify_command_arity(self, command, expected_arity):
-        command_info = self.client.execute_command('COMMAND', 'INFO', command)
-        actual_arity = command_info.get(command).get('arity')
-        assert actual_arity == expected_arity, f"Arity mismatch for command '{command}'"
-
     def test_topk_command_arity(self):
         self.verify_command_arity('TOPK.RESERVE', -1)
         self.verify_command_arity('TOPK.ADD', -1)

--- a/tests/valkey_bloom_test_case.py
+++ b/tests/valkey_bloom_test_case.py
@@ -40,6 +40,11 @@ class ValkeyBloomTestCaseBase(ValkeyTestCase):
         elif bloom_config_parameterization == "fixed-seed":
             self.use_random_seed = "no"
 
+    def verify_command_arity(self, command, expected_arity):
+        command_info = self.client.execute_command('COMMAND', 'INFO', command)
+        actual_arity = command_info.get(command).get('arity')
+        assert actual_arity == expected_arity, f"Arity mismatch for command '{command}'"
+
     def verify_error_response(self, client, cmd, expected_err_reply):
         try:
             client.execute_command(cmd)


### PR DESCRIPTION
## Summary
Implements `TOPK.ADD key item [item ...]`. Adds items to a sketch created by `TOPK.RESERVE` and returns an array with one entry per item: nil if nothing was displaced from the top-k, otherwise the bulk string of the evicted item.

## Changes
- `TopKObject::add` wraps heavykeeper's `add_with_evicted` to surface the displaced item.
- `topk_add` handler: arity check, missing-key error (no auto-create), wrong-type handling, per-item reply assembly.
- Registered `TOPK.ADD` in `lib.rs`.
- Reorganized `test_topk_command.py` into table-driven arity/error/behavior tests covering RESERVE and ADD.

## Testing
- `pytest tests/test_topk_command.py`.
- `cargo build --release` clean.

## Note
Depends on a new `add_with_evicted` API not yet in published heavykeeper;`Cargo.toml` pins a fork branch for now and needs to move to an upstreamed version before merge.
