### PR TITLE
Add TOPK.COUNT, TOPK.QUERY commands

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,8 +16,7 @@ valkey-module = { version = "0.1.5", features = ["min-valkey-compatibility-versi
 valkey-module-macros = "0"
 linkme = "0"
 bloomfilter = { version = "3.0.1", features = ["serde"] }
-# TODO: This is a temporary solution until we add this functionality to the original heavykeeper crate.
-heavykeeper = { git = "https://github.com/detemmienation/heavykeeper-rs.git", branch = "query" }
+heavykeeper = "0.6.7"
 lazy_static = "1.4.0"
 libc = "0.2"
 serde = { version = "1.0", features = ["derive"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,8 @@ valkey-module = { version = "0.1.5", features = ["min-valkey-compatibility-versi
 valkey-module-macros = "0"
 linkme = "0"
 bloomfilter = { version = "3.0.1", features = ["serde"] }
-heavykeeper = "0.6.6"
+# TODO: This is a temporary solution until we add this functionality to the original heavykeeper crate.
+heavykeeper = { git = "https://github.com/detemmienation/heavykeeper-rs.git", branch = "query" }
 lazy_static = "1.4.0"
 libc = "0.2"
 serde = { version = "1.0", features = ["derive"] }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -118,6 +118,11 @@ fn topk_list_command(ctx: &Context, args: Vec<ValkeyString>) -> ValkeyResult {
     topk_command_handler::topk_list(ctx, &args)
 }
 
+/// Command handler for TOPK.COUNT key item [item ...]
+fn topk_count_command(ctx: &Context, args: Vec<ValkeyString>) -> ValkeyResult {
+    topk_command_handler::topk_count(ctx, &args)
+}
+
 ///
 /// Module Info
 ///
@@ -158,6 +163,7 @@ valkey_module! {
         ["TOPK.INCRBY", topk_incrby_command, "write fast deny-oom", 1, 1, 1, "fast write topk"],
         ["TOPK.INFO", topk_info_command, "readonly fast", 1, 1, 1, "fast read topk"],
         ["TOPK.LIST", topk_list_command, "readonly", 1, 1, 1, "read topk"],
+        ["TOPK.COUNT", topk_count_command, "readonly fast", 1, 1, 1, "fast read topk"],
     ],
     configurations: [
         i64: [

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -123,6 +123,11 @@ fn topk_count_command(ctx: &Context, args: Vec<ValkeyString>) -> ValkeyResult {
     topk_command_handler::topk_count(ctx, &args)
 }
 
+/// Command handler for TOPK.QUERY key item [item ...]
+fn topk_query_command(ctx: &Context, args: Vec<ValkeyString>) -> ValkeyResult {
+    topk_command_handler::topk_query(ctx, &args)
+}
+
 ///
 /// Module Info
 ///
@@ -164,6 +169,7 @@ valkey_module! {
         ["TOPK.INFO", topk_info_command, "readonly fast", 1, 1, 1, "fast read topk"],
         ["TOPK.LIST", topk_list_command, "readonly", 1, 1, 1, "read topk"],
         ["TOPK.COUNT", topk_count_command, "readonly fast", 1, 1, 1, "fast read topk"],
+        ["TOPK.QUERY", topk_query_command, "readonly fast", 1, 1, 1, "fast read topk"],
     ],
     configurations: [
         i64: [

--- a/src/topk/command_handler.rs
+++ b/src/topk/command_handler.rs
@@ -332,6 +332,38 @@ pub fn topk_list(ctx: &Context, input_args: &[ValkeyString]) -> ValkeyResult {
     Ok(ValkeyValue::Array(result))
 }
 
+/// Handle TOPK.COUNT.
+///
+/// Syntax:
+///     TOPK.COUNT key item [item ...]
+///
+/// Return the estimated count for one or more items. Returns an array, one
+/// entry per input item, in order.
+///
+/// Note: the returned counts are estimates and may be lower than the true
+/// counts, but never higher, due to the decaying nature of the sketch.
+pub fn topk_count(ctx: &Context, input_args: &[ValkeyString]) -> ValkeyResult {
+    let argc = input_args.len();
+    if argc < 3 {
+        return Err(ValkeyError::WrongArity);
+    }
+
+    let key_name = &input_args[1];
+    let key = ctx.open_key(key_name);
+    let topk = match key.get_value::<TopKObject>(&TOPK_TYPE) {
+        Ok(Some(topk)) => topk,
+        Ok(None) => return Err(ValkeyError::Str(utils::NOT_FOUND)),
+        Err(_) => return Err(ValkeyError::WrongType),
+    };
+
+    let items = &input_args[2..];
+    let result: Vec<ValkeyValue> = items
+        .iter()
+        .map(|item| ValkeyValue::Integer(topk.count(item.as_slice()) as i64))
+        .collect();
+    Ok(ValkeyValue::Array(result))
+}
+
 /// Case-insensitive match for the literal SEED keyword.
 fn is_seed_token(arg: &ValkeyString) -> bool {
     arg.to_string_lossy().eq_ignore_ascii_case("SEED")

--- a/src/topk/command_handler.rs
+++ b/src/topk/command_handler.rs
@@ -364,6 +364,35 @@ pub fn topk_count(ctx: &Context, input_args: &[ValkeyString]) -> ValkeyResult {
     Ok(ValkeyValue::Array(result))
 }
 
+/// Handle TOPK.QUERY.
+///
+/// Syntax:
+///     TOPK.QUERY key item [item ...]
+///
+/// Return, for each item, whether it is currently in the Top-K list. Returns
+/// an array of integers (1 = in the list, 0 = not) in order.
+pub fn topk_query(ctx: &Context, input_args: &[ValkeyString]) -> ValkeyResult {
+    let argc = input_args.len();
+    if argc < 3 {
+        return Err(ValkeyError::WrongArity);
+    }
+
+    let key_name = &input_args[1];
+    let key = ctx.open_key(key_name);
+    let topk = match key.get_value::<TopKObject>(&TOPK_TYPE) {
+        Ok(Some(topk)) => topk,
+        Ok(None) => return Err(ValkeyError::Str(utils::NOT_FOUND)),
+        Err(_) => return Err(ValkeyError::WrongType),
+    };
+
+    let items = &input_args[2..];
+    let result: Vec<ValkeyValue> = items
+        .iter()
+        .map(|item| ValkeyValue::Integer(topk.query(item.as_slice()) as i64))
+        .collect();
+    Ok(ValkeyValue::Array(result))
+}
+
 /// Case-insensitive match for the literal SEED keyword.
 fn is_seed_token(arg: &ValkeyString) -> bool {
     arg.to_string_lossy().eq_ignore_ascii_case("SEED")

--- a/src/topk/utils.rs
+++ b/src/topk/utils.rs
@@ -90,6 +90,12 @@ impl TopKObject {
         self.sketch.add_with_evicted(item, increment)
     }
 
+    /// Return the estimated count for `item`, or 0 if it has no residual
+    /// presence in the priority queue or sketch cells.
+    pub fn count(&self, item: &[u8]) -> u64 {
+        self.sketch.count(item)
+    }
+
     /// Return the Top-K items
     pub fn list(&self) -> Vec<(Vec<u8>, u64)> {
         self.sketch
@@ -211,6 +217,52 @@ mod tests {
         let counts: std::collections::HashMap<Vec<u8>, u64> = topk.list().into_iter().collect();
         assert_eq!(counts.get(item_a), Some(&10));
         assert_eq!(counts.get(item_b), Some(&5));
+    }
+
+    #[rstest(seed, case::seed_a(1), case::seed_b(42), case::seed_c(123456789))]
+    fn test_count_untracked_item_is_zero(seed: u64) {
+        let topk = TopKObject::new_reserved(3, 256, 4, DEFAULT_DECAY, seed);
+        assert_eq!(topk.count(b"apple"), 0);
+    }
+
+    #[rstest(seed, case::seed_a(1), case::seed_b(42), case::seed_c(123456789))]
+    fn test_count_reflects_added_increments(seed: u64) {
+        let mut topk = TopKObject::new_reserved(3, 256, 4, DEFAULT_DECAY, seed);
+        topk.add(b"apple", 10);
+        topk.add(b"banana", 5);
+        assert_eq!(topk.count(b"apple"), 10);
+        assert_eq!(topk.count(b"banana"), 5);
+        assert_eq!(topk.count(b"cherry"), 0);
+    }
+
+    #[rstest(seed, case::seed_a(1), case::seed_b(42), case::seed_c(123456789))]
+    fn test_count_accumulates_repeated_adds(seed: u64) {
+        let mut topk = TopKObject::new_reserved(3, 256, 4, DEFAULT_DECAY, seed);
+        topk.add(b"apple", 4);
+        topk.add(b"apple", 6);
+        assert_eq!(topk.count(b"apple"), 10);
+    }
+
+    #[rstest(seed, case::seed_a(1), case::seed_b(42), case::seed_c(123456789))]
+    fn test_count_never_exceeds_true_count(seed: u64) {
+        let mut topk = TopKObject::new_reserved(3, 256, 4, DEFAULT_DECAY, seed);
+        for item in [b"a".as_slice(), b"b".as_slice(), b"c".as_slice()] {
+            for _ in 0..20 {
+                topk.add(item, 1);
+            }
+            assert!(topk.count(item) <= 20);
+        }
+    }
+
+    #[test]
+    fn test_count_matches_list_withcount() {
+        // The count reported by count() agrees with the count surfaced by list().
+        let mut topk = TopKObject::new_reserved(5, 256, 4, DEFAULT_DECAY, 42);
+        topk.add(b"apple", 10);
+        topk.add(b"banana", 5);
+        let counts: std::collections::HashMap<Vec<u8>, u64> = topk.list().into_iter().collect();
+        assert_eq!(topk.count(b"apple"), counts[b"apple".as_slice()]);
+        assert_eq!(topk.count(b"banana"), counts[b"banana".as_slice()]);
     }
 
     #[test]

--- a/src/topk/utils.rs
+++ b/src/topk/utils.rs
@@ -225,18 +225,15 @@ mod tests {
     }
 
     #[rstest(seed, case::seed_a(1), case::seed_b(42), case::seed_c(123456789))]
-    fn test_count_untracked_item_is_zero(seed: u64) {
-        let topk = TopKObject::new_reserved(3, 256, 4, DEFAULT_DECAY, seed);
-        assert_eq!(topk.count(b"apple"), 0);
-    }
-
-    #[rstest(seed, case::seed_a(1), case::seed_b(42), case::seed_c(123456789))]
     fn test_count_reflects_added_increments(seed: u64) {
         let mut topk = TopKObject::new_reserved(3, 256, 4, DEFAULT_DECAY, seed);
+        // Untracked items report a count of zero before anything is added.
+        assert_eq!(topk.count(b"apple"), 0);
         topk.add(b"apple", 10);
         topk.add(b"banana", 5);
         assert_eq!(topk.count(b"apple"), 10);
         assert_eq!(topk.count(b"banana"), 5);
+        // An item that was never added also reports zero.
         assert_eq!(topk.count(b"cherry"), 0);
     }
 
@@ -268,12 +265,6 @@ mod tests {
         let counts: std::collections::HashMap<Vec<u8>, u64> = topk.list().into_iter().collect();
         assert_eq!(topk.count(b"apple"), counts[b"apple".as_slice()]);
         assert_eq!(topk.count(b"banana"), counts[b"banana".as_slice()]);
-    }
-
-    #[rstest(seed, case::seed_a(1), case::seed_b(42), case::seed_c(123456789))]
-    fn test_query_untracked_item_is_false(seed: u64) {
-        let topk = TopKObject::new_reserved(3, 256, 4, DEFAULT_DECAY, seed);
-        assert!(!topk.query(b"apple"));
     }
 
     #[rstest(seed, case::seed_a(1), case::seed_b(42), case::seed_c(123456789))]

--- a/src/topk/utils.rs
+++ b/src/topk/utils.rs
@@ -98,7 +98,7 @@ impl TopKObject {
 
     /// Return whether `item` is currently in the Top-K list.
     pub fn query(&self, item: &[u8]) -> bool {
-        self.sketch.query_topk_items(item)
+        self.sketch.contains_top_k(item)
     }
 
     /// Return the Top-K items

--- a/src/topk/utils.rs
+++ b/src/topk/utils.rs
@@ -96,6 +96,11 @@ impl TopKObject {
         self.sketch.count(item)
     }
 
+    /// Return whether `item` is currently in the Top-K list.
+    pub fn query(&self, item: &[u8]) -> bool {
+        self.sketch.query_topk_items(item)
+    }
+
     /// Return the Top-K items
     pub fn list(&self) -> Vec<(Vec<u8>, u64)> {
         self.sketch
@@ -263,6 +268,51 @@ mod tests {
         let counts: std::collections::HashMap<Vec<u8>, u64> = topk.list().into_iter().collect();
         assert_eq!(topk.count(b"apple"), counts[b"apple".as_slice()]);
         assert_eq!(topk.count(b"banana"), counts[b"banana".as_slice()]);
+    }
+
+    #[rstest(seed, case::seed_a(1), case::seed_b(42), case::seed_c(123456789))]
+    fn test_query_untracked_item_is_false(seed: u64) {
+        let topk = TopKObject::new_reserved(3, 256, 4, DEFAULT_DECAY, seed);
+        assert!(!topk.query(b"apple"));
+    }
+
+    #[rstest(seed, case::seed_a(1), case::seed_b(42), case::seed_c(123456789))]
+    fn test_query_tracked_item_is_true(seed: u64) {
+        let mut topk = TopKObject::new_reserved(3, 256, 4, DEFAULT_DECAY, seed);
+        topk.add(b"apple", 10);
+        topk.add(b"banana", 5);
+        assert!(topk.query(b"apple"));
+        assert!(topk.query(b"banana"));
+        assert!(!topk.query(b"cherry"));
+    }
+
+    #[rstest(seed, case::seed_a(1), case::seed_b(42), case::seed_c(123456789))]
+    fn test_query_evicted_item_is_false(seed: u64) {
+        // An item displaced from the top-k by hotter items is no longer a
+        // member, even though it may still have a residual sketch count.
+        let mut topk = TopKObject::new_reserved(2, 256, 4, DEFAULT_DECAY, seed);
+        topk.add(b"apple", 5);
+        topk.add(b"banana", 10);
+        topk.add(b"cherry", 20);
+        assert!(!topk.query(b"apple"));
+        assert!(topk.query(b"banana"));
+        assert!(topk.query(b"cherry"));
+    }
+
+    #[test]
+    fn test_query_agrees_with_list() {
+        // query() membership matches what list() reports.
+        let mut topk = TopKObject::new_reserved(3, 256, 4, DEFAULT_DECAY, 42);
+        topk.add(b"apple", 10);
+        topk.add(b"banana", 5);
+        let listed: std::collections::HashSet<Vec<u8>> =
+            topk.list().into_iter().map(|(item, _)| item).collect();
+        assert_eq!(topk.query(b"apple"), listed.contains(b"apple".as_slice()));
+        assert_eq!(topk.query(b"banana"), listed.contains(b"banana".as_slice()));
+        assert_eq!(
+            topk.query(b"missing"),
+            listed.contains(b"missing".as_slice())
+        );
     }
 
     #[test]

--- a/tests/test_topk_basic.py
+++ b/tests/test_topk_basic.py
@@ -54,3 +54,15 @@ class TestTopkBasic(ValkeyBloomTestCaseBase):
         listed = self.client.execute_command('TOPK.LIST tk')
         assert b'cold' not in listed
 
+    def test_topk_count_never_exceeds_true_count(self):
+        # Estimates never exceed true counts. Use a small, narrow sketch so
+        # collisions are likely, then check the invariant holds.
+        assert self.client.execute_command('TOPK.RESERVE tk_inv 5 4 2 0.9 SEED 42') == b'OK'
+        true_counts = {f'item-{i}': i + 1 for i in range(50)}
+        for item, count in true_counts.items():
+            self.client.execute_command(f'TOPK.INCRBY tk_inv {item} {count}')
+        items = list(true_counts.keys())
+        estimates = self.client.execute_command('TOPK.COUNT tk_inv ' + ' '.join(items))
+        for item, estimate in zip(items, estimates):
+            assert estimate <= true_counts[item], f'{item}: {estimate} > {true_counts[item]}'
+

--- a/tests/test_topk_command.py
+++ b/tests/test_topk_command.py
@@ -9,6 +9,7 @@ class TestTopkCommand(ValkeyBloomTestCaseBase):
         self.verify_command_arity('TOPK.INCRBY', -1)
         self.verify_command_arity('TOPK.INFO', -1)
         self.verify_command_arity('TOPK.LIST', -1)
+        self.verify_command_arity('TOPK.COUNT', -1)
 
     def test_topk_command_error(self):
         # test set up
@@ -88,6 +89,13 @@ class TestTopkCommand(ValkeyBloomTestCaseBase):
             # wrong number of arguments.
             ('TOPK.LIST', "wrong number of arguments for 'TOPK.LIST' command"),
             ('TOPK.LIST dup WITHCOUNT extra', "wrong number of arguments for 'TOPK.LIST' command"),
+            # key must exist.
+            ('TOPK.COUNT missing apple', 'TopK: key does not exist'),
+            # wrong type
+            ('TOPK.COUNT strkey apple', 'WRONGTYPE Operation against a key holding the wrong kind of value'),
+            # wrong number of arguments: needs key plus at least one item.
+            ('TOPK.COUNT', "wrong number of arguments for 'TOPK.COUNT' command"),
+            ('TOPK.COUNT dup', "wrong number of arguments for 'TOPK.COUNT' command"),
         ]
         for cmd, expected_err_reply in basic_error_test_cases:
             self.verify_error_response(self.client, cmd, expected_err_reply)
@@ -174,3 +182,23 @@ class TestTopkCommand(ValkeyBloomTestCaseBase):
         # The list never exceeds k even when more distinct items are added.
         self.client.execute_command('TOPK.INCRBY tk_list durian 1 elderberry 1')
         assert len(self.client.execute_command('TOPK.LIST tk_list')) <= 3
+
+        # TOPK.COUNT returns the estimated count per item, in order.
+        assert self.client.execute_command('TOPK.RESERVE tk_count 3 50 4 0.9 SEED 42') == b'OK'
+        self.client.execute_command('TOPK.INCRBY tk_count apple 10 banana 5 cherry 2')
+        assert self.client.execute_command('TOPK.COUNT tk_count apple') == [10]
+        assert self.client.execute_command('TOPK.COUNT tk_count apple banana cherry') == [10, 5, 2]
+        assert self.client.execute_command('TOPK.COUNT tk_count missing') == [0]
+        assert self.client.execute_command('TOPK.COUNT tk_count apple missing banana') == [10, 0, 5]
+        assert self.client.execute_command('TOPK.COUNT tk_count apple apple') == [10, 10]
+
+        # Estimates never exceed true counts. Use a small, narrow
+        # sketch so collisions are likely, then check the invariant holds.
+        assert self.client.execute_command('TOPK.RESERVE tk_inv 5 4 2 0.9 SEED 42') == b'OK'
+        true_counts = {f'item-{i}': i + 1 for i in range(50)}
+        for item, count in true_counts.items():
+            self.client.execute_command(f'TOPK.INCRBY tk_inv {item} {count}')
+        items = list(true_counts.keys())
+        estimates = self.client.execute_command('TOPK.COUNT tk_inv ' + ' '.join(items))
+        for item, estimate in zip(items, estimates):
+            assert estimate <= true_counts[item], f'{item}: {estimate} > {true_counts[item]}'

--- a/tests/test_topk_command.py
+++ b/tests/test_topk_command.py
@@ -200,17 +200,6 @@ class TestTopkCommand(ValkeyBloomTestCaseBase):
         assert self.client.execute_command('TOPK.COUNT tk_count apple missing banana') == [10, 0, 5]
         assert self.client.execute_command('TOPK.COUNT tk_count apple apple') == [10, 10]
 
-        # Estimates never exceed true counts. Use a small, narrow
-        # sketch so collisions are likely, then check the invariant holds.
-        assert self.client.execute_command('TOPK.RESERVE tk_inv 5 4 2 0.9 SEED 42') == b'OK'
-        true_counts = {f'item-{i}': i + 1 for i in range(50)}
-        for item, count in true_counts.items():
-            self.client.execute_command(f'TOPK.INCRBY tk_inv {item} {count}')
-        items = list(true_counts.keys())
-        estimates = self.client.execute_command('TOPK.COUNT tk_inv ' + ' '.join(items))
-        for item, estimate in zip(items, estimates):
-            assert estimate <= true_counts[item], f'{item}: {estimate} > {true_counts[item]}'
-
         # TOPK.QUERY reports top-k membership (1/0) per item, in order.
         assert self.client.execute_command('TOPK.RESERVE tk_query 3 50 4 0.9 SEED 42') == b'OK'
         self.client.execute_command('TOPK.INCRBY tk_query apple 10 banana 5 cherry 2')

--- a/tests/test_topk_command.py
+++ b/tests/test_topk_command.py
@@ -10,6 +10,7 @@ class TestTopkCommand(ValkeyBloomTestCaseBase):
         self.verify_command_arity('TOPK.INFO', -1)
         self.verify_command_arity('TOPK.LIST', -1)
         self.verify_command_arity('TOPK.COUNT', -1)
+        self.verify_command_arity('TOPK.QUERY', -1)
 
     def test_topk_command_error(self):
         # test set up
@@ -96,6 +97,13 @@ class TestTopkCommand(ValkeyBloomTestCaseBase):
             # wrong number of arguments: needs key plus at least one item.
             ('TOPK.COUNT', "wrong number of arguments for 'TOPK.COUNT' command"),
             ('TOPK.COUNT dup', "wrong number of arguments for 'TOPK.COUNT' command"),
+            # key must exist.
+            ('TOPK.QUERY missing apple', 'TopK: key does not exist'),
+            # wrong type
+            ('TOPK.QUERY strkey apple', 'WRONGTYPE Operation against a key holding the wrong kind of value'),
+            # wrong number of arguments: needs key plus at least one item.
+            ('TOPK.QUERY', "wrong number of arguments for 'TOPK.QUERY' command"),
+            ('TOPK.QUERY dup', "wrong number of arguments for 'TOPK.QUERY' command"),
         ]
         for cmd, expected_err_reply in basic_error_test_cases:
             self.verify_error_response(self.client, cmd, expected_err_reply)
@@ -202,3 +210,23 @@ class TestTopkCommand(ValkeyBloomTestCaseBase):
         estimates = self.client.execute_command('TOPK.COUNT tk_inv ' + ' '.join(items))
         for item, estimate in zip(items, estimates):
             assert estimate <= true_counts[item], f'{item}: {estimate} > {true_counts[item]}'
+
+        # TOPK.QUERY reports top-k membership (1/0) per item, in order.
+        assert self.client.execute_command('TOPK.RESERVE tk_query 3 50 4 0.9 SEED 42') == b'OK'
+        self.client.execute_command('TOPK.INCRBY tk_query apple 10 banana 5 cherry 2')
+        assert self.client.execute_command('TOPK.QUERY tk_query apple') == [1]
+        assert self.client.execute_command('TOPK.QUERY tk_query missing') == [0]
+        assert self.client.execute_command('TOPK.QUERY tk_query apple banana cherry') == [1, 1, 1]
+        assert self.client.execute_command('TOPK.QUERY tk_query apple missing banana') == [1, 0, 1]
+
+        # QUERY agrees with the membership reported by LIST.
+        listed = set(self.client.execute_command('TOPK.LIST tk_query'))
+        for item in [b'apple', b'banana', b'cherry', b'missing']:
+            expected = 1 if item in listed else 0
+            assert self.client.execute_command('TOPK.QUERY tk_query', item) == [expected]
+
+        # An item displaced from the top-k reports 0
+        assert self.client.execute_command('TOPK.RESERVE tk_evict 2 50 4 0.9 SEED 42') == b'OK'
+        self.client.execute_command('TOPK.INCRBY tk_evict apple 5 banana 10 cherry 20')
+        assert self.client.execute_command('TOPK.QUERY tk_evict apple') == [0]
+        assert self.client.execute_command('TOPK.QUERY tk_evict banana cherry') == [1, 1]


### PR DESCRIPTION
## Summary

Adds two read-only TOPK commands:

- `TOPK.COUNT key item [item ...]` — returns the estimated count for each item in order. Untracked items return 0. Counts are estimates that may be lower than the true count but never higher.
- `TOPK.QUERY key item [item ...]` — returns whether each item is currently in the Top-K list, as 1 (in) or 0 (not), in order. 

## Dependency change

`TOPK.QUERY` relies on a new `query_topk_items` API in the heavykeeper crate. This PR temporarily points the dependency at a fork branch. This needs to move to a published release before merge.

## Tests

- Rust unit tests for `count()` and `query()` (seed-parametrized), including the eviction case where a displaced item reports not-in-top-k.
- Python integration tests: arity, error cases (missing key, wrong type, wrong arity), per-item results in order, mixed tracked/untracked, agreement with TOPK.LIST, and the count `<=` true-count invariant.
