### PR TITLE
Add keyspace notification and ACL category test coverage for TopK

### DIFF
--- a/src/topk/command_handler.rs
+++ b/src/topk/command_handler.rs
@@ -16,7 +16,7 @@ struct ReplicateArgs {
 /// Helper function to replicate mutative commands to the replica nodes and publish keyspace events.
 /// There are two main cases for replication:
 /// - RESERVE operation: replays a deterministic TOPK.RESERVE on replicas.
-/// - ADD: covers TOPK.ADD and TOPK.INCRBY; both replicate verbatim and publish
+/// - ADD operation: covers TOPK.ADD and TOPK.INCRBY; both replicate verbatim and publish
 ///   the same `topk.add` event, safe because they are deterministic once the
 ///   replica is seeded identically via the replicated TOPK.RESERVE.
 fn replicate_and_notify_events(

--- a/src/topk/command_handler.rs
+++ b/src/topk/command_handler.rs
@@ -16,9 +16,9 @@ struct ReplicateArgs {
 /// Helper function to replicate mutative commands to the replica nodes and publish keyspace events.
 /// There are two main cases for replication:
 /// - RESERVE operation: replays a deterministic TOPK.RESERVE on replicas.
-/// - ADD operation: verbatim replication is safe because TOPK.ADD is
-///   deterministic given the same sketch state, and replicas were seeded
-///   identically via the replicated TOPK.RESERVE.
+/// - ADD: covers TOPK.ADD and TOPK.INCRBY; both replicate verbatim and publish
+///   the same `topk.add` event, safe because they are deterministic once the
+///   replica is seeded identically via the replicated TOPK.RESERVE.
 fn replicate_and_notify_events(
     ctx: &Context,
     key_name: &ValkeyString,

--- a/tests/test_bloom_acl_category.py
+++ b/tests/test_bloom_acl_category.py
@@ -1,5 +1,6 @@
 from valkeytestframework.conftest import resource_port_tracker
 from valkey_bloom_test_case import ValkeyBloomTestCaseBase
+from valkeytestframework.util.waiters import *
 
 class TestBloomACLCategory(ValkeyBloomTestCaseBase):
 
@@ -15,7 +16,28 @@ class TestBloomACLCategory(ValkeyBloomTestCaseBase):
             ('BF.INFO insert_key filters', 1),
             ('BF.RESERVE reserve_key 0.01 1000', b'OK'),
         ]
-        self.run_acl_category_permissions_test("bloom", bloom_commands)
+        client = self.server.get_new_client()
+        # Get a list of all commands with the acl category bloom
+        list_of_bloom_commands = client.execute_command("COMMAND LIST FILTERBY ACLCAT bloom")
+        # Create users with different acl permissions
+        client.execute_command("ACL SETUSER nonbloomuser1 on >bloom_pass -@bloom")
+        client.execute_command("ACL SETUSER nonbloomuser2 on >bloom_pass -@all")
+        client.execute_command("ACL SETUSER bloomuser1 on >bloom_pass ~* &* +@all ")
+        client.execute_command("ACL SETUSER bloomuser2 on >bloom_pass ~* &* -@all +@bloom ")
+        client.execute_command("ACL SETUSER bloomuser3 on >bloom_pass ~* &* -@all +@write +@read ")
+        client.execute_command("ACL SETUSER bloomuser4 on >bloom_pass ~* &* -@all +@write +@bloom")
+        # Switch to the users with no bloom command access and check error occurs as expected
+        for i in range(1, 3):
+            client.execute_command(f"AUTH nonbloomuser{i} bloom_pass")
+            for cmd in bloom_commands:
+                self.verify_invalid_user_permissions(client, cmd, list_of_bloom_commands)
+        # Switch to the users with bloom command access and check commands are run as expected
+        for i in range(1, 5):
+            client.execute_command(f"AUTH bloomuser{i} bloom_pass")
+            for cmd in bloom_commands:
+                self.verify_valid_user_permissions(client, cmd)
+            self.client.execute_command('FLUSHDB')
+            wait_for_equal(lambda: self.client.execute_command('DBSIZE'), 0)
 
     def verify_valid_user_permissions(self, client, cmd):
         cmd_name = cmd[0].split()[0]

--- a/tests/test_bloom_acl_category.py
+++ b/tests/test_bloom_acl_category.py
@@ -1,6 +1,5 @@
 from valkeytestframework.conftest import resource_port_tracker
 from valkey_bloom_test_case import ValkeyBloomTestCaseBase
-from valkeytestframework.util.waiters import *
 
 class TestBloomACLCategory(ValkeyBloomTestCaseBase):
 
@@ -16,28 +15,7 @@ class TestBloomACLCategory(ValkeyBloomTestCaseBase):
             ('BF.INFO insert_key filters', 1),
             ('BF.RESERVE reserve_key 0.01 1000', b'OK'),
         ]
-        client = self.server.get_new_client()
-        # Get a list of all commands with the acl category bloom
-        list_of_bloom_commands = client.execute_command("COMMAND LIST FILTERBY ACLCAT bloom")
-        # Create users with different acl permissions
-        client.execute_command("ACL SETUSER nonbloomuser1 on >bloom_pass -@bloom")
-        client.execute_command("ACL SETUSER nonbloomuser2 on >bloom_pass -@all")
-        client.execute_command("ACL SETUSER bloomuser1 on >bloom_pass ~* &* +@all ")
-        client.execute_command("ACL SETUSER bloomuser2 on >bloom_pass ~* &* -@all +@bloom ")
-        client.execute_command("ACL SETUSER bloomuser3 on >bloom_pass ~* &* -@all +@write +@read ")
-        client.execute_command("ACL SETUSER bloomuser4 on >bloom_pass ~* &* -@all +@write +@bloom")
-        # Switch to the users with no bloom command access and check error occurs as expected
-        for i in range(1, 3):
-            client.execute_command(f"AUTH nonbloomuser{i} bloom_pass")
-            for cmd in bloom_commands:
-                self.verify_invalid_user_permissions(client, cmd, list_of_bloom_commands)
-        # Switch to the users with bloom command access and check commands are run as expected
-        for i in range(1, 5):
-            client.execute_command(f"AUTH bloomuser{i} bloom_pass")
-            for cmd in bloom_commands:
-                self.verify_valid_user_permissions(client, cmd)
-            self.client.execute_command('FLUSHDB')
-            wait_for_equal(lambda: self.client.execute_command('DBSIZE'), 0)
+        self.run_acl_category_permissions_test("bloom", bloom_commands)
 
     def verify_valid_user_permissions(self, client, cmd):
         cmd_name = cmd[0].split()[0]
@@ -52,16 +30,6 @@ class TestBloomACLCategory(ValkeyBloomTestCaseBase):
         except Exception as e:
             assert False, f"bloomuser should be able to execute {cmd_name}: {str(e)}"
 
-    def verify_invalid_user_permissions(self, client, cmd, list_of_bloom_commands):
-        cmd_name = cmd[0].split()[0]
-        # Check that each command we try to run appeared in the list of commands with the bloom acl category
-        assert cmd_name.encode() in list_of_bloom_commands
-        try:
-            result = client.execute_command(cmd[0])
-            assert False, f"User with no bloom category access shouldnt be able to run {cmd_name}"
-        except Exception as e:
-            assert f"has no permissions to run the '{cmd_name}' command" in str(e)
-
     def test_bloom_command_acl_categories(self):
         # List of bloom commands and their acl categories
         bloom_commands = [
@@ -75,9 +43,4 @@ class TestBloomACLCategory(ValkeyBloomTestCaseBase):
             ('BF.RESERVE', [b'write', b'denyoom', b'module', b'fast'], [b'@write', b'@fast', b'@bloom']),
             ('BF.LOAD', [b'write', b'denyoom', b'module'], [b'@write', b'@bloom']),
         ]
-        for cmd in bloom_commands:
-            # Get the info of the commands and compare the acl categories
-            cmd_info = self.client.execute_command(f'COMMAND INFO {cmd[0]}')
-            assert cmd_info[0][2] == cmd[1]
-            for category in cmd[2]:
-                assert category in cmd_info[0][6]
+        self.verify_command_acl_categories(bloom_commands)

--- a/tests/test_bloom_keyspace.py
+++ b/tests/test_bloom_keyspace.py
@@ -1,70 +1,30 @@
-import time
 from valkey_bloom_test_case import ValkeyBloomTestCaseBase
 from valkeytestframework.conftest import resource_port_tracker
 
 class TestKeyEventNotifications(ValkeyBloomTestCaseBase):
-    RESERVE_KEYSPACE_MESSAGE = {'type': 'pmessage', 'pattern': b'__key*__:*', 'channel': b'__keyspace@0__:intermediate_val', 'data': b'bloom.reserve'}
-    RESERVE_KEYEVENT_MESSAGE = {'type': 'pmessage', 'pattern': b'__key*__:*', 'channel': b'__keyevent@0__:bloom.reserve', 'data': b'intermediate_val'}
-    ADD_KEYSPACE_MESSAGE = {'type': 'pmessage', 'pattern': b'__key*__:*', 'channel': b'__keyspace@0__:intermediate_val', 'data': b'bloom.add'} 
-    ADD_KEYEVENT_MESSAGE = {'type': 'pmessage', 'pattern': b'__key*__:*', 'channel': b'__keyevent@0__:bloom.add', 'data': b'intermediate_val'}
 
-    def create_expected_message_list(self, reserve_expected, add_expected, key_name):
-        expected_messages = []
-        self.RESERVE_KEYSPACE_MESSAGE['channel'] = f"__keyspace@0__:{key_name}".encode('utf-8')
-        self.RESERVE_KEYEVENT_MESSAGE['data'] = f"{key_name}".encode('utf-8')
-        self.ADD_KEYSPACE_MESSAGE['channel'] = f"__keyspace@0__:{key_name}".encode('utf-8')
-        self.ADD_KEYEVENT_MESSAGE['data'] = f"{key_name}".encode('utf-8')
-        if reserve_expected:
-            expected_messages.append(self.RESERVE_KEYEVENT_MESSAGE)
-            expected_messages.append(self.RESERVE_KEYSPACE_MESSAGE)
-        if add_expected:
-            expected_messages.append(self.ADD_KEYSPACE_MESSAGE)
-            expected_messages.append(self.ADD_KEYEVENT_MESSAGE)
-        return expected_messages
-
-    def check_response(self, result_messages, expected_messages):
-        extra_message = self.keyspace_client_subscribe.get_message()
-        if extra_message:
-            assert False, f"Unexpected extra message returned: {extra_message}"
-        for message in expected_messages:
-            assert message in result_messages, f"{message} was not found in messages received"
-
-    def get_subscribe_client_messages(self, client, cmd, expected_message_count):
-        client.execute_command(cmd)
-        count = 0
-        messages = []
-        timeout = time.time() + 5
-        while expected_message_count != count:
-            message = self.keyspace_client_subscribe.get_message()
-            if message:
-                # Only for the first time we get messages we should skip the first message gotten
-                if count > 0 or "BF.ADD" not in cmd:
-                    messages.append(message)    
-                count = count + 1
-            if timeout < time.time():
-                assert False, f"The number of expected messages failed to return in time, messages received so far {messages}"
-        return messages
-    
     def test_keyspace_bloom_commands(self):
         self.create_subscribe_clients()
-        # The first call to get messages will return message that shows we subscribed to messages so we expect one more message than we need to check for
-        # the first time we look at messages
+        # (command, events_expected, message_count). A BF.ADD/BF.MADD/BF.INSERT
+        # against a missing key both creates the filter (bloom.reserve) and adds
+        # items (bloom.add), so it emits both events.
         bloom_commands = [
-            ('BF.ADD add_test key', True, True, 5),
-            ('BF.MADD madd_test key1 key2', True, True, 4),
-            ('BF.EXISTS exists_test key', False, False, 0),
-            ('BF.INSERT insert_test ITEMS key1 key2', True, True, 4),
-            ('BF.RESERVE reserve_test 0.01 1000', True, False, 2)
+            ('BF.ADD add_test key', ['bloom.reserve', 'bloom.add'], 4),
+            ('BF.MADD madd_test key1 key2', ['bloom.reserve', 'bloom.add'], 4),
+            ('BF.EXISTS exists_test key', [], 0),
+            ('BF.INSERT insert_test ITEMS key1 key2', ['bloom.reserve', 'bloom.add'], 4),
+            ('BF.RESERVE reserve_test 0.01 1000', ['bloom.reserve'], 2),
         ]
 
-        for command, reserve_expected, add_expected, expected_message_count in bloom_commands:
-            expected_messages = self.create_expected_message_list(reserve_expected, add_expected, command.split()[1]) if reserve_expected else []
+        for command, events_expected, expected_message_count in bloom_commands:
+            key_name = command.split()[1]
+            expected_messages = []
+            for event in events_expected:
+                keyspace_message, keyevent_message = self.build_keyspace_event_messages(event, key_name)
+                expected_messages.extend([keyspace_message, keyevent_message])
             result_messages = self.get_subscribe_client_messages(self.keyspace_client, command, expected_message_count)
-            self.check_response(result_messages, expected_messages)
+            self.check_keyspace_response(result_messages, expected_messages)
 
-    def create_subscribe_clients(self):
-        self.keyspace_client = self.server.get_new_client()
-        self.keyspace_client_subscribe = self.keyspace_client.pubsub()
-        self.keyspace_client_subscribe.psubscribe('__key*__:*')
-        self.keyspace_client.execute_command('CONFIG' ,'SET','notify-keyspace-events', 'KEA')
-    
+        # test del
+        del_messages = self.get_subscribe_client_messages(self.keyspace_client, 'DEL add_test', 2)
+        self.check_keyspace_response(del_messages, list(self.build_keyspace_event_messages('del', 'add_test')))

--- a/tests/test_topk_acl_category.py
+++ b/tests/test_topk_acl_category.py
@@ -1,11 +1,10 @@
 from valkeytestframework.conftest import resource_port_tracker
 from valkey_bloom_test_case import ValkeyBloomTestCaseBase
-from valkeytestframework.util.waiters import *
 
 class TestTopkACLCategory(ValkeyBloomTestCaseBase):
 
     def test_topk_acl_category_permissions(self):
-        # List of topk commands and the expected returns if the command is valid
+        # List of topk commands and the expected returns if the command is valid.
         topk_commands = [
             ('TOPK.RESERVE reserve_key 50', b'OK'),
             ('TOPK.ADD reserve_key item', 1),
@@ -15,51 +14,18 @@ class TestTopkACLCategory(ValkeyBloomTestCaseBase):
             ('TOPK.LIST reserve_key', [b'item']),
             ('TOPK.INFO reserve_key', 8),
         ]
-        client = self.server.get_new_client()
-        # Get a list of all commands with the acl category topk
-        list_of_topk_commands = client.execute_command("COMMAND LIST FILTERBY ACLCAT topk")
-        # Create users with different acl permissions
-        client.execute_command("ACL SETUSER nontopkuser1 on >topk_pass -@topk")
-        client.execute_command("ACL SETUSER nontopkuser2 on >topk_pass -@all")
-        client.execute_command("ACL SETUSER topkuser1 on >topk_pass ~* &* +@all ")
-        client.execute_command("ACL SETUSER topkuser2 on >topk_pass ~* &* -@all +@topk ")
-        client.execute_command("ACL SETUSER topkuser3 on >topk_pass ~* &* -@all +@write +@read ")
-        client.execute_command("ACL SETUSER topkuser4 on >topk_pass ~* &* -@all +@write +@topk")
-        # Switch to the users with no topk command access and check error occurs as expected
-        for i in range(1, 3):
-            client.execute_command(f"AUTH nontopkuser{i} topk_pass")
-            for cmd in topk_commands:
-                self.verify_invalid_user_permissions(client, cmd, list_of_topk_commands)
-        # Switch to the users with topk command access and check commands are run as expected
-        for i in range(1, 5):
-            client.execute_command(f"AUTH topkuser{i} topk_pass")
-            for cmd in topk_commands:
-                self.verify_valid_user_permissions(client, cmd)
-            self.client.execute_command('FLUSHDB')
-            wait_for_equal(lambda: self.client.execute_command('DBSIZE'), 0)
+        self.run_acl_category_permissions_test("topk", topk_commands)
 
     def verify_valid_user_permissions(self, client, cmd):
         cmd_name = cmd[0].split()[0]
         try:
             result = client.execute_command(cmd[0])
-            # An integer expectation means the command returns an array whose
-            # length we check; anything else is compared exactly.
             if isinstance(cmd[1], int):
                 assert len(result) == cmd[1], f"{cmd_name} returned an unexpected number of results"
             else:
                 assert result == cmd[1], f"{cmd_name} should work for default user"
         except Exception as e:
             assert False, f"topkuser should be able to execute {cmd_name}: {str(e)}"
-
-    def verify_invalid_user_permissions(self, client, cmd, list_of_topk_commands):
-        cmd_name = cmd[0].split()[0]
-        # Check that each command we try to run appeared in the list of commands with the topk acl category
-        assert cmd_name.encode() in list_of_topk_commands
-        try:
-            result = client.execute_command(cmd[0])
-            assert False, f"User with no topk category access shouldnt be able to run {cmd_name}"
-        except Exception as e:
-            assert f"has no permissions to run the '{cmd_name}' command" in str(e)
 
     def test_topk_command_acl_categories(self):
         # List of topk commands and their acl categories
@@ -72,9 +38,4 @@ class TestTopkACLCategory(ValkeyBloomTestCaseBase):
             ('TOPK.COUNT', [b'readonly', b'module', b'fast'], [b'@read', b'@fast', b'@topk']),
             ('TOPK.QUERY', [b'readonly', b'module', b'fast'], [b'@read', b'@fast', b'@topk']),
         ]
-        for cmd in topk_commands:
-            # Get the info of the commands and compare the acl categories
-            cmd_info = self.client.execute_command(f'COMMAND INFO {cmd[0]}')
-            assert cmd_info[0][2] == cmd[1]
-            for category in cmd[2]:
-                assert category in cmd_info[0][6]
+        self.verify_command_acl_categories(topk_commands)

--- a/tests/test_topk_acl_category.py
+++ b/tests/test_topk_acl_category.py
@@ -1,5 +1,6 @@
 from valkeytestframework.conftest import resource_port_tracker
 from valkey_bloom_test_case import ValkeyBloomTestCaseBase
+from valkeytestframework.util.waiters import *
 
 class TestTopkACLCategory(ValkeyBloomTestCaseBase):
 
@@ -14,7 +15,28 @@ class TestTopkACLCategory(ValkeyBloomTestCaseBase):
             ('TOPK.LIST reserve_key', [b'item']),
             ('TOPK.INFO reserve_key', 8),
         ]
-        self.run_acl_category_permissions_test("topk", topk_commands)
+        client = self.server.get_new_client()
+        # Get a list of all commands with the acl category topk
+        list_of_topk_commands = client.execute_command("COMMAND LIST FILTERBY ACLCAT topk")
+        # Create users with different acl permissions
+        client.execute_command("ACL SETUSER nontopkuser1 on >topk_pass -@topk")
+        client.execute_command("ACL SETUSER nontopkuser2 on >topk_pass -@all")
+        client.execute_command("ACL SETUSER topkuser1 on >topk_pass ~* &* +@all ")
+        client.execute_command("ACL SETUSER topkuser2 on >topk_pass ~* &* -@all +@topk ")
+        client.execute_command("ACL SETUSER topkuser3 on >topk_pass ~* &* -@all +@write +@read ")
+        client.execute_command("ACL SETUSER topkuser4 on >topk_pass ~* &* -@all +@write +@topk")
+        # Switch to the users with no topk command access and check error occurs as expected
+        for i in range(1, 3):
+            client.execute_command(f"AUTH nontopkuser{i} topk_pass")
+            for cmd in topk_commands:
+                self.verify_invalid_user_permissions(client, cmd, list_of_topk_commands)
+        # Switch to the users with topk command access and check commands are run as expected
+        for i in range(1, 5):
+            client.execute_command(f"AUTH topkuser{i} topk_pass")
+            for cmd in topk_commands:
+                self.verify_valid_user_permissions(client, cmd)
+            self.client.execute_command('FLUSHDB')
+            wait_for_equal(lambda: self.client.execute_command('DBSIZE'), 0)
 
     def verify_valid_user_permissions(self, client, cmd):
         cmd_name = cmd[0].split()[0]

--- a/tests/test_topk_acl_category.py
+++ b/tests/test_topk_acl_category.py
@@ -1,0 +1,80 @@
+from valkeytestframework.conftest import resource_port_tracker
+from valkey_bloom_test_case import ValkeyBloomTestCaseBase
+from valkeytestframework.util.waiters import *
+
+class TestTopkACLCategory(ValkeyBloomTestCaseBase):
+
+    def test_topk_acl_category_permissions(self):
+        # List of topk commands and the expected returns if the command is valid
+        topk_commands = [
+            ('TOPK.RESERVE reserve_key 50', b'OK'),
+            ('TOPK.ADD reserve_key item', 1),
+            ('TOPK.INCRBY reserve_key item 5', 1),
+            ('TOPK.QUERY reserve_key item', [1]),
+            ('TOPK.COUNT reserve_key item', [6]),
+            ('TOPK.LIST reserve_key', [b'item']),
+            ('TOPK.INFO reserve_key', 8),
+        ]
+        client = self.server.get_new_client()
+        # Get a list of all commands with the acl category topk
+        list_of_topk_commands = client.execute_command("COMMAND LIST FILTERBY ACLCAT topk")
+        # Create users with different acl permissions
+        client.execute_command("ACL SETUSER nontopkuser1 on >topk_pass -@topk")
+        client.execute_command("ACL SETUSER nontopkuser2 on >topk_pass -@all")
+        client.execute_command("ACL SETUSER topkuser1 on >topk_pass ~* &* +@all ")
+        client.execute_command("ACL SETUSER topkuser2 on >topk_pass ~* &* -@all +@topk ")
+        client.execute_command("ACL SETUSER topkuser3 on >topk_pass ~* &* -@all +@write +@read ")
+        client.execute_command("ACL SETUSER topkuser4 on >topk_pass ~* &* -@all +@write +@topk")
+        # Switch to the users with no topk command access and check error occurs as expected
+        for i in range(1, 3):
+            client.execute_command(f"AUTH nontopkuser{i} topk_pass")
+            for cmd in topk_commands:
+                self.verify_invalid_user_permissions(client, cmd, list_of_topk_commands)
+        # Switch to the users with topk command access and check commands are run as expected
+        for i in range(1, 5):
+            client.execute_command(f"AUTH topkuser{i} topk_pass")
+            for cmd in topk_commands:
+                self.verify_valid_user_permissions(client, cmd)
+            self.client.execute_command('FLUSHDB')
+            wait_for_equal(lambda: self.client.execute_command('DBSIZE'), 0)
+
+    def verify_valid_user_permissions(self, client, cmd):
+        cmd_name = cmd[0].split()[0]
+        try:
+            result = client.execute_command(cmd[0])
+            # An integer expectation means the command returns an array whose
+            # length we check; anything else is compared exactly.
+            if isinstance(cmd[1], int):
+                assert len(result) == cmd[1], f"{cmd_name} returned an unexpected number of results"
+            else:
+                assert result == cmd[1], f"{cmd_name} should work for default user"
+        except Exception as e:
+            assert False, f"topkuser should be able to execute {cmd_name}: {str(e)}"
+
+    def verify_invalid_user_permissions(self, client, cmd, list_of_topk_commands):
+        cmd_name = cmd[0].split()[0]
+        # Check that each command we try to run appeared in the list of commands with the topk acl category
+        assert cmd_name.encode() in list_of_topk_commands
+        try:
+            result = client.execute_command(cmd[0])
+            assert False, f"User with no topk category access shouldnt be able to run {cmd_name}"
+        except Exception as e:
+            assert f"has no permissions to run the '{cmd_name}' command" in str(e)
+
+    def test_topk_command_acl_categories(self):
+        # List of topk commands and their acl categories
+        topk_commands = [
+            ('TOPK.RESERVE', [b'write', b'denyoom', b'module', b'fast'], [b'@write', b'@fast', b'@topk']),
+            ('TOPK.ADD', [b'write', b'denyoom', b'module', b'fast'], [b'@write', b'@fast', b'@topk']),
+            ('TOPK.INCRBY', [b'write', b'denyoom', b'module', b'fast'], [b'@write', b'@fast', b'@topk']),
+            ('TOPK.INFO', [b'readonly', b'module', b'fast'], [b'@read', b'@fast', b'@topk']),
+            ('TOPK.LIST', [b'readonly', b'module'], [b'@read', b'@topk']),
+            ('TOPK.COUNT', [b'readonly', b'module', b'fast'], [b'@read', b'@fast', b'@topk']),
+            ('TOPK.QUERY', [b'readonly', b'module', b'fast'], [b'@read', b'@fast', b'@topk']),
+        ]
+        for cmd in topk_commands:
+            # Get the info of the commands and compare the acl categories
+            cmd_info = self.client.execute_command(f'COMMAND INFO {cmd[0]}')
+            assert cmd_info[0][2] == cmd[1]
+            for category in cmd[2]:
+                assert category in cmd_info[0][6]

--- a/tests/test_topk_keyspace.py
+++ b/tests/test_topk_keyspace.py
@@ -1,0 +1,72 @@
+import time
+from valkey_bloom_test_case import ValkeyBloomTestCaseBase
+from valkeytestframework.conftest import resource_port_tracker
+
+class TestTopkKeyEventNotifications(ValkeyBloomTestCaseBase):
+    RESERVE_KEYSPACE_MESSAGE = {'type': 'pmessage', 'pattern': b'__key*__:*', 'channel': b'__keyspace@0__:intermediate_val', 'data': b'topk.reserve'}
+    RESERVE_KEYEVENT_MESSAGE = {'type': 'pmessage', 'pattern': b'__key*__:*', 'channel': b'__keyevent@0__:topk.reserve', 'data': b'intermediate_val'}
+    ADD_KEYSPACE_MESSAGE = {'type': 'pmessage', 'pattern': b'__key*__:*', 'channel': b'__keyspace@0__:intermediate_val', 'data': b'topk.add'}
+    ADD_KEYEVENT_MESSAGE = {'type': 'pmessage', 'pattern': b'__key*__:*', 'channel': b'__keyevent@0__:topk.add', 'data': b'intermediate_val'}
+
+    def create_expected_message_list(self, reserve_expected, add_expected, key_name):
+        expected_messages = []
+        self.RESERVE_KEYSPACE_MESSAGE['channel'] = f"__keyspace@0__:{key_name}".encode('utf-8')
+        self.RESERVE_KEYEVENT_MESSAGE['data'] = f"{key_name}".encode('utf-8')
+        self.ADD_KEYSPACE_MESSAGE['channel'] = f"__keyspace@0__:{key_name}".encode('utf-8')
+        self.ADD_KEYEVENT_MESSAGE['data'] = f"{key_name}".encode('utf-8')
+        if reserve_expected:
+            expected_messages.append(self.RESERVE_KEYEVENT_MESSAGE)
+            expected_messages.append(self.RESERVE_KEYSPACE_MESSAGE)
+        if add_expected:
+            expected_messages.append(self.ADD_KEYSPACE_MESSAGE)
+            expected_messages.append(self.ADD_KEYEVENT_MESSAGE)
+        return expected_messages
+
+    def check_response(self, result_messages, expected_messages):
+        extra_message = self.keyspace_client_subscribe.get_message()
+        if extra_message:
+            assert False, f"Unexpected extra message returned: {extra_message}"
+        for message in expected_messages:
+            assert message in result_messages, f"{message} was not found in messages received"
+
+    def get_subscribe_client_messages(self, client, cmd, expected_message_count):
+        client.execute_command(cmd)
+        count = 0
+        messages = []
+        timeout = time.time() + 5
+        while expected_message_count != count:
+            message = self.keyspace_client_subscribe.get_message()
+            if message:
+                if message.get('type') != 'pmessage':
+                    continue
+                messages.append(message)
+                count = count + 1
+            if timeout < time.time():
+                assert False, f"The number of expected messages failed to return in time, messages received so far {messages}"
+        return messages
+
+    def test_keyspace_topk_commands(self):
+        self.create_subscribe_clients()
+        topk_commands = [
+            ('TOPK.RESERVE add_test 3 50 4 0.9', True, False, 2),
+            ('TOPK.ADD add_test apple banana', False, True, 2),
+            ('TOPK.RESERVE incr_test 3 50 4 0.9', True, False, 2),
+            ('TOPK.INCRBY incr_test apple 5 banana 3', False, True, 2),
+            ('TOPK.QUERY add_test apple', False, False, 0)
+        ]
+
+        for command, reserve_expected, add_expected, expected_message_count in topk_commands:
+            expected_messages = self.create_expected_message_list(reserve_expected, add_expected, command.split()[1]) if reserve_expected or add_expected else []
+            result_messages = self.get_subscribe_client_messages(self.keyspace_client, command, expected_message_count)
+            self.check_response(result_messages, expected_messages)
+
+        # test del
+        del_messages = self.get_subscribe_client_messages(self.keyspace_client, 'DEL add_test', 2)
+        assert {'type': 'pmessage', 'pattern': b'__key*__:*', 'channel': b'__keyspace@0__:add_test', 'data': b'del'} in del_messages
+        assert {'type': 'pmessage', 'pattern': b'__key*__:*', 'channel': b'__keyevent@0__:del', 'data': b'add_test'} in del_messages
+
+    def create_subscribe_clients(self):
+        self.keyspace_client = self.server.get_new_client()
+        self.keyspace_client_subscribe = self.keyspace_client.pubsub()
+        self.keyspace_client_subscribe.psubscribe('__key*__:*')
+        self.keyspace_client.execute_command('CONFIG', 'SET', 'notify-keyspace-events', 'KEA')

--- a/tests/test_topk_keyspace.py
+++ b/tests/test_topk_keyspace.py
@@ -1,72 +1,31 @@
-import time
 from valkey_bloom_test_case import ValkeyBloomTestCaseBase
 from valkeytestframework.conftest import resource_port_tracker
 
 class TestTopkKeyEventNotifications(ValkeyBloomTestCaseBase):
-    RESERVE_KEYSPACE_MESSAGE = {'type': 'pmessage', 'pattern': b'__key*__:*', 'channel': b'__keyspace@0__:intermediate_val', 'data': b'topk.reserve'}
-    RESERVE_KEYEVENT_MESSAGE = {'type': 'pmessage', 'pattern': b'__key*__:*', 'channel': b'__keyevent@0__:topk.reserve', 'data': b'intermediate_val'}
-    ADD_KEYSPACE_MESSAGE = {'type': 'pmessage', 'pattern': b'__key*__:*', 'channel': b'__keyspace@0__:intermediate_val', 'data': b'topk.add'}
-    ADD_KEYEVENT_MESSAGE = {'type': 'pmessage', 'pattern': b'__key*__:*', 'channel': b'__keyevent@0__:topk.add', 'data': b'intermediate_val'}
-
-    def create_expected_message_list(self, reserve_expected, add_expected, key_name):
-        expected_messages = []
-        self.RESERVE_KEYSPACE_MESSAGE['channel'] = f"__keyspace@0__:{key_name}".encode('utf-8')
-        self.RESERVE_KEYEVENT_MESSAGE['data'] = f"{key_name}".encode('utf-8')
-        self.ADD_KEYSPACE_MESSAGE['channel'] = f"__keyspace@0__:{key_name}".encode('utf-8')
-        self.ADD_KEYEVENT_MESSAGE['data'] = f"{key_name}".encode('utf-8')
-        if reserve_expected:
-            expected_messages.append(self.RESERVE_KEYEVENT_MESSAGE)
-            expected_messages.append(self.RESERVE_KEYSPACE_MESSAGE)
-        if add_expected:
-            expected_messages.append(self.ADD_KEYSPACE_MESSAGE)
-            expected_messages.append(self.ADD_KEYEVENT_MESSAGE)
-        return expected_messages
-
-    def check_response(self, result_messages, expected_messages):
-        extra_message = self.keyspace_client_subscribe.get_message()
-        if extra_message:
-            assert False, f"Unexpected extra message returned: {extra_message}"
-        for message in expected_messages:
-            assert message in result_messages, f"{message} was not found in messages received"
-
-    def get_subscribe_client_messages(self, client, cmd, expected_message_count):
-        client.execute_command(cmd)
-        count = 0
-        messages = []
-        timeout = time.time() + 5
-        while expected_message_count != count:
-            message = self.keyspace_client_subscribe.get_message()
-            if message:
-                if message.get('type') != 'pmessage':
-                    continue
-                messages.append(message)
-                count = count + 1
-            if timeout < time.time():
-                assert False, f"The number of expected messages failed to return in time, messages received so far {messages}"
-        return messages
 
     def test_keyspace_topk_commands(self):
         self.create_subscribe_clients()
+        # (command, events_expected, message_count). TOPK.ADD and TOPK.INCRBY
+        # both publish topk.add; neither auto-creates the key, so each is
+        # preceded by its own TOPK.RESERVE. TOPK.QUERY stands in for the
+        # read-only commands, none of which notify.
         topk_commands = [
-            ('TOPK.RESERVE add_test 3 50 4 0.9', True, False, 2),
-            ('TOPK.ADD add_test apple banana', False, True, 2),
-            ('TOPK.RESERVE incr_test 3 50 4 0.9', True, False, 2),
-            ('TOPK.INCRBY incr_test apple 5 banana 3', False, True, 2),
-            ('TOPK.QUERY add_test apple', False, False, 0)
+            ('TOPK.RESERVE add_test 3 50 4 0.9', ['topk.reserve'], 2),
+            ('TOPK.ADD add_test apple banana', ['topk.add'], 2),
+            ('TOPK.RESERVE incr_test 3 50 4 0.9', ['topk.reserve'], 2),
+            ('TOPK.INCRBY incr_test apple 5 banana 3', ['topk.add'], 2),
+            ('TOPK.QUERY add_test apple', [], 0),
         ]
 
-        for command, reserve_expected, add_expected, expected_message_count in topk_commands:
-            expected_messages = self.create_expected_message_list(reserve_expected, add_expected, command.split()[1]) if reserve_expected or add_expected else []
+        for command, events_expected, expected_message_count in topk_commands:
+            key_name = command.split()[1]
+            expected_messages = []
+            for event in events_expected:
+                keyspace_message, keyevent_message = self.build_keyspace_event_messages(event, key_name)
+                expected_messages.extend([keyspace_message, keyevent_message])
             result_messages = self.get_subscribe_client_messages(self.keyspace_client, command, expected_message_count)
-            self.check_response(result_messages, expected_messages)
+            self.check_keyspace_response(result_messages, expected_messages)
 
         # test del
         del_messages = self.get_subscribe_client_messages(self.keyspace_client, 'DEL add_test', 2)
-        assert {'type': 'pmessage', 'pattern': b'__key*__:*', 'channel': b'__keyspace@0__:add_test', 'data': b'del'} in del_messages
-        assert {'type': 'pmessage', 'pattern': b'__key*__:*', 'channel': b'__keyevent@0__:del', 'data': b'add_test'} in del_messages
-
-    def create_subscribe_clients(self):
-        self.keyspace_client = self.server.get_new_client()
-        self.keyspace_client_subscribe = self.keyspace_client.pubsub()
-        self.keyspace_client_subscribe.psubscribe('__key*__:*')
-        self.keyspace_client.execute_command('CONFIG', 'SET', 'notify-keyspace-events', 'KEA')
+        self.check_keyspace_response(del_messages, list(self.build_keyspace_event_messages('del', 'add_test')))

--- a/tests/test_topk_keyspace.py
+++ b/tests/test_topk_keyspace.py
@@ -14,7 +14,11 @@ class TestTopkKeyEventNotifications(ValkeyBloomTestCaseBase):
             ('TOPK.ADD add_test apple banana', ['topk.add'], 2),
             ('TOPK.RESERVE incr_test 3 50 4 0.9', ['topk.reserve'], 2),
             ('TOPK.INCRBY incr_test apple 5 banana 3', ['topk.add'], 2),
+            # Read-only commands 
             ('TOPK.QUERY add_test apple', [], 0),
+            ('TOPK.COUNT add_test apple', [], 0),
+            ('TOPK.LIST add_test', [], 0),
+            ('TOPK.INFO add_test', [], 0),
         ]
 
         for command, events_expected, expected_message_count in topk_commands:

--- a/tests/valkey_bloom_test_case.py
+++ b/tests/valkey_bloom_test_case.py
@@ -308,3 +308,47 @@ class ValkeyBloomTestCaseBase(ValkeyTestCase):
             server.connect()
         
         return server.client
+    
+    # Keyspace notification helpers
+
+    def create_subscribe_clients(self):
+        """Create a client subscribed to all keyspace/keyevent channels and
+        enable keyspace notifications on the server."""
+        self.keyspace_client = self.server.get_new_client()
+        self.keyspace_client_subscribe = self.keyspace_client.pubsub()
+        self.keyspace_client_subscribe.psubscribe('__key*__:*')
+        self.keyspace_client.execute_command('CONFIG', 'SET', 'notify-keyspace-events', 'KEA')
+
+    def build_keyspace_event_messages(self, event, key_name):
+        """Return the (keyspace, keyevent) pmessage pair expected for a given
+        event name fired against key_name."""
+        keyspace_message = {'type': 'pmessage', 'pattern': b'__key*__:*', 'channel': f"__keyspace@0__:{key_name}".encode('utf-8'), 'data': event.encode('utf-8')}
+        keyevent_message = {'type': 'pmessage', 'pattern': b'__key*__:*', 'channel': f"__keyevent@0__:{event}".encode('utf-8'), 'data': f"{key_name}".encode('utf-8')}
+        return keyspace_message, keyevent_message
+
+    def get_subscribe_client_messages(self, client, cmd, expected_message_count):
+        """Run cmd and collect exactly expected_message_count keyspace
+        notifications, skipping the one-time psubscribe confirmation (only
+        real notifications have type 'pmessage')."""
+        client.execute_command(cmd)
+        messages = []
+        timeout = time.time() + 5
+        while len(messages) != expected_message_count:
+            message = self.keyspace_client_subscribe.get_message()
+            if message:
+                if message.get('type') != 'pmessage':
+                    continue
+                messages.append(message)
+            if timeout < time.time():
+                assert False, f"The number of expected messages failed to return in time, messages received so far {messages}"
+        return messages
+
+    def check_keyspace_response(self, result_messages, expected_messages):
+        """Assert no extra notifications are pending and every expected message
+        was received."""
+        extra_message = self.keyspace_client_subscribe.get_message()
+        if extra_message:
+            assert False, f"Unexpected extra message returned: {extra_message}"
+        for message in expected_messages:
+            assert message in result_messages, f"{message} was not found in messages received"
+

--- a/tests/valkey_bloom_test_case.py
+++ b/tests/valkey_bloom_test_case.py
@@ -7,6 +7,7 @@ import string
 import logging
 import subprocess
 import time
+from valkeytestframework.util.waiters import wait_for_equal
 
 class ValkeyBloomTestCaseBase(ValkeyTestCase):
 
@@ -351,4 +352,51 @@ class ValkeyBloomTestCaseBase(ValkeyTestCase):
             assert False, f"Unexpected extra message returned: {extra_message}"
         for message in expected_messages:
             assert message in result_messages, f"{message} was not found in messages received"
+
+    # ACL category helpers
+
+    def run_acl_category_permissions_test(self, category, commands):
+        """Create users with assorted grants for the given ACL category and
+        verify denied users are rejected while permitted users succeed."""
+        client = self.server.get_new_client()
+        list_of_commands = client.execute_command(f"COMMAND LIST FILTERBY ACLCAT {category}")
+        # Users without access to the category.
+        client.execute_command(f"ACL SETUSER non{category}user1 on >{category}_pass -@{category}")
+        client.execute_command(f"ACL SETUSER non{category}user2 on >{category}_pass -@all")
+        # Users with access via different grant combinations.
+        client.execute_command(f"ACL SETUSER {category}user1 on >{category}_pass ~* &* +@all ")
+        client.execute_command(f"ACL SETUSER {category}user2 on >{category}_pass ~* &* -@all +@{category} ")
+        client.execute_command(f"ACL SETUSER {category}user3 on >{category}_pass ~* &* -@all +@write +@read ")
+        client.execute_command(f"ACL SETUSER {category}user4 on >{category}_pass ~* &* -@all +@write +@{category}")
+        # Denied users cannot run any command in the category.
+        for i in range(1, 3):
+            client.execute_command(f"AUTH non{category}user{i} {category}_pass")
+            for cmd in commands:
+                self.verify_invalid_user_permissions(client, cmd, list_of_commands)
+        # Permitted users can run every command in the category.
+        for i in range(1, 5):
+            client.execute_command(f"AUTH {category}user{i} {category}_pass")
+            for cmd in commands:
+                self.verify_valid_user_permissions(client, cmd)
+            self.client.execute_command('FLUSHDB')
+            wait_for_equal(lambda: self.client.execute_command('DBSIZE'), 0)
+
+    def verify_invalid_user_permissions(self, client, cmd, list_of_commands):
+        cmd_name = cmd[0].split()[0]
+        # Each command under test should appear in the category's command list.
+        assert cmd_name.encode() in list_of_commands
+        try:
+            client.execute_command(cmd[0])
+            assert False, f"User with no category access shouldnt be able to run {cmd_name}"
+        except Exception as e:
+            assert f"has no permissions to run the '{cmd_name}' command" in str(e)
+
+    def verify_command_acl_categories(self, commands):
+        """Assert each command exposes the expected flags and ACL categories via
+        COMMAND INFO. Each entry is (command, expected_flags, expected_categories)."""
+        for cmd in commands:
+            cmd_info = self.client.execute_command(f'COMMAND INFO {cmd[0]}')
+            assert cmd_info[0][2] == cmd[1]
+            for category in cmd[2]:
+                assert category in cmd_info[0][6]
 

--- a/tests/valkey_bloom_test_case.py
+++ b/tests/valkey_bloom_test_case.py
@@ -7,7 +7,6 @@ import string
 import logging
 import subprocess
 import time
-from valkeytestframework.util.waiters import wait_for_equal
 
 class ValkeyBloomTestCaseBase(ValkeyTestCase):
 
@@ -354,32 +353,6 @@ class ValkeyBloomTestCaseBase(ValkeyTestCase):
             assert message in result_messages, f"{message} was not found in messages received"
 
     # ACL category helpers
-
-    def run_acl_category_permissions_test(self, category, commands):
-        """Create users with assorted grants for the given ACL category and
-        verify denied users are rejected while permitted users succeed."""
-        client = self.server.get_new_client()
-        list_of_commands = client.execute_command(f"COMMAND LIST FILTERBY ACLCAT {category}")
-        # Users without access to the category.
-        client.execute_command(f"ACL SETUSER non{category}user1 on >{category}_pass -@{category}")
-        client.execute_command(f"ACL SETUSER non{category}user2 on >{category}_pass -@all")
-        # Users with access via different grant combinations.
-        client.execute_command(f"ACL SETUSER {category}user1 on >{category}_pass ~* &* +@all ")
-        client.execute_command(f"ACL SETUSER {category}user2 on >{category}_pass ~* &* -@all +@{category} ")
-        client.execute_command(f"ACL SETUSER {category}user3 on >{category}_pass ~* &* -@all +@write +@read ")
-        client.execute_command(f"ACL SETUSER {category}user4 on >{category}_pass ~* &* -@all +@write +@{category}")
-        # Denied users cannot run any command in the category.
-        for i in range(1, 3):
-            client.execute_command(f"AUTH non{category}user{i} {category}_pass")
-            for cmd in commands:
-                self.verify_invalid_user_permissions(client, cmd, list_of_commands)
-        # Permitted users can run every command in the category.
-        for i in range(1, 5):
-            client.execute_command(f"AUTH {category}user{i} {category}_pass")
-            for cmd in commands:
-                self.verify_valid_user_permissions(client, cmd)
-            self.client.execute_command('FLUSHDB')
-            wait_for_equal(lambda: self.client.execute_command('DBSIZE'), 0)
 
     def verify_invalid_user_permissions(self, client, cmd, list_of_commands):
         cmd_name = cmd[0].split()[0]


### PR DESCRIPTION
## Summary

Adds integration test coverage for TopK keyspace notifications and ACL categories.

## Changes

### `tests/test_topk_keyspace.py` 
Modeled on `test_bloom_keyspace.py`. Verifies:
- `TOPK.RESERVE` emits `topk.reserve`.
- `TOPK.ADD` and `TOPK.INCRBY` both emit `topk.add` (one event per command, regardless of item count).
- Read-only commands (represented by `TOPK.QUERY`) emit no notification.
- `DEL` of a TopK key emits the native `del` keyspace event.

Unlike `BF.ADD`, TopK commands do not auto-create the key, so each mutative command is preceded by its own `TOPK.RESERVE`. The psubscribe confirmation is skipped by filtering on message `type == 'pmessage'` rather than matching on command name.

### `tests/test_topk_acl_category.py` 
Modeled on `test_bloom_acl_category.py`. Verifies:
- Users without `@topk` access (via `-@topk` / `-@all`) are denied every TopK command.
- Users granted access (`+@all`, `+@topk`, `+@write +@read`, `+@write +@topk`) can run them.
- Each command exposes the expected flags and ACL categories via `COMMAND INFO` (`TOPK.LIST` is `readonly` without `fast`; the rest carry`fast`, with write commands also `denyoom`).