### PR TITLE
`BF.INFO`: documentation and reabability nits

### DIFF
--- a/src/bloom/command_handler.rs
+++ b/src/bloom/command_handler.rs
@@ -758,14 +758,14 @@ pub fn bloom_filter_info(ctx: &Context, input_args: &[ValkeyString]) -> ValkeyRe
                 "FILTERS" => Ok(ValkeyValue::Integer(val.num_filters() as i64)),
                 "ITEMS" => Ok(ValkeyValue::Integer(val.cardinality())),
                 "ERROR" => Ok(ValkeyValue::Float(val.fp_rate())),
-                "TIGHTENING" if val.expansion() > 0 => {
-                    Ok(ValkeyValue::Float(val.tightening_ratio()))
-                }
                 "EXPANSION" => {
                     if val.expansion() == 0 {
                         return Ok(ValkeyValue::Null);
                     }
                     Ok(ValkeyValue::Integer(val.expansion() as i64))
+                }
+                "TIGHTENING" if val.expansion() > 0 => {
+                    Ok(ValkeyValue::Float(val.tightening_ratio()))
                 }
                 // Only calculate and expose MAXSCALEDCAPACITY for scaling bloom objects.
                 "MAXSCALEDCAPACITY" if val.expansion() > 0 => {

--- a/src/commands/bf.info.json
+++ b/src/commands/bf.info.json
@@ -37,14 +37,14 @@
                         "token": "FILTERS"
                     },
                     {
-                        "name": "expansion",
-                        "type": "pure-token",
-                        "token": "EXPANSION"
-                    },
-                    {
                         "name": "error",
                         "type": "pure-token",
                         "token": "ERROR"
+                    },
+                    {
+                        "name": "expansion",
+                        "type": "pure-token",
+                        "token": "EXPANSION"
                     },
                     {
                         "name": "tightening",

--- a/src/commands/bf.info.json
+++ b/src/commands/bf.info.json
@@ -37,6 +37,11 @@
                         "token": "FILTERS"
                     },
                     {
+                        "name": "items",
+                        "type": "pure-token",
+                        "token": "ITEMS"
+                    },
+                    {
                         "name": "error",
                         "type": "pure-token",
                         "token": "ERROR"


### PR DESCRIPTION
* `bf.info`: Harmonize sorting of info types

  The order of the types between the web documentation `Usage` section,
  `INFO FIELDS` section, and the code did not agree.

  We sort all three alike to make things more readable.

* `commands/bf.info`: Add missing `ITEMS` entry

  `ITEMS` was missing from the web documentation's `Usage` section. So
  we add it.
