### PR TITLE
Add TOPK.INFO, TOPK.INCRBY, and TOPK.LIST commands

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,8 +16,7 @@ valkey-module = { version = "0.1.5", features = ["min-valkey-compatibility-versi
 valkey-module-macros = "0"
 linkme = "0"
 bloomfilter = { version = "3.0.1", features = ["serde"] }
-# TODO: This is a temporary solution until we add this functionality to the original heavykeeper crate.
-heavykeeper = { git = "https://github.com/detemmienation/heavykeeper-rs.git", branch = "evicted" }
+heavykeeper = "0.6.6"
 lazy_static = "1.4.0"
 libc = "0.2"
 serde = { version = "1.0", features = ["derive"] }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -107,6 +107,12 @@ fn topk_add_command(ctx: &Context, args: Vec<ValkeyString>) -> ValkeyResult {
 }
 
 /// Command handler for:
+///  TOPK.INCRBY <key> <item> <increment> [<item> <increment> ...]
+fn topk_incrby_command(ctx: &Context, args: Vec<ValkeyString>) -> ValkeyResult {
+    topk_command_handler::topk_incrby(ctx, &args)
+}
+
+/// Command handler for:
 /// TOPK.INFO key
 fn topk_info_command(ctx: &Context, args: Vec<ValkeyString>) -> ValkeyResult {
     topk_command_handler::topk_info(ctx, &args)
@@ -149,6 +155,7 @@ valkey_module! {
         // TOPK Commands
         ["TOPK.RESERVE", topk_reserve_command, "write fast deny-oom", 1, 1, 1, "fast write topk"],
         ["TOPK.ADD", topk_add_command, "write fast deny-oom", 1, 1, 1, "fast write topk"],
+        ["TOPK.INCRBY", topk_incrby_command, "write fast deny-oom", 1, 1, 1, "fast write topk"],
         ["TOPK.INFO", topk_info_command, "readonly fast", 1, 1, 1, "fast read topk"],
     ],
     configurations: [

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -100,9 +100,16 @@ fn topk_reserve_command(ctx: &Context, args: Vec<ValkeyString>) -> ValkeyResult 
     topk_command_handler::topk_reserve(ctx, &args)
 }
 
-/// Command handler for TOPK.ADD <key> <item> [<item> ...]
+/// Command handler for:
+///  TOPK.ADD <key> <item> [<item> ...]
 fn topk_add_command(ctx: &Context, args: Vec<ValkeyString>) -> ValkeyResult {
     topk_command_handler::topk_add(ctx, &args)
+}
+
+/// Command handler for:
+/// TOPK.INFO key
+fn topk_info_command(ctx: &Context, args: Vec<ValkeyString>) -> ValkeyResult {
+    topk_command_handler::topk_info(ctx, &args)
 }
 
 ///
@@ -142,6 +149,7 @@ valkey_module! {
         // TOPK Commands
         ["TOPK.RESERVE", topk_reserve_command, "write fast deny-oom", 1, 1, 1, "fast write topk"],
         ["TOPK.ADD", topk_add_command, "write fast deny-oom", 1, 1, 1, "fast write topk"],
+        ["TOPK.INFO", topk_info_command, "readonly fast", 1, 1, 1, "fast read topk"],
     ],
     configurations: [
         i64: [

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -88,38 +88,32 @@ fn bloom_insert_command(ctx: &Context, args: Vec<ValkeyString>) -> ValkeyResult 
     command_handler::bloom_filter_insert(ctx, &args)
 }
 
-/// Command handler for:
-/// BF.LOAD <key> data
+/// Command handler for BF.LOAD <key> data
 fn bloom_load_command(ctx: &Context, args: Vec<ValkeyString>) -> ValkeyResult {
     command_handler::bloom_filter_load(ctx, &args)
 }
 
-/// Command handler for:
-/// TOPK.RESERVE key topk [width depth decay] [SEED seed]
+/// Command handler for TOPK.RESERVE key topk [width depth decay] [SEED seed]
 fn topk_reserve_command(ctx: &Context, args: Vec<ValkeyString>) -> ValkeyResult {
     topk_command_handler::topk_reserve(ctx, &args)
 }
 
-/// Command handler for:
-///  TOPK.ADD <key> <item> [<item> ...]
+/// Command handler for TOPK.ADD <key> <item> [<item> ...]
 fn topk_add_command(ctx: &Context, args: Vec<ValkeyString>) -> ValkeyResult {
     topk_command_handler::topk_add(ctx, &args)
 }
 
-/// Command handler for:
-///  TOPK.INCRBY <key> <item> <increment> [<item> <increment> ...]
+/// Command handler for TOPK.INCRBY <key> <item> <increment> [<item> <increment> ...]
 fn topk_incrby_command(ctx: &Context, args: Vec<ValkeyString>) -> ValkeyResult {
     topk_command_handler::topk_incrby(ctx, &args)
 }
 
-/// Command handler for:
-/// TOPK.INFO key
+/// Command handler for TOPK.INFO key
 fn topk_info_command(ctx: &Context, args: Vec<ValkeyString>) -> ValkeyResult {
     topk_command_handler::topk_info(ctx, &args)
 }
 
-/// Command handler for:
-///  TOPK.LIST key [WITHCOUNT]
+/// Command handler for TOPK.LIST key [WITHCOUNT]
 fn topk_list_command(ctx: &Context, args: Vec<ValkeyString>) -> ValkeyResult {
     topk_command_handler::topk_list(ctx, &args)
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -118,6 +118,12 @@ fn topk_info_command(ctx: &Context, args: Vec<ValkeyString>) -> ValkeyResult {
     topk_command_handler::topk_info(ctx, &args)
 }
 
+/// Command handler for:
+///  TOPK.LIST key [WITHCOUNT]
+fn topk_list_command(ctx: &Context, args: Vec<ValkeyString>) -> ValkeyResult {
+    topk_command_handler::topk_list(ctx, &args)
+}
+
 ///
 /// Module Info
 ///
@@ -157,6 +163,7 @@ valkey_module! {
         ["TOPK.ADD", topk_add_command, "write fast deny-oom", 1, 1, 1, "fast write topk"],
         ["TOPK.INCRBY", topk_incrby_command, "write fast deny-oom", 1, 1, 1, "fast write topk"],
         ["TOPK.INFO", topk_info_command, "readonly fast", 1, 1, 1, "fast read topk"],
+        ["TOPK.LIST", topk_list_command, "readonly", 1, 1, 1, "read topk"],
     ],
     configurations: [
         i64: [

--- a/src/topk/command_handler.rs
+++ b/src/topk/command_handler.rs
@@ -159,7 +159,6 @@ pub fn topk_reserve(ctx: &Context, input_args: &[ValkeyString]) -> ValkeyResult 
         Err(_) => Err(ValkeyError::Str(utils::ERROR)),
     }
 }
-
 /// Handle TOPK.ADD.
 ///
 /// Syntax:
@@ -192,6 +191,39 @@ pub fn topk_add(ctx: &Context, input_args: &[ValkeyString]) -> ValkeyResult {
     }
 
     replicate_and_notify_events(ctx, key_name, false, true, None);
+    Ok(ValkeyValue::Array(result))
+}
+
+/// Handle TOPK.INFO.
+///
+/// Syntax:
+///     TOPK.INFO key
+///
+/// Returns the number of required items (k), width, depth, and decay of the
+/// sketch stored at `key`.
+pub fn topk_info(ctx: &Context, input_args: &[ValkeyString]) -> ValkeyResult {
+    if input_args.len() != 2 {
+        return Err(ValkeyError::WrongArity);
+    }
+
+    let key_name = &input_args[1];
+    let key = ctx.open_key(key_name);
+    let topk = match key.get_value::<TopKObject>(&TOPK_TYPE) {
+        Ok(Some(topk)) => topk,
+        Ok(None) => return Err(ValkeyError::Str(utils::NOT_FOUND)),
+        Err(_) => return Err(ValkeyError::WrongType),
+    };
+
+    let result = vec![
+        ValkeyValue::SimpleStringStatic("k"),
+        ValkeyValue::Integer(topk.k() as i64),
+        ValkeyValue::SimpleStringStatic("width"),
+        ValkeyValue::Integer(topk.width() as i64),
+        ValkeyValue::SimpleStringStatic("depth"),
+        ValkeyValue::Integer(topk.depth() as i64),
+        ValkeyValue::SimpleStringStatic("decay"),
+        ValkeyValue::Float(topk.decay()),
+    ];
     Ok(ValkeyValue::Array(result))
 }
 

--- a/src/topk/command_handler.rs
+++ b/src/topk/command_handler.rs
@@ -160,7 +160,7 @@ pub fn topk_reserve(ctx: &Context, input_args: &[ValkeyString]) -> ValkeyResult 
     }
 }
 
-fn apply_increments<'a>(
+fn add_with_increments<'a>(
     topk: &mut TopKObject,
     items: impl ExactSizeIterator<Item = (&'a [u8], u64)>,
 ) -> Vec<ValkeyValue> {
@@ -197,7 +197,7 @@ pub fn topk_add(ctx: &Context, input_args: &[ValkeyString]) -> ValkeyResult {
     };
 
     let items = &input_args[2..];
-    let result = apply_increments(topk, items.iter().map(|item| (item.as_slice(), 1)));
+    let result = add_with_increments(topk, items.iter().map(|item| (item.as_slice(), 1)));
 
     replicate_and_notify_events(ctx, key_name, false, true, None);
     Ok(ValkeyValue::Array(result))
@@ -239,7 +239,7 @@ pub fn topk_incrby(ctx: &Context, input_args: &[ValkeyString]) -> ValkeyResult {
         parsed.push((item, increment));
     }
 
-    let result = apply_increments(
+    let result = add_with_increments(
         topk,
         parsed
             .iter()

--- a/src/topk/command_handler.rs
+++ b/src/topk/command_handler.rs
@@ -275,6 +275,55 @@ pub fn topk_info(ctx: &Context, input_args: &[ValkeyString]) -> ValkeyResult {
     Ok(ValkeyValue::Array(result))
 }
 
+/// Handle TOPK.LIST.
+///
+/// Syntax:
+///     TOPK.LIST key [WITHCOUNT]
+///
+/// Return the full list of items in Top-K sketch.
+/// With WITHCOUNT, each item is followed by its estimated count.
+pub fn topk_list(ctx: &Context, input_args: &[ValkeyString]) -> ValkeyResult {
+    let argc = input_args.len();
+    if !(2..=3).contains(&argc) {
+        return Err(ValkeyError::WrongArity);
+    }
+
+    let with_count = if argc == 3 {
+        if input_args[2]
+            .to_string_lossy()
+            .eq_ignore_ascii_case("WITHCOUNT")
+        {
+            true
+        } else {
+            return Err(ValkeyError::Str(utils::ERROR));
+        }
+    } else {
+        false
+    };
+
+    let key_name = &input_args[1];
+    let key = ctx.open_key(key_name);
+    let topk = match key.get_value::<TopKObject>(&TOPK_TYPE) {
+        Ok(Some(topk)) => topk,
+        Ok(None) => return Err(ValkeyError::Str(utils::NOT_FOUND)),
+        Err(_) => return Err(ValkeyError::WrongType),
+    };
+
+    let items = topk.list();
+    let mut result: Vec<ValkeyValue> = Vec::with_capacity(if with_count {
+        items.len() * 2
+    } else {
+        items.len()
+    });
+    for (item, count) in items {
+        result.push(ValkeyValue::StringBuffer(item));
+        if with_count {
+            result.push(ValkeyValue::Integer(count as i64));
+        }
+    }
+    Ok(ValkeyValue::Array(result))
+}
+
 /// Case-insensitive match for the literal SEED keyword.
 fn is_seed_token(arg: &ValkeyString) -> bool {
     arg.to_string_lossy().eq_ignore_ascii_case("SEED")

--- a/src/topk/command_handler.rs
+++ b/src/topk/command_handler.rs
@@ -194,6 +194,54 @@ pub fn topk_add(ctx: &Context, input_args: &[ValkeyString]) -> ValkeyResult {
     Ok(ValkeyValue::Array(result))
 }
 
+/// Handle TOPK.INCRBY.
+///
+/// Syntax:
+///     TOPK.INCRBY key item increment [item increment ...]
+///
+/// Like TOPK.ADD, but each item carries an explicit increment.
+/// Returns an array, one entry per item/increment pair, in order:
+///   - Null if no heavy-slot resident was displaced by the insertion.
+///   - The bulk-string of the displaced item otherwise.
+pub fn topk_incrby(ctx: &Context, input_args: &[ValkeyString]) -> ValkeyResult {
+    let argc = input_args.len();
+    // key + at least one item/increment pair, and the pairs must be complete.
+    if argc < 4 || !(argc - 2).is_multiple_of(2) {
+        return Err(ValkeyError::WrongArity);
+    }
+
+    let key_name = &input_args[1];
+    let key = ctx.open_key_writable(key_name);
+    let topk = match key.get_value::<TopKObject>(&TOPK_TYPE) {
+        Ok(Some(v)) => v,
+        Ok(None) => return Err(ValkeyError::Str(utils::NOT_FOUND)),
+        Err(_) => return Err(ValkeyError::WrongType),
+    };
+
+    let pairs = &input_args[2..];
+    let mut parsed: Vec<(&ValkeyString, u64)> = Vec::with_capacity(pairs.len() / 2);
+    for pair in pairs.chunks_exact(2) {
+        let item = &pair[0];
+        let increment = match pair[1].to_string_lossy().parse::<u64>() {
+            Ok(0) => return Err(ValkeyError::Str(utils::BAD_INCREMENT)),
+            Ok(num) => num,
+            Err(_) => return Err(ValkeyError::Str(utils::BAD_INCREMENT)),
+        };
+        parsed.push((item, increment));
+    }
+
+    let mut result: Vec<ValkeyValue> = Vec::with_capacity(parsed.len());
+    for (item, increment) in parsed {
+        match topk.add(item.as_slice(), increment) {
+            Some(evicted) => result.push(ValkeyValue::StringBuffer(evicted)),
+            None => result.push(ValkeyValue::Null),
+        }
+    }
+
+    replicate_and_notify_events(ctx, key_name, false, true, None);
+    Ok(ValkeyValue::Array(result))
+}
+
 /// Handle TOPK.INFO.
 ///
 /// Syntax:

--- a/src/topk/command_handler.rs
+++ b/src/topk/command_handler.rs
@@ -159,6 +159,21 @@ pub fn topk_reserve(ctx: &Context, input_args: &[ValkeyString]) -> ValkeyResult 
         Err(_) => Err(ValkeyError::Str(utils::ERROR)),
     }
 }
+
+fn apply_increments<'a>(
+    topk: &mut TopKObject,
+    items: impl ExactSizeIterator<Item = (&'a [u8], u64)>,
+) -> Vec<ValkeyValue> {
+    let mut result: Vec<ValkeyValue> = Vec::with_capacity(items.len());
+    for (item, increment) in items {
+        match topk.add(item, increment) {
+            Some(evicted) => result.push(ValkeyValue::StringBuffer(evicted)),
+            None => result.push(ValkeyValue::Null),
+        }
+    }
+    result
+}
+
 /// Handle TOPK.ADD.
 ///
 /// Syntax:
@@ -182,13 +197,7 @@ pub fn topk_add(ctx: &Context, input_args: &[ValkeyString]) -> ValkeyResult {
     };
 
     let items = &input_args[2..];
-    let mut result: Vec<ValkeyValue> = Vec::with_capacity(items.len());
-    for item in items {
-        match topk.add(item.as_slice(), 1) {
-            Some(evicted) => result.push(ValkeyValue::StringBuffer(evicted)),
-            None => result.push(ValkeyValue::Null),
-        }
-    }
+    let result = apply_increments(topk, items.iter().map(|item| (item.as_slice(), 1)));
 
     replicate_and_notify_events(ctx, key_name, false, true, None);
     Ok(ValkeyValue::Array(result))
@@ -206,7 +215,7 @@ pub fn topk_add(ctx: &Context, input_args: &[ValkeyString]) -> ValkeyResult {
 pub fn topk_incrby(ctx: &Context, input_args: &[ValkeyString]) -> ValkeyResult {
     let argc = input_args.len();
     // key + at least one item/increment pair, and the pairs must be complete.
-    if argc < 4 || !(argc - 2).is_multiple_of(2) {
+    if argc < 4 || !argc.is_multiple_of(2) {
         return Err(ValkeyError::WrongArity);
     }
 
@@ -230,13 +239,12 @@ pub fn topk_incrby(ctx: &Context, input_args: &[ValkeyString]) -> ValkeyResult {
         parsed.push((item, increment));
     }
 
-    let mut result: Vec<ValkeyValue> = Vec::with_capacity(parsed.len());
-    for (item, increment) in parsed {
-        match topk.add(item.as_slice(), increment) {
-            Some(evicted) => result.push(ValkeyValue::StringBuffer(evicted)),
-            None => result.push(ValkeyValue::Null),
-        }
-    }
+    let result = apply_increments(
+        topk,
+        parsed
+            .iter()
+            .map(|(item, increment)| (item.as_slice(), *increment)),
+    );
 
     replicate_and_notify_events(ctx, key_name, false, true, None);
     Ok(ValkeyValue::Array(result))

--- a/src/topk/utils.rs
+++ b/src/topk/utils.rs
@@ -99,3 +99,139 @@ impl TopKObject {
             .collect()
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rstest::rstest;
+
+    fn new_topk(k: u32, seed: u64) -> TopKObject {
+        TopKObject::new_reserved(k, 256, 4, DEFAULT_DECAY, seed)
+    }
+
+    #[test]
+    fn test_new_reserved_stores_params() {
+        // The constructor should round-trip every parameter through the getters.
+        let topk = TopKObject::new_reserved(5, 50, 4, 0.9, 42);
+        assert_eq!(topk.k(), 5);
+        assert_eq!(topk.width(), 50);
+        assert_eq!(topk.depth(), 4);
+        assert_eq!(topk.decay(), 0.9);
+        assert_eq!(topk.seed(), 42);
+    }
+
+    #[rstest(seed, case::seed_a(1), case::seed_b(42), case::seed_c(123456789))]
+    fn test_add_zero_increment_is_noop(seed: u64) {
+        let mut topk = new_topk(3, seed);
+        // A zero increment does no work and never evicts.
+        assert_eq!(topk.add(b"apple", 0), None);
+        assert!(topk.list().is_empty());
+    }
+
+    #[rstest(seed, case::seed_a(1), case::seed_b(42), case::seed_c(123456789))]
+    fn test_add_no_eviction_until_full(seed: u64) {
+        let mut topk = new_topk(2, seed);
+        // Priority queue has room (k=2), so neither insert evicts.
+        assert_eq!(topk.add(b"apple", 5), None);
+        assert_eq!(topk.add(b"banana", 10), None);
+        assert_eq!(topk.list().len(), 2);
+    }
+
+    #[rstest(seed, case::seed_a(1), case::seed_b(42), case::seed_c(123456789))]
+    fn test_add_returns_evicted_item(seed: u64) {
+        let mut topk = new_topk(2, seed);
+        assert_eq!(topk.add(b"apple", 5), None);
+        assert_eq!(topk.add(b"banana", 10), None);
+        assert_eq!(topk.add(b"cherry", 20), Some(b"apple".to_vec()));
+
+        let items: Vec<Vec<u8>> = topk.list().into_iter().map(|(item, _)| item).collect();
+        assert!(items.contains(&b"banana".to_vec()));
+        assert!(items.contains(&b"cherry".to_vec()));
+        assert!(!items.contains(&b"apple".to_vec()));
+    }
+
+    #[rstest(seed, case::seed_a(1), case::seed_b(42), case::seed_c(123456789))]
+    fn test_add_low_count_does_not_displace_min(seed: u64) {
+        let mut topk = new_topk(2, seed);
+        topk.add(b"hot", 50);
+        topk.add(b"warm", 30);
+        // "cold" never beats the current minimum (30), so nothing is evicted.
+        assert_eq!(topk.add(b"cold", 10), None);
+    }
+
+    #[rstest(seed, case::seed_a(1), case::seed_b(42), case::seed_c(123456789))]
+    fn test_add_existing_item_accumulates_count(seed: u64) {
+        let mut topk = new_topk(3, seed);
+        topk.add(b"apple", 4);
+        topk.add(b"apple", 6);
+        let counts: std::collections::HashMap<Vec<u8>, u64> = topk.list().into_iter().collect();
+        assert_eq!(counts.get(&b"apple".to_vec()), Some(&10));
+    }
+
+    #[rstest(seed, case::seed_a(1), case::seed_b(42), case::seed_c(123456789))]
+    fn test_list_sorted_by_descending_count(seed: u64) {
+        let mut topk = new_topk(5, seed);
+        topk.add(b"apple", 10);
+        topk.add(b"banana", 5);
+        topk.add(b"cherry", 2);
+
+        let listed = topk.list();
+        assert_eq!(
+            listed,
+            vec![
+                (b"apple".to_vec(), 10),
+                (b"banana".to_vec(), 5),
+                (b"cherry".to_vec(), 2),
+            ]
+        );
+    }
+
+    #[rstest(seed, case::seed_a(1), case::seed_b(42), case::seed_c(123456789))]
+    fn test_list_never_exceeds_k(seed: u64) {
+        let mut topk = new_topk(3, seed);
+        for (item, incr) in [
+            (b"a".as_slice(), 10),
+            (b"b".as_slice(), 9),
+            (b"c".as_slice(), 8),
+            (b"d".as_slice(), 7),
+            (b"e".as_slice(), 6),
+        ] {
+            topk.add(item, incr);
+        }
+        assert!(topk.list().len() <= 3);
+    }
+
+    #[rstest(
+        item_a,
+        item_b,
+        case::numeric(b"12345", b"67890"),
+        case::mixed(b"item-1", b"item-2")
+    )]
+    fn test_add_and_list_with_non_alpha_items(item_a: &[u8], item_b: &[u8]) {
+        let mut topk = new_topk(2, 42);
+        topk.add(item_a, 10);
+        topk.add(item_b, 5);
+
+        let counts: std::collections::HashMap<Vec<u8>, u64> = topk.list().into_iter().collect();
+        assert_eq!(counts.get(&item_a.to_vec()), Some(&10));
+        assert_eq!(counts.get(&item_b.to_vec()), Some(&5));
+    }
+
+    #[test]
+    fn test_seed() {
+        // Two sketches built with the same seed are deterministic: identical
+        // input produces identical Top-K output.
+        let mut a = new_topk(3, 42);
+        let mut b = new_topk(3, 42);
+        for (item, incr) in [
+            (b"apple".as_slice(), 7),
+            (b"banana".as_slice(), 11),
+            (b"cherry".as_slice(), 3),
+        ] {
+            a.add(item, incr);
+            b.add(item, incr);
+        }
+        assert_eq!(a.seed(), b.seed());
+        assert_eq!(a.list(), b.list());
+    }
+}

--- a/src/topk/utils.rs
+++ b/src/topk/utils.rs
@@ -21,8 +21,8 @@ pub const TOPK_DEPTH_MAX: u32 = u32::MAX;
 
 /// Client Errors
 pub const ERROR: &str = "ERROR";
-pub const KEY_EXISTS: &str = "BUSYKEY Target key name already exists.";
 pub const NOT_FOUND: &str = "ERR TopK: key does not exist";
+pub const KEY_EXISTS: &str = "BUSYKEY Target key name already exists.";
 pub const BAD_TOPK: &str = "ERR bad topk";
 pub const BAD_WIDTH: &str = "ERR bad width";
 pub const BAD_DEPTH: &str = "ERR bad depth";

--- a/src/topk/utils.rs
+++ b/src/topk/utils.rs
@@ -86,8 +86,6 @@ impl TopKObject {
     /// heavy-slot resident displaced by this insertion (if any). At most one
     /// item can be evicted per call.
     pub fn add(&mut self, item: &[u8], increment: u64) -> Option<Vec<u8>> {
-        self.sketch
-            .add_with_evicted(item, increment)
-            .map(|node| node.item)
+        self.sketch.add_with_evicted(item, increment)
     }
 }

--- a/src/topk/utils.rs
+++ b/src/topk/utils.rs
@@ -28,6 +28,7 @@ pub const BAD_WIDTH: &str = "ERR bad width";
 pub const BAD_DEPTH: &str = "ERR bad depth";
 pub const BAD_DECAY: &str = "ERR bad decay";
 pub const INVALID_SEED: &str = "ERR invalid seed";
+pub const BAD_INCREMENT: &str = "ERR bad increment";
 pub const TOPK_LARGER_THAN_0: &str = "ERR (topk should be larger than 0)";
 pub const WIDTH_LARGER_THAN_0: &str = "ERR (width should be larger than 0)";
 pub const DEPTH_LARGER_THAN_0: &str = "ERR (depth should be larger than 0)";

--- a/src/topk/utils.rs
+++ b/src/topk/utils.rs
@@ -105,10 +105,6 @@ mod tests {
     use super::*;
     use rstest::rstest;
 
-    fn new_topk(k: u32, seed: u64) -> TopKObject {
-        TopKObject::new_reserved(k, 256, 4, DEFAULT_DECAY, seed)
-    }
-
     #[test]
     fn test_new_reserved_stores_params() {
         // The constructor should round-trip every parameter through the getters.
@@ -122,7 +118,7 @@ mod tests {
 
     #[rstest(seed, case::seed_a(1), case::seed_b(42), case::seed_c(123456789))]
     fn test_add_zero_increment_is_noop(seed: u64) {
-        let mut topk = new_topk(3, seed);
+        let mut topk = TopKObject::new_reserved(3, 256, 4, DEFAULT_DECAY, seed);
         // A zero increment does no work and never evicts.
         assert_eq!(topk.add(b"apple", 0), None);
         assert!(topk.list().is_empty());
@@ -130,7 +126,7 @@ mod tests {
 
     #[rstest(seed, case::seed_a(1), case::seed_b(42), case::seed_c(123456789))]
     fn test_add_no_eviction_until_full(seed: u64) {
-        let mut topk = new_topk(2, seed);
+        let mut topk = TopKObject::new_reserved(2, 256, 4, DEFAULT_DECAY, seed);
         // Priority queue has room (k=2), so neither insert evicts.
         assert_eq!(topk.add(b"apple", 5), None);
         assert_eq!(topk.add(b"banana", 10), None);
@@ -139,7 +135,7 @@ mod tests {
 
     #[rstest(seed, case::seed_a(1), case::seed_b(42), case::seed_c(123456789))]
     fn test_add_returns_evicted_item(seed: u64) {
-        let mut topk = new_topk(2, seed);
+        let mut topk = TopKObject::new_reserved(2, 256, 4, DEFAULT_DECAY, seed);
         assert_eq!(topk.add(b"apple", 5), None);
         assert_eq!(topk.add(b"banana", 10), None);
         assert_eq!(topk.add(b"cherry", 20), Some(b"apple".to_vec()));
@@ -152,7 +148,7 @@ mod tests {
 
     #[rstest(seed, case::seed_a(1), case::seed_b(42), case::seed_c(123456789))]
     fn test_add_low_count_does_not_displace_min(seed: u64) {
-        let mut topk = new_topk(2, seed);
+        let mut topk = TopKObject::new_reserved(2, 256, 4, DEFAULT_DECAY, seed);
         topk.add(b"hot", 50);
         topk.add(b"warm", 30);
         // "cold" never beats the current minimum (30), so nothing is evicted.
@@ -161,16 +157,16 @@ mod tests {
 
     #[rstest(seed, case::seed_a(1), case::seed_b(42), case::seed_c(123456789))]
     fn test_add_existing_item_accumulates_count(seed: u64) {
-        let mut topk = new_topk(3, seed);
+        let mut topk = TopKObject::new_reserved(3, 256, 4, DEFAULT_DECAY, seed);
         topk.add(b"apple", 4);
         topk.add(b"apple", 6);
         let counts: std::collections::HashMap<Vec<u8>, u64> = topk.list().into_iter().collect();
-        assert_eq!(counts.get(&b"apple".to_vec()), Some(&10));
+        assert_eq!(counts.get(b"apple".as_slice()), Some(&10));
     }
 
     #[rstest(seed, case::seed_a(1), case::seed_b(42), case::seed_c(123456789))]
     fn test_list_sorted_by_descending_count(seed: u64) {
-        let mut topk = new_topk(5, seed);
+        let mut topk = TopKObject::new_reserved(5, 256, 4, DEFAULT_DECAY, seed);
         topk.add(b"apple", 10);
         topk.add(b"banana", 5);
         topk.add(b"cherry", 2);
@@ -188,7 +184,7 @@ mod tests {
 
     #[rstest(seed, case::seed_a(1), case::seed_b(42), case::seed_c(123456789))]
     fn test_list_never_exceeds_k(seed: u64) {
-        let mut topk = new_topk(3, seed);
+        let mut topk = TopKObject::new_reserved(3, 256, 4, DEFAULT_DECAY, seed);
         for (item, incr) in [
             (b"a".as_slice(), 10),
             (b"b".as_slice(), 9),
@@ -208,21 +204,21 @@ mod tests {
         case::mixed(b"item-1", b"item-2")
     )]
     fn test_add_and_list_with_non_alpha_items(item_a: &[u8], item_b: &[u8]) {
-        let mut topk = new_topk(2, 42);
+        let mut topk = TopKObject::new_reserved(2, 256, 4, DEFAULT_DECAY, 42);
         topk.add(item_a, 10);
         topk.add(item_b, 5);
 
         let counts: std::collections::HashMap<Vec<u8>, u64> = topk.list().into_iter().collect();
-        assert_eq!(counts.get(&item_a.to_vec()), Some(&10));
-        assert_eq!(counts.get(&item_b.to_vec()), Some(&5));
+        assert_eq!(counts.get(item_a), Some(&10));
+        assert_eq!(counts.get(item_b), Some(&5));
     }
 
     #[test]
     fn test_seed() {
         // Two sketches built with the same seed are deterministic: identical
         // input produces identical Top-K output.
-        let mut a = new_topk(3, 42);
-        let mut b = new_topk(3, 42);
+        let mut a = TopKObject::new_reserved(3, 256, 4, DEFAULT_DECAY, 42);
+        let mut b = TopKObject::new_reserved(3, 256, 4, DEFAULT_DECAY, 42);
         for (item, incr) in [
             (b"apple".as_slice(), 7),
             (b"banana".as_slice(), 11),

--- a/src/topk/utils.rs
+++ b/src/topk/utils.rs
@@ -89,4 +89,13 @@ impl TopKObject {
     pub fn add(&mut self, item: &[u8], increment: u64) -> Option<Vec<u8>> {
         self.sketch.add_with_evicted(item, increment)
     }
+
+    /// Return the Top-K items
+    pub fn list(&self) -> Vec<(Vec<u8>, u64)> {
+        self.sketch
+            .list()
+            .into_iter()
+            .map(|node| (node.item, node.count))
+            .collect()
+    }
 }

--- a/tests/test_topk_basic.py
+++ b/tests/test_topk_basic.py
@@ -34,3 +34,23 @@ class TestTopkBasic(ValkeyBloomTestCaseBase):
         evictions = [r for r in result if r is not None]
         assert len(evictions) == 1
 
+    def test_topk_incrby_accumulates_count(self):
+        # Repeated increments of the same item accumulate. Verify the summed
+        # count through TOPK.LIST WITHCOUNT.
+        assert self.client.execute_command('TOPK.RESERVE tk 3 50 4 0.9 SEED 42') == b'OK'
+        self.client.execute_command('TOPK.INCRBY tk apple 4')
+        self.client.execute_command('TOPK.INCRBY tk apple 6')
+        listed = self.client.execute_command('TOPK.LIST tk WITHCOUNT')
+        it = iter(listed)
+        counts = dict(zip(it, it))
+        assert counts[b'apple'] == 10
+
+    def test_topk_add_low_count_does_not_displace_min(self):
+        # Once the top-k is full, an item whose count never beats the current
+        # minimum tracked count is not admitted and displaces nothing.
+        assert self.client.execute_command('TOPK.RESERVE tk 2 50 4 0.9 SEED 42') == b'OK'
+        self.client.execute_command('TOPK.INCRBY tk hot 50 warm 30')
+        assert self.client.execute_command('TOPK.ADD tk cold') == [None]
+        listed = self.client.execute_command('TOPK.LIST tk')
+        assert b'cold' not in listed
+

--- a/tests/test_topk_command.py
+++ b/tests/test_topk_command.py
@@ -114,6 +114,11 @@ class TestTopkCommand(ValkeyBloomTestCaseBase):
             ('TOPK.ADD tk_add apple', 1),
             ('TOPK.ADD tk_add apple banana cherry', 3),
             ('TOPK.ADD tk_add a b c d e f g', 7),
+            ('TOPK.ADD tk_add 12345 67890', 2),
+            ('TOPK.ADD tk_add item-1 item_2 item.3 item:4', 4),
+            ('TOPK.ADD tk_add Item1 ITEM2 iTeM3', 3),
+            ('TOPK.ADD tk_add dup dup dup', 3),
+            ('TOPK.ADD tk_add ' + 'x' * 256, 1),
         ]
         for cmd, expected_len in add_success_cases:
             assert len(self.client.execute_command(cmd)) == expected_len
@@ -124,6 +129,9 @@ class TestTopkCommand(ValkeyBloomTestCaseBase):
             ('TOPK.INCRBY tk_incr apple 1', 1),
             ('TOPK.INCRBY tk_incr apple 5 banana 3', 2),
             ('TOPK.INCRBY tk_incr a 1 b 2 c 3', 3),
+            ('TOPK.INCRBY tk_incr 12345 7 item-1 2', 2),
+            ('TOPK.INCRBY tk_incr whale 1000000', 1),
+            ('TOPK.INCRBY tk_incr dup 2 dup 3', 2),
         ]
         for cmd, expected_len in incrby_success_cases:
             assert len(self.client.execute_command(cmd)) == expected_len

--- a/tests/test_topk_command.py
+++ b/tests/test_topk_command.py
@@ -6,6 +6,7 @@ class TestTopkCommand(ValkeyBloomTestCaseBase):
     def test_topk_command_arity(self):
         self.verify_command_arity('TOPK.RESERVE', -1)
         self.verify_command_arity('TOPK.ADD', -1)
+        self.verify_command_arity('TOPK.INFO', -1)
 
     def test_topk_command_error(self):
         # test set up
@@ -56,6 +57,13 @@ class TestTopkCommand(ValkeyBloomTestCaseBase):
             # wrong number of arguments
             ('TOPK.ADD', "wrong number of arguments for 'TOPK.ADD' command"),
             ('TOPK.ADD tk', "wrong number of arguments for 'TOPK.ADD' command"),
+            # key must exist.
+            ('TOPK.INFO missing', 'TopK: key does not exist'),
+            # wrong type
+            ('TOPK.INFO strkey', 'WRONGTYPE Operation against a key holding the wrong kind of value'),
+            # wrong number of arguments 
+            ('TOPK.INFO', "wrong number of arguments for 'TOPK.INFO' command"),
+            ('TOPK.INFO dup extra', "wrong number of arguments for 'TOPK.INFO' command"),
         ]
         for cmd, expected_err_reply in basic_error_test_cases:
             self.verify_error_response(self.client, cmd, expected_err_reply)
@@ -85,3 +93,20 @@ class TestTopkCommand(ValkeyBloomTestCaseBase):
         ]
         for cmd, expected_len in add_success_cases:
             assert len(self.client.execute_command(cmd)) == expected_len
+
+        # TOPK.INFO reports k, width, depth, and decay of an existing sketch.
+        def info_dict(key):
+            raw = self.client.execute_command(f'TOPK.INFO {key}')
+            it = iter(raw)
+            return dict(zip(it, it))
+        info = info_dict('tk1')
+        assert info[b'k'] == 5
+        assert info[b'width'] == 8
+        assert info[b'depth'] == 7
+        assert info[b'decay'] == b'0.9'
+
+        info = info_dict('tk5')
+        assert info[b'k'] == 10
+        assert info[b'width'] == 200
+        assert info[b'depth'] == 5
+        assert info[b'decay'] == b'0.5'

--- a/tests/test_topk_command.py
+++ b/tests/test_topk_command.py
@@ -8,6 +8,7 @@ class TestTopkCommand(ValkeyBloomTestCaseBase):
         self.verify_command_arity('TOPK.ADD', -1)
         self.verify_command_arity('TOPK.INCRBY', -1)
         self.verify_command_arity('TOPK.INFO', -1)
+        self.verify_command_arity('TOPK.LIST', -1)
 
     def test_topk_command_error(self):
         # test set up
@@ -78,6 +79,15 @@ class TestTopkCommand(ValkeyBloomTestCaseBase):
             # wrong number of arguments 
             ('TOPK.INFO', "wrong number of arguments for 'TOPK.INFO' command"),
             ('TOPK.INFO dup extra', "wrong number of arguments for 'TOPK.INFO' command"),
+            # key must exist.
+            ('TOPK.LIST missing', 'TopK: key does not exist'),
+            # wrong type
+            ('TOPK.LIST strkey', 'WRONGTYPE Operation against a key holding the wrong kind of value'),
+            # only WITHCOUNT is accepted as the optional third argument.
+            ('TOPK.LIST dup NOTWITHCOUNT', 'ERROR'),
+            # wrong number of arguments.
+            ('TOPK.LIST', "wrong number of arguments for 'TOPK.LIST' command"),
+            ('TOPK.LIST dup WITHCOUNT extra', "wrong number of arguments for 'TOPK.LIST' command"),
         ]
         for cmd, expected_err_reply in basic_error_test_cases:
             self.verify_error_response(self.client, cmd, expected_err_reply)
@@ -134,3 +144,25 @@ class TestTopkCommand(ValkeyBloomTestCaseBase):
         assert info[b'width'] == 200
         assert info[b'depth'] == 5
         assert info[b'decay'] == b'0.5'
+
+        # TOPK.LIST returns tracked items by descending count, at most k.
+        assert self.client.execute_command('TOPK.RESERVE tk_list 3 50 4 0.9 SEED 42') == b'OK'
+        self.client.execute_command('TOPK.INCRBY tk_list apple 10 banana 5 cherry 2')
+
+        listed = self.client.execute_command('TOPK.LIST tk_list')
+        assert listed == [b'apple', b'banana', b'cherry']
+
+        # WITHCOUNT interleaves each item with its estimated count.
+        listed_wc = self.client.execute_command('TOPK.LIST tk_list WITHCOUNT')
+        it = iter(listed_wc)
+        counts = dict(zip(it, it))
+        assert counts[b'apple'] == 10
+        assert counts[b'banana'] == 5
+        assert counts[b'cherry'] == 2
+
+        # WITHCOUNT is case-insensitive.
+        assert self.client.execute_command('TOPK.LIST tk_list withcount') == listed_wc
+
+        # The list never exceeds k even when more distinct items are added.
+        self.client.execute_command('TOPK.INCRBY tk_list durian 1 elderberry 1')
+        assert len(self.client.execute_command('TOPK.LIST tk_list')) <= 3

--- a/tests/test_topk_command.py
+++ b/tests/test_topk_command.py
@@ -6,6 +6,7 @@ class TestTopkCommand(ValkeyBloomTestCaseBase):
     def test_topk_command_arity(self):
         self.verify_command_arity('TOPK.RESERVE', -1)
         self.verify_command_arity('TOPK.ADD', -1)
+        self.verify_command_arity('TOPK.INCRBY', -1)
         self.verify_command_arity('TOPK.INFO', -1)
 
     def test_topk_command_error(self):
@@ -57,6 +58,19 @@ class TestTopkCommand(ValkeyBloomTestCaseBase):
             # wrong number of arguments
             ('TOPK.ADD', "wrong number of arguments for 'TOPK.ADD' command"),
             ('TOPK.ADD tk', "wrong number of arguments for 'TOPK.ADD' command"),
+            # key must already be reserved
+            ('TOPK.INCRBY missing apple 1', 'TopK: key does not exist'),
+            # wrong type
+            ('TOPK.INCRBY strkey apple 1', 'WRONGTYPE Operation against a key holding the wrong kind of value'),
+            # increment must parse as u64 and be > 0.
+            ('TOPK.INCRBY dup apple abc', 'bad increment'),
+            ('TOPK.INCRBY dup apple -1', 'bad increment'),
+            ('TOPK.INCRBY dup apple 0', 'bad increment'),
+            # wrong number of arguments: needs complete item/increment pairs.
+            ('TOPK.INCRBY', "wrong number of arguments for 'TOPK.INCRBY' command"),
+            ('TOPK.INCRBY dup', "wrong number of arguments for 'TOPK.INCRBY' command"),
+            ('TOPK.INCRBY dup apple', "wrong number of arguments for 'TOPK.INCRBY' command"),
+            ('TOPK.INCRBY dup apple 1 banana', "wrong number of arguments for 'TOPK.INCRBY' command"),
             # key must exist.
             ('TOPK.INFO missing', 'TopK: key does not exist'),
             # wrong type
@@ -92,6 +106,16 @@ class TestTopkCommand(ValkeyBloomTestCaseBase):
             ('TOPK.ADD tk_add a b c d e f g', 7),
         ]
         for cmd, expected_len in add_success_cases:
+            assert len(self.client.execute_command(cmd)) == expected_len
+
+        # TOPK.INCRBY behaves like ADD but with explicit per-item increments.
+        assert self.client.execute_command('TOPK.RESERVE tk_incr 5 50 4 0.9') == b'OK'
+        incrby_success_cases = [
+            ('TOPK.INCRBY tk_incr apple 1', 1),
+            ('TOPK.INCRBY tk_incr apple 5 banana 3', 2),
+            ('TOPK.INCRBY tk_incr a 1 b 2 c 3', 3),
+        ]
+        for cmd, expected_len in incrby_success_cases:
             assert len(self.client.execute_command(cmd)) == expected_len
 
         # TOPK.INFO reports k, width, depth, and decay of an existing sketch.


### PR DESCRIPTION
## Summary

Adds three read/write TOPK commands:

- **TOPK.INFO key** — returns the sketch parameters: `k`, `width`, `depth`, and `decay`. Read-only.
- **TOPK.INCRBY key item increment [item increment ...]** — like TOPK.ADD but with an explicit per-item increment. Returns one entry per pair: the evicted item (bulk string) or nil.
- **TOPK.LIST key [WITHCOUNT]** — returns the tracked items ordered by descending count (Top `k`). With WITHCOUNT, each item is followed by its estimated count. Read-only.


## Dependency change

`Cargo.toml` now points at the published `heavykeeper = "0.6.6"`  
`add_with_evicted` returns `Option<T>` in this version; the sketch adapter was adjusted accordingly.

## Testing

Full Python integration suite passes, including new TOPK.INFO/INCRBY/LIST coverage in `tests/test_topk_command.py`: arity, error paths (missing key, wrong type, bad arguments, wrong arity), and behavior (reply shape, ranked order, WITHCOUNT pairs, case-insensitive token, at-most-k guarantee).

