### PR TITLE
Count min sketch Module Start - CMS.INITBYDIM & CMS.INITBYPROB

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ lazy_static = "1.4.0"
 libc = "0.2"
 serde = { version = "1.0", features = ["derive"] }
 bincode = "1.3"
+flowstats = { version = "0.1.2", features = ["frequency"]}
 
 [dev-dependencies]
 rand = "0.8"
@@ -39,4 +40,5 @@ default = ["min-valkey-compatibility-version-8-0"]
 enable-system-alloc = ["valkey-module/enable-system-alloc"]
 min-valkey-compatibility-version-8-0 = []
 valkey_8_0 = []  # Valkey-bloom is intended to be loaded on server versions >= Valkey 8.1 and by default it is built this way (unless this flag is provided). It is however compatible with Valkey version 8.0 if the user explicitly provides this feature flag in their cargo build command.
-use-redismodule-api = [] # We don't support this feature flag which is why it is empty. 
+use-redismodule-api = [] # We don't support this feature flag which is why it is empty.
+

--- a/src/cms/cms_command_handler.rs
+++ b/src/cms/cms_command_handler.rs
@@ -1,7 +1,58 @@
-use valkey_module::{Context, ValkeyError, ValkeyResult, ValkeyString, VALKEY_OK};
+use valkey_module::{Context, NotifyEvent, ValkeyError, ValkeyResult, ValkeyString, VALKEY_OK};
 
 use crate::cms::data_type::CMS_TYPE;
 use crate::cms::utils::{self, CMSObject};
+
+struct ReplicateArgs {
+    seed: [u8; 32],
+    args: Replications,
+}
+
+enum Replications {
+    ReplicateArgsDim { width: u64, depth: u64 },
+    ReplicateArgsProb { error: f64 },
+}
+
+fn replicate_and_notify_events(
+    ctx: &Context,
+    key_name: &ValkeyString,
+    init_operation: bool,
+    incr_operation: bool,
+    args: ReplicateArgs,
+) {
+    if init_operation {
+        let seed_str = ValkeyString::create_from_slice(std::ptr::null_mut(), "SEED".as_bytes());
+        let seed_val = ValkeyString::create_from_slice(std::ptr::null_mut(), &args.seed);
+
+        match args.args {
+            Replications::ReplicateArgsDim { width, depth } => {
+                let width_val = ValkeyString::create_from_slice(
+                    std::ptr::null_mut(),
+                    width.to_string().as_bytes(),
+                );
+                let depth_val = ValkeyString::create_from_slice(
+                    std::ptr::null_mut(),
+                    depth.to_string().as_bytes(),
+                );
+                let cmd = vec![&width_val, &depth_val, &seed_str, &seed_val];
+                ctx.replicate("CMS.INITBYDIM", cmd.as_slice());
+                ctx.notify_keyspace_event(NotifyEvent::GENERIC, utils::INITBYDIM_EVENT, key_name);
+            }
+            Replications::ReplicateArgsProb { error } => {
+                let error_val = ValkeyString::create_from_slice(
+                    std::ptr::null_mut(),
+                    error.to_string().as_bytes(),
+                );
+                let cmd = vec![&error_val, &seed_str, &seed_val];
+                ctx.replicate("CMS.INITBYPROB", cmd.as_slice());
+                ctx.notify_keyspace_event(NotifyEvent::GENERIC, utils::INITBYPROB_EVENT, key_name);
+            }
+        }
+    } else if incr_operation {
+        ctx.replicate_verbatim();
+        ctx.notify_keyspace_event(NotifyEvent::GENERIC, utils::INCR_EVENT, key_name);
+    }
+}
 
 /// Function that implements logic to handle the CMS.INITBYDIM command.
 pub fn cms_initialize_by_dimensions(ctx: &Context, args: Vec<ValkeyString>) -> ValkeyResult {
@@ -40,7 +91,14 @@ pub fn cms_initialize_by_dimensions(ctx: &Context, args: Vec<ValkeyString>) -> V
 
             match filter_key.set_value(&CMS_TYPE, cms) {
                 Ok(()) => {
-                    //replicate_and_notify_events(ctx, filter_name, false, true, replicate_args);
+                    //TEMP REMOVE AFTER DOING SEED CONFIGURATION
+                    let seed = [0u8; 32];
+                    let r = Replications::ReplicateArgsDim { width, depth };
+                    let replicate_args = ReplicateArgs {
+                        seed,
+                        args: r,
+                    };
+                    replicate_and_notify_events(ctx, key, true, false, replicate_args);
                     VALKEY_OK
                 }
                 Err(_) => Err(ValkeyError::Str(utils::ERROR)),
@@ -91,7 +149,14 @@ pub fn cms_initialize_by_probability(ctx: &Context, args: Vec<ValkeyString>) -> 
             //TODO: Replication Args need done still
             match filter_key.set_value(&CMS_TYPE, cms) {
                 Ok(()) => {
-                    //replicate_and_notify_events(ctx, filter_name, false, true, replicate_args);
+                    //TEMP REMOVE AFTER DOING SEED CONFIGURATION
+                    let seed = [0u8; 32];
+                    let r = Replications::ReplicateArgsProb { error: error_rate };
+                    let replicate_args = ReplicateArgs {
+                        seed,
+                        args: r,
+                    };
+                    replicate_and_notify_events(ctx, key, true, false, replicate_args);
                     VALKEY_OK
                 }
                 Err(_) => Err(ValkeyError::Str(utils::ERROR)),

--- a/src/cms/cms_command_handler.rs
+++ b/src/cms/cms_command_handler.rs
@@ -3,29 +3,24 @@ use valkey_module::{Context, NotifyEvent, ValkeyError, ValkeyResult, ValkeyStrin
 use crate::cms::data_type::CMS_TYPE;
 use crate::cms::utils::{self, CMSObject};
 
-struct ReplicateArgs {
-    //seed: [u8; 32],
-    args: Replications,
-}
-
 enum Replications {
     ReplicateArgsDim { width: u64, depth: u64 },
     ReplicateArgsProb { error_rate: f64, fp_rate: f64 },
 }
 
+enum Operation {
+    Initialization {},
+    Increment {},
+}
+
 fn replicate_and_notify_events(
     ctx: &Context,
     key_name: &ValkeyString,
-    init_operation: bool,
-    incr_operation: bool,
-    args: ReplicateArgs,
+    operation: Operation,
+    args: Replications,
 ) {
-    if init_operation {
-        //For later when we need seeding discussions (cms.merge)
-        // let seed_str = ValkeyString::create_from_slice(std::ptr::null_mut(), "SEED".as_bytes());
-        // let seed_val = ValkeyString::create_from_slice(std::ptr::null_mut(), &args.seed);
-
-        match args.args {
+    match operation {
+        Operation::Initialization {} => match args {
             Replications::ReplicateArgsDim { width, depth } => {
                 let width_val = ValkeyString::create_from_slice(
                     std::ptr::null_mut(),
@@ -55,10 +50,11 @@ fn replicate_and_notify_events(
                 ctx.replicate("CMS.INITBYPROB", cmd.as_slice());
                 ctx.notify_keyspace_event(NotifyEvent::GENERIC, utils::INITBYPROB_EVENT, key_name);
             }
+        },
+        Operation::Increment {} => {
+            ctx.replicate_verbatim();
+            ctx.notify_keyspace_event(NotifyEvent::GENERIC, utils::INCR_EVENT, key_name);
         }
-    } else if incr_operation {
-        ctx.replicate_verbatim();
-        ctx.notify_keyspace_event(NotifyEvent::GENERIC, utils::INCR_EVENT, key_name);
     }
 }
 
@@ -97,9 +93,13 @@ pub fn cms_initialize_by_dimensions(ctx: &Context, args: Vec<ValkeyString>) -> V
 
             match filter_key.set_value(&CMS_TYPE, cms) {
                 Ok(()) => {
-                    let r = Replications::ReplicateArgsDim { width, depth };
-                    let replicate_args = ReplicateArgs { args: r };
-                    replicate_and_notify_events(ctx, key, true, false, replicate_args);
+                    let replications = Replications::ReplicateArgsDim { width, depth };
+                    replicate_and_notify_events(
+                        ctx,
+                        key,
+                        Operation::Initialization {},
+                        replications,
+                    );
                     VALKEY_OK
                 }
                 Err(_) => Err(ValkeyError::Str(utils::ERROR)),
@@ -149,12 +149,17 @@ pub fn cms_initialize_by_probability(ctx: &Context, args: Vec<ValkeyString>) -> 
 
             match filter_key.set_value(&CMS_TYPE, cms) {
                 Ok(()) => {
-                    let r = Replications::ReplicateArgsProb {
+                    let replications = Replications::ReplicateArgsProb {
                         error_rate,
                         fp_rate,
                     };
-                    let replicate_args = ReplicateArgs { args: r };
-                    replicate_and_notify_events(ctx, key, true, false, replicate_args);
+
+                    replicate_and_notify_events(
+                        ctx,
+                        key,
+                        Operation::Initialization {},
+                        replications,
+                    );
                     VALKEY_OK
                 }
                 Err(_) => Err(ValkeyError::Str(utils::ERROR)),

--- a/src/cms/cms_command_handler.rs
+++ b/src/cms/cms_command_handler.rs
@@ -9,8 +9,8 @@ enum Replications {
 }
 
 enum Operation {
-    Initialization {},
-    Increment {},
+    Initialization,
+    Increment,
 }
 
 fn replicate_and_notify_events(
@@ -20,7 +20,7 @@ fn replicate_and_notify_events(
     args: Replications,
 ) {
     match operation {
-        Operation::Initialization {} => match args {
+        Operation::Initialization => match args {
             Replications::ReplicateArgsDim { width, depth } => {
                 let width_val = ValkeyString::create_from_slice(
                     std::ptr::null_mut(),
@@ -51,7 +51,7 @@ fn replicate_and_notify_events(
                 ctx.notify_keyspace_event(NotifyEvent::GENERIC, utils::INITBYPROB_EVENT, key_name);
             }
         },
-        Operation::Increment {} => {
+        Operation::Increment => {
             ctx.replicate_verbatim();
             ctx.notify_keyspace_event(NotifyEvent::GENERIC, utils::INCR_EVENT, key_name);
         }
@@ -94,12 +94,7 @@ pub fn cms_initialize_by_dimensions(ctx: &Context, args: Vec<ValkeyString>) -> V
             match filter_key.set_value(&CMS_TYPE, cms) {
                 Ok(()) => {
                     let replications = Replications::ReplicateArgsDim { width, depth };
-                    replicate_and_notify_events(
-                        ctx,
-                        key,
-                        Operation::Initialization {},
-                        replications,
-                    );
+                    replicate_and_notify_events(ctx, key, Operation::Initialization, replications);
                     VALKEY_OK
                 }
                 Err(_) => Err(ValkeyError::Str(utils::ERROR)),
@@ -154,12 +149,7 @@ pub fn cms_initialize_by_probability(ctx: &Context, args: Vec<ValkeyString>) -> 
                         fp_rate,
                     };
 
-                    replicate_and_notify_events(
-                        ctx,
-                        key,
-                        Operation::Initialization {},
-                        replications,
-                    );
+                    replicate_and_notify_events(ctx, key, Operation::Initialization, replications);
                     VALKEY_OK
                 }
                 Err(_) => Err(ValkeyError::Str(utils::ERROR)),

--- a/src/cms/cms_command_handler.rs
+++ b/src/cms/cms_command_handler.rs
@@ -1,0 +1,101 @@
+use valkey_module::{Context, ValkeyError, ValkeyResult, ValkeyString, VALKEY_OK};
+
+use crate::cms::data_type::CMS_TYPE;
+use crate::cms::utils::{self, CMSObject};
+
+/// Function that implements logic to handle the CMS.INITBYDIM command.
+pub fn cms_initialize_by_dimensions(ctx: &Context, args: Vec<ValkeyString>) -> ValkeyResult {
+    let args_count = args.len();
+    if args_count != 4 {
+        return Err(valkey_module::ValkeyError::WrongArity);
+    }
+
+    let key = &args[1];
+
+    let width = match args[2].to_string_lossy().parse::<u64>() {
+        Ok(w) if w > 0 => w,
+        _ => return Err(ValkeyError::Str(utils::BAD_WIDTH)),
+    };
+
+    let depth = match args[3].to_string_lossy().parse::<u64>() {
+        Ok(d) if d > 0 => d,
+        _ => return Err(ValkeyError::Str(utils::BAD_DEPTH)),
+    };
+
+    let filter_key = ctx.open_key_writable(key);
+    let cms = match filter_key.get_value::<CMSObject>(&CMS_TYPE) {
+        Ok(v) => v,
+        Err(_) => return Err(ValkeyError::WrongType),
+    };
+
+    match cms {
+        Some(_) => Err(ValkeyError::Str(utils::ITEM_EXISTS)),
+        None => {
+            let cms = match utils::CMSObject::new_by_dimension(width, depth) {
+                Ok(v) => v,
+                Err(err) => return Err(ValkeyError::Str(err.as_str())),
+            };
+
+            //TODO: Replication Args need done still
+
+            match filter_key.set_value(&CMS_TYPE, cms) {
+                Ok(()) => {
+                    //replicate_and_notify_events(ctx, filter_name, false, true, replicate_args);
+                    VALKEY_OK
+                }
+                Err(_) => Err(ValkeyError::Str(utils::ERROR)),
+            }
+        }
+    }
+}
+
+/// Function that implements logic to handle the CMS.INITBYPROB command.
+pub fn cms_initialize_by_probability(ctx: &Context, args: Vec<ValkeyString>) -> ValkeyResult {
+    let args_count = args.len();
+    if args_count != 4 {
+        return Err(ValkeyError::WrongArity);
+    }
+
+    let key = &args[1];
+
+    // Maximum allowable error rate.  Epsilon
+    // For an epsilon of 1% and a estimated count of 1000 the actual could be between 990 and 1010
+    let error_rate = match args[2].to_string_lossy().parse::<f64>() {
+        Ok(e) if e > 0.0 && e < 1.0 => e,
+        Ok(_) => return Err(ValkeyError::Str(utils::ERROR_RATE_RANGE)),
+        Err(_) => return Err(ValkeyError::Str(utils::BAD_ERROR_RATE)),
+    };
+
+    //False positive rate. Delta
+    // A delta of 1% means the count will be outside of the epsilon range 1% of the time.
+    let probability = match args[3].to_string_lossy().parse::<f64>() {
+        Ok(p) if p > 0.0 && p < 1.0 => p,
+        Ok(_) => return Err(ValkeyError::Str(utils::PROBABILITY_RANGE)),
+        Err(_) => return Err(ValkeyError::Str(utils::BAD_PROBABILITY)),
+    };
+
+    let filter_key = ctx.open_key_writable(key);
+    let cms = match filter_key.get_value::<CMSObject>(&CMS_TYPE) {
+        Ok(v) => v,
+        Err(_) => return Err(ValkeyError::WrongType),
+    };
+
+    match cms {
+        Some(_) => Err(ValkeyError::Str(utils::ITEM_EXISTS)),
+        None => {
+            let cms = match utils::CMSObject::new_by_probability(error_rate, probability) {
+                Ok(v) => v,
+                Err(err) => return Err(ValkeyError::Str(err.as_str())),
+            };
+
+            //TODO: Replication Args need done still
+            match filter_key.set_value(&CMS_TYPE, cms) {
+                Ok(()) => {
+                    //replicate_and_notify_events(ctx, filter_name, false, true, replicate_args);
+                    VALKEY_OK
+                }
+                Err(_) => Err(ValkeyError::Str(utils::ERROR)),
+            }
+        }
+    }
+}

--- a/src/cms/cms_command_handler.rs
+++ b/src/cms/cms_command_handler.rs
@@ -30,7 +30,7 @@ fn replicate_and_notify_events(
                     std::ptr::null_mut(),
                     depth.to_string().as_bytes(),
                 );
-                let cmd = vec![&width_val, &depth_val];
+                let cmd = vec![&key_name, &width_val, &depth_val];
                 ctx.replicate("CMS.INITBYDIM", cmd.as_slice());
                 ctx.notify_keyspace_event(NotifyEvent::GENERIC, utils::INITBYDIM_EVENT, key_name);
             }
@@ -46,7 +46,7 @@ fn replicate_and_notify_events(
                     std::ptr::null_mut(),
                     fp_rate.to_string().as_bytes(),
                 );
-                let cmd = vec![&error_val, &fp_val];
+                let cmd = vec![&key_name, &error_val, &fp_val];
                 ctx.replicate("CMS.INITBYPROB", cmd.as_slice());
                 ctx.notify_keyspace_event(NotifyEvent::GENERIC, utils::INITBYPROB_EVENT, key_name);
             }

--- a/src/cms/cms_command_handler.rs
+++ b/src/cms/cms_command_handler.rs
@@ -4,13 +4,13 @@ use crate::cms::data_type::CMS_TYPE;
 use crate::cms::utils::{self, CMSObject};
 
 struct ReplicateArgs {
-    seed: [u8; 32],
+    //seed: [u8; 32],
     args: Replications,
 }
 
 enum Replications {
     ReplicateArgsDim { width: u64, depth: u64 },
-    ReplicateArgsProb { error: f64 },
+    ReplicateArgsProb { error_rate: f64, fp_rate: f64 },
 }
 
 fn replicate_and_notify_events(
@@ -21,8 +21,9 @@ fn replicate_and_notify_events(
     args: ReplicateArgs,
 ) {
     if init_operation {
-        let seed_str = ValkeyString::create_from_slice(std::ptr::null_mut(), "SEED".as_bytes());
-        let seed_val = ValkeyString::create_from_slice(std::ptr::null_mut(), &args.seed);
+        //For later when we need seeding discussions (cms.merge)
+        // let seed_str = ValkeyString::create_from_slice(std::ptr::null_mut(), "SEED".as_bytes());
+        // let seed_val = ValkeyString::create_from_slice(std::ptr::null_mut(), &args.seed);
 
         match args.args {
             Replications::ReplicateArgsDim { width, depth } => {
@@ -34,16 +35,23 @@ fn replicate_and_notify_events(
                     std::ptr::null_mut(),
                     depth.to_string().as_bytes(),
                 );
-                let cmd = vec![&width_val, &depth_val, &seed_str, &seed_val];
+                let cmd = vec![&width_val, &depth_val];
                 ctx.replicate("CMS.INITBYDIM", cmd.as_slice());
                 ctx.notify_keyspace_event(NotifyEvent::GENERIC, utils::INITBYDIM_EVENT, key_name);
             }
-            Replications::ReplicateArgsProb { error } => {
+            Replications::ReplicateArgsProb {
+                error_rate,
+                fp_rate,
+            } => {
                 let error_val = ValkeyString::create_from_slice(
                     std::ptr::null_mut(),
-                    error.to_string().as_bytes(),
+                    error_rate.to_string().as_bytes(),
                 );
-                let cmd = vec![&error_val, &seed_str, &seed_val];
+                let fp_val = ValkeyString::create_from_slice(
+                    std::ptr::null_mut(),
+                    fp_rate.to_string().as_bytes(),
+                );
+                let cmd = vec![&error_val, &fp_val];
                 ctx.replicate("CMS.INITBYPROB", cmd.as_slice());
                 ctx.notify_keyspace_event(NotifyEvent::GENERIC, utils::INITBYPROB_EVENT, key_name);
             }
@@ -87,14 +95,10 @@ pub fn cms_initialize_by_dimensions(ctx: &Context, args: Vec<ValkeyString>) -> V
                 Err(err) => return Err(ValkeyError::Str(err.as_str())),
             };
 
-            //TODO: Replication Args need done still
-
             match filter_key.set_value(&CMS_TYPE, cms) {
                 Ok(()) => {
-                    //TEMP REMOVE AFTER DOING SEED CONFIGURATION
-                    let seed = [0u8; 32];
                     let r = Replications::ReplicateArgsDim { width, depth };
-                    let replicate_args = ReplicateArgs { seed, args: r };
+                    let replicate_args = ReplicateArgs { args: r };
                     replicate_and_notify_events(ctx, key, true, false, replicate_args);
                     VALKEY_OK
                 }
@@ -123,7 +127,7 @@ pub fn cms_initialize_by_probability(ctx: &Context, args: Vec<ValkeyString>) -> 
 
     //False positive rate. Delta
     // A delta of 1% means the count will be outside of the epsilon range 1% of the time.
-    let probability = match args[3].to_string_lossy().parse::<f64>() {
+    let fp_rate = match args[3].to_string_lossy().parse::<f64>() {
         Ok(p) if p > 0.0 && p < 1.0 => p,
         Ok(_) => return Err(ValkeyError::Str(utils::PROBABILITY_RANGE)),
         Err(_) => return Err(ValkeyError::Str(utils::BAD_PROBABILITY)),
@@ -138,18 +142,18 @@ pub fn cms_initialize_by_probability(ctx: &Context, args: Vec<ValkeyString>) -> 
     match cms {
         Some(_) => Err(ValkeyError::Str(utils::ITEM_EXISTS)),
         None => {
-            let cms = match utils::CMSObject::new_by_probability(error_rate, probability) {
+            let cms = match utils::CMSObject::new_by_probability(error_rate, fp_rate) {
                 Ok(v) => v,
                 Err(err) => return Err(ValkeyError::Str(err.as_str())),
             };
 
-            //TODO: Replication Args need done still
             match filter_key.set_value(&CMS_TYPE, cms) {
                 Ok(()) => {
-                    //TEMP REMOVE AFTER DOING SEED CONFIGURATION
-                    let seed = [0u8; 32];
-                    let r = Replications::ReplicateArgsProb { error: error_rate };
-                    let replicate_args = ReplicateArgs { seed, args: r };
+                    let r = Replications::ReplicateArgsProb {
+                        error_rate,
+                        fp_rate,
+                    };
+                    let replicate_args = ReplicateArgs { args: r };
                     replicate_and_notify_events(ctx, key, true, false, replicate_args);
                     VALKEY_OK
                 }

--- a/src/cms/cms_command_handler.rs
+++ b/src/cms/cms_command_handler.rs
@@ -94,10 +94,7 @@ pub fn cms_initialize_by_dimensions(ctx: &Context, args: Vec<ValkeyString>) -> V
                     //TEMP REMOVE AFTER DOING SEED CONFIGURATION
                     let seed = [0u8; 32];
                     let r = Replications::ReplicateArgsDim { width, depth };
-                    let replicate_args = ReplicateArgs {
-                        seed,
-                        args: r,
-                    };
+                    let replicate_args = ReplicateArgs { seed, args: r };
                     replicate_and_notify_events(ctx, key, true, false, replicate_args);
                     VALKEY_OK
                 }
@@ -152,10 +149,7 @@ pub fn cms_initialize_by_probability(ctx: &Context, args: Vec<ValkeyString>) -> 
                     //TEMP REMOVE AFTER DOING SEED CONFIGURATION
                     let seed = [0u8; 32];
                     let r = Replications::ReplicateArgsProb { error: error_rate };
-                    let replicate_args = ReplicateArgs {
-                        seed,
-                        args: r,
-                    };
+                    let replicate_args = ReplicateArgs { seed, args: r };
                     replicate_and_notify_events(ctx, key, true, false, replicate_args);
                     VALKEY_OK
                 }

--- a/src/cms/data_type.rs
+++ b/src/cms/data_type.rs
@@ -1,0 +1,36 @@
+use valkey_module::native_types::ValkeyType;
+use valkey_module::raw;
+
+const CMS_TYPE_ENCODING_VERSION: i32 = 1;
+
+//Note this is mocked out for now.
+pub static CMS_TYPE: ValkeyType = ValkeyType::new(
+    "cntmnskch",
+    CMS_TYPE_ENCODING_VERSION,
+    raw::RedisModuleTypeMethods {
+        version: raw::REDISMODULE_TYPE_METHOD_VERSION as u64,
+        rdb_load: None,
+        rdb_save: None,
+        aof_rewrite: None,
+        digest: None,
+
+        mem_usage: None,
+        free: None,
+
+        aux_load: None,
+
+        aux_save: None,
+        aux_save2: None,
+        aux_save_triggers: raw::Aux::Before as i32,
+
+        free_effort: None,
+        unlink: None,
+        copy: None,
+        defrag: None,
+
+        mem_usage2: None,
+        free_effort2: None,
+        unlink2: None,
+        copy2: None,
+    },
+);

--- a/src/cms/mod.rs
+++ b/src/cms/mod.rs
@@ -1,0 +1,3 @@
+pub mod cms_command_handler;
+pub mod data_type;
+pub mod utils;

--- a/src/cms/utils.rs
+++ b/src/cms/utils.rs
@@ -14,6 +14,11 @@ pub const KEY_EXISTS: &str = "ERR Target key name already exists.";
 pub const BAD_INCREMENT: &str = "ERR bad increment";
 pub const INCREMENT_MUST_BE_POSITIVE: &str = "ERR increment must be positive";
 
+///Keyspace Notification Events
+pub const INITBYPROB_EVENT: &str = "countminsketch.initbyprob";
+pub const INITBYDIM_EVENT: &str = "countminsketch.initbydim";
+pub const INCR_EVENT: &str = "countminsketch.incrby";
+
 #[derive(Debug, PartialEq)]
 pub enum CMSError {
     InvalidWidth,
@@ -101,7 +106,6 @@ impl CMSObject {
     pub fn total(&self) -> u64 {
         self.total
     }
-
 }
 
 struct CMS {

--- a/src/cms/utils.rs
+++ b/src/cms/utils.rs
@@ -1,0 +1,124 @@
+use flowstats::CountMinSketch;
+
+/// Client Errors
+pub const ERROR: &str = "ERROR";
+pub const NOT_FOUND: &str = "ERR not found";
+pub const ITEM_EXISTS: &str = "ERR item exists";
+pub const BAD_WIDTH: &str = "ERR bad width";
+pub const BAD_DEPTH: &str = "ERR bad depth";
+pub const BAD_ERROR_RATE: &str = "ERR bad error rate";
+pub const ERROR_RATE_RANGE: &str = "ERR error rate should be between 0 and 1";
+pub const BAD_PROBABILITY: &str = "ERR bad probability";
+pub const PROBABILITY_RANGE: &str = "ERR probability rate should be between 0 and 1";
+pub const KEY_EXISTS: &str = "ERR Target key name already exists.";
+pub const BAD_INCREMENT: &str = "ERR bad increment";
+pub const INCREMENT_MUST_BE_POSITIVE: &str = "ERR increment must be positive";
+
+#[derive(Debug, PartialEq)]
+pub enum CMSError {
+    InvalidWidth,
+    InvalidDepth,
+    InvalidErrorRate,
+    InvalidProbability,
+}
+
+impl CMSError {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            CMSError::InvalidWidth => BAD_WIDTH,
+            CMSError::InvalidDepth => BAD_DEPTH,
+            CMSError::InvalidErrorRate => ERROR_RATE_RANGE,
+            CMSError::InvalidProbability => PROBABILITY_RANGE,
+        }
+    }
+}
+
+pub struct CMSObject {
+    width: u64,
+    depth: u64,
+    total: u64,
+    cms: CMS,
+}
+
+impl CMSObject {
+    pub fn new_by_dimension(width: u64, depth: u64) -> Result<CMSObject, CMSError> {
+        if width == 0 {
+            return Err(CMSError::InvalidWidth);
+        }
+
+        if depth == 0 {
+            return Err(CMSError::InvalidDepth);
+        }
+
+        let cms = CMS::new_by_dimensions(width as usize, depth as usize)?;
+        let obj = CMSObject {
+            width,
+            depth,
+            total: 0,
+            cms,
+        };
+
+        Ok(obj)
+    }
+
+    //Error_tolerance is max variance of the count
+    // probability is the false positive rate
+    pub fn new_by_probability(
+        error_tolerance: f64,
+        probability: f64,
+    ) -> Result<CMSObject, CMSError> {
+        if error_tolerance <= 0.0 || error_tolerance >= 1.0 {
+            return Err(CMSError::InvalidErrorRate);
+        }
+        if probability <= 0.0 || probability >= 1.0 {
+            return Err(CMSError::InvalidProbability);
+        }
+
+        // width = ceil(e / error)
+        let width = (std::f64::consts::E / error_tolerance).ceil() as u64;
+        // depth = ceil(ln(1 / probability_confidence))
+        let depth = (1.0_f64 / probability).ln().ceil() as u64;
+
+        let cms = CMS::new_by_probability(error_tolerance, probability)?;
+        let obj = CMSObject {
+            width,
+            depth,
+            total: 0,
+            cms,
+        };
+
+        Ok(obj)
+    }
+
+    pub fn width(&self) -> u64 {
+        self.width
+    }
+
+    pub fn depth(&self) -> u64 {
+        self.depth
+    }
+
+    pub fn total(&self) -> u64 {
+        self.total
+    }
+
+}
+
+struct CMS {
+    sketch: CountMinSketch,
+}
+
+impl CMS {
+    pub fn new_by_probability(epsilon: f64, probability: f64) -> Result<CMS, CMSError> {
+        // flowstats::CountMinSketch::new(epsilon, delta)
+        // epsilon: Maximum overcount as a fraction of total (e.g., 0.01 for 1%)
+        // delta (probability): Probability of exceeding the error bound (e.g., 0.001 for 0.1%)
+        let cms = CountMinSketch::new(epsilon, probability);
+        Ok(CMS { sketch: cms })
+    }
+
+    pub fn new_by_dimensions(width: usize, depth: usize) -> Result<CMS, CMSError> {
+        let cms = CountMinSketch::with_dimensions(width, depth);
+        Ok(CMS { sketch: cms })
+    }
+}

--- a/src/cms/utils.rs
+++ b/src/cms/utils.rs
@@ -11,13 +11,10 @@ pub const ERROR_RATE_RANGE: &str = "ERR error rate should be between 0 and 1";
 pub const BAD_PROBABILITY: &str = "ERR bad probability";
 pub const PROBABILITY_RANGE: &str = "ERR probability rate should be between 0 and 1";
 pub const KEY_EXISTS: &str = "ERR Target key name already exists.";
-pub const BAD_INCREMENT: &str = "ERR bad increment";
-pub const INCREMENT_MUST_BE_POSITIVE: &str = "ERR increment must be positive";
 
 ///Keyspace Notification Events
 pub const INITBYPROB_EVENT: &str = "countminsketch.initbyprob";
 pub const INITBYDIM_EVENT: &str = "countminsketch.initbydim";
-pub const INCR_EVENT: &str = "countminsketch.incrby";
 
 #[derive(Debug, PartialEq)]
 pub enum CMSError {

--- a/src/cms/utils.rs
+++ b/src/cms/utils.rs
@@ -44,6 +44,7 @@ pub struct CMSObject {
 }
 
 impl CMSObject {
+    //TODO: Are there any MAX ranges that we should have for configuration?
     pub fn new_by_dimension(width: u64, depth: u64) -> Result<CMSObject, CMSError> {
         if width < 1 {
             return Err(CMSError::InvalidWidth);

--- a/src/cms/utils.rs
+++ b/src/cms/utils.rs
@@ -47,11 +47,11 @@ pub struct CMSObject {
 
 impl CMSObject {
     pub fn new_by_dimension(width: u64, depth: u64) -> Result<CMSObject, CMSError> {
-        if width == 0 {
+        if width < 1 {
             return Err(CMSError::InvalidWidth);
         }
 
-        if depth == 0 {
+        if depth < 1 {
             return Err(CMSError::InvalidDepth);
         }
 
@@ -79,15 +79,10 @@ impl CMSObject {
             return Err(CMSError::InvalidProbability);
         }
 
-        // width = ceil(e / error)
-        let width = (std::f64::consts::E / error_tolerance).ceil() as u64;
-        // depth = ceil(ln(1 / probability_confidence))
-        let depth = (1.0_f64 / probability).ln().ceil() as u64;
-
         let cms = CMS::new_by_probability(error_tolerance, probability)?;
         let obj = CMSObject {
-            width,
-            depth,
+            width: cms.sketch.width() as u64,
+            depth: cms.sketch.depth() as u64,
             total: 0,
             cms,
         };
@@ -114,7 +109,6 @@ struct CMS {
 
 impl CMS {
     pub fn new_by_probability(epsilon: f64, probability: f64) -> Result<CMS, CMSError> {
-        // flowstats::CountMinSketch::new(epsilon, delta)
         // epsilon: Maximum overcount as a fraction of total (e.g., 0.01 for 1%)
         // delta (probability): Probability of exceeding the error bound (e.g., 0.001 for 0.1%)
         let cms = CountMinSketch::new(epsilon, probability);

--- a/src/cms/utils.rs
+++ b/src/cms/utils.rs
@@ -15,6 +15,7 @@ pub const KEY_EXISTS: &str = "ERR Target key name already exists.";
 ///Keyspace Notification Events
 pub const INITBYPROB_EVENT: &str = "countminsketch.initbyprob";
 pub const INITBYDIM_EVENT: &str = "countminsketch.initbydim";
+pub const INCR_EVENT: &str = "countminsketch.incrby";
 
 #[derive(Debug, PartialEq)]
 pub enum CMSError {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,12 +4,15 @@ use valkey_module::{
     ValkeyString,
 };
 pub mod bloom;
+pub mod cms;
 pub mod configs;
 pub mod metrics;
 pub mod wrapper;
 use crate::bloom::command_handler;
 use crate::bloom::data_type::BLOOM_TYPE;
 use crate::bloom::utils::valid_server_version;
+use crate::cms::cms_command_handler;
+use crate::cms::data_type::CMS_TYPE;
 use valkey_module::ModuleOptions;
 use valkey_module_macros::info_command_handler;
 
@@ -91,6 +94,17 @@ fn bloom_load_command(ctx: &Context, args: Vec<ValkeyString>) -> ValkeyResult {
     command_handler::bloom_filter_load(ctx, &args)
 }
 
+/// Command handler for CMS.INITBYDIM <key> <width> <depth>
+fn cms_initbydim_command(ctx: &Context, args: Vec<ValkeyString>) -> ValkeyResult {
+    cms_command_handler::cms_initialize_by_dimensions(ctx, args)
+}
+
+/// Command handler for CMS.INITBYPROB <key> <error> <probability>
+fn cms_initbyprob_command(ctx: &Context, args: Vec<ValkeyString>) -> ValkeyResult {
+    cms_command_handler::cms_initialize_by_probability(ctx, args)
+}
+
+
 ///
 /// Module Info
 ///
@@ -107,11 +121,13 @@ valkey_module! {
     allocator: (valkey_module::alloc::ValkeyAlloc, valkey_module::alloc::ValkeyAlloc),
     data_types: [
         BLOOM_TYPE,
+        CMS_TYPE
     ],
     init: initialize,
     deinit: deinitialize,
     acl_categories: [
         "bloom",
+        "cms",
     ]
     commands: [
         ["BF.ADD", bloom_add_command, "write fast deny-oom", 1, 1, 1, "fast write bloom"],
@@ -122,7 +138,9 @@ valkey_module! {
         ["BF.RESERVE", bloom_reserve_command, "write fast deny-oom", 1, 1, 1, "fast write bloom"],
         ["BF.INFO", bloom_info_command, "readonly fast", 1, 1, 1, "fast read bloom"],
         ["BF.INSERT", bloom_insert_command, "write fast deny-oom", 1, 1, 1, "fast write bloom"],
-        ["BF.LOAD", bloom_load_command, "write deny-oom", 1, 1, 1, "write bloom"]
+        ["BF.LOAD", bloom_load_command, "write deny-oom", 1, 1, 1, "write bloom"],
+        ["CMS.INITBYDIM", cms_initbydim_command, "write fast deny-oom", 1, 1, 1, "fast write cms"],
+        ["CMS.INITBYPROB", cms_initbyprob_command, "write fast deny-oom", 1, 1, 1, "fast write cms"],
     ],
     configurations: [
         i64: [

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -104,7 +104,6 @@ fn cms_initbyprob_command(ctx: &Context, args: Vec<ValkeyString>) -> ValkeyResul
     cms_command_handler::cms_initialize_by_probability(ctx, args)
 }
 
-
 ///
 /// Module Info
 ///

--- a/tests/test_cms_command.py
+++ b/tests/test_cms_command.py
@@ -1,0 +1,50 @@
+#!/usr/bin/env python3
+
+import pytest
+from valkey import ResponseError
+from valkey_bloom_test_case import ValkeyBloomTestCaseBase
+from valkeytestframework.conftest import resource_port_tracker
+
+class TestCMSCommand(ValkeyBloomTestCaseBase):
+
+    def test_cms_command_error(self):
+
+        assert self.client.execute_command('CMS.INITBYDIM sketch 1000 5') == b'OK'
+
+        basic_error_test_cases = [
+
+            # incorrect syntax and argument usage
+            ('CMS.INITBYDIM sketch 1000 5', 'item exists'),
+            ('CMS.INITBYDIM newsketch abc 5', 'bad width'),
+            ('CMS.INITBYDIM newsketch 1000 abc', 'bad depth'),
+            ('CMS.INITBYDIM newsketch 0 5', 'bad width'),
+            ('CMS.INITBYDIM newsketch 1000 0', 'bad depth'),
+            ('CMS.INITBYDIM newsketch -1 5', 'bad width'),
+            ('CMS.INITBYDIM newsketch 1000 -1', 'bad depth'),
+
+            ('CMS.INITBYPROB newsketch abc 0.01', 'bad error rate'),
+            ('CMS.INITBYPROB newsketch 0.01 abc', 'bad probability'),
+            ('CMS.INITBYPROB newsketch 0 0.01', 'error rate should be between 0 and 1'),
+            ('CMS.INITBYPROB newsketch 1 0.01', 'error rate should be between 0 and 1'),
+            ('CMS.INITBYPROB newsketch 0.01 0', 'probability rate should be between 0 and 1'),
+            ('CMS.INITBYPROB newsketch 0.01 1', 'probability rate should be between 0 and 1'),
+
+
+            # wrong number of arguments
+            ('CMS.INITBYDIM', 'wrong number of arguments for \'CMS.INITBYDIM\' command'),
+            ('CMS.INITBYDIM key', 'wrong number of arguments for \'CMS.INITBYDIM\' command'),
+            ('CMS.INITBYDIM key 1000', 'wrong number of arguments for \'CMS.INITBYDIM\' command'),
+            ('CMS.INITBYDIM key 1000 5 extra', 'wrong number of arguments for \'CMS.INITBYDIM\' command'),
+
+            ('CMS.INITBYPROB', 'wrong number of arguments for \'CMS.INITBYPROB\' command'),
+            ('CMS.INITBYPROB key', 'wrong number of arguments for \'CMS.INITBYPROB\' command'),
+            ('CMS.INITBYPROB key 0.01', 'wrong number of arguments for \'CMS.INITBYPROB\' command'),
+            ('CMS.INITBYPROB key 0.01 0.01 extra', 'wrong number of arguments for \'CMS.INITBYPROB\' command'),
+
+         
+        ]
+
+        for test_case in basic_error_test_cases:
+            cmd = test_case[0]
+            expected_err_reply = test_case[1]
+            self.verify_error_response(self.client, cmd, expected_err_reply)


### PR DESCRIPTION
This is the start of the count min sketch module, just broken up into more specific bite sized PRs to make it easier to review and talk about trade offs on.  If a maintainer of Valkey-Bloom could create a count-min-sketch branch in the repository I can point this and the next PRs towards it to have a flow of approval into that feature branch.  

This PR adds the CMS.INITBYDIM and CMS.INITBYPROB commands to Valkey-Bloom.  I decided to ignore the seeding properties that we will need later for MERGE until that time, which also requires the underlying libraries to support doing so which is outlined below.  

This PR has Valkey-bloom take a dependency on flowstats, but I believe the correct dependency to be on rust-count-min-sketch which is outlined here: https://github.com/valkey-io/valkey-bloom/issues/84.  This comes with a trade-off outlined in that issue, needing the PRs for the methods of dimension initialization as well as having the width as a power of 2.  I'm happy to PR these to that repository if we feel that's the best chocie.

I'm more than happy to make changes and take suggestions as much of Valkey's internals were new to me.  Thank you


