### PR TITLE
Add TopK core metrics, deep-copy COPY support, and basic test coverage

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,8 +16,7 @@ valkey-module = { version = "0.1.5", features = ["min-valkey-compatibility-versi
 valkey-module-macros = "0"
 linkme = "0"
 bloomfilter = { version = "3.0.1", features = ["serde"] }
-# TODO: This is a temporary solution until we add this functionality to the original heavykeeper crate.
-heavykeeper = { git = "https://github.com/detemmienation/heavykeeper-rs.git", branch = "copy" }
+heavykeeper = "0.6.8"
 lazy_static = "1.4.0"
 libc = "0.2"
 serde = { version = "1.0", features = ["derive"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,8 +16,7 @@ valkey-module = { version = "0.1.5", features = ["min-valkey-compatibility-versi
 valkey-module-macros = "0"
 linkme = "0"
 bloomfilter = { version = "3.0.1", features = ["serde"] }
-# TODO: This is a temporary solution until we add this functionality to the original heavykeeper crate.
-heavykeeper = { git = "https://github.com/detemmienation/heavykeeper-rs.git", branch = "memory" }
+heavykeeper = "0.6.9"
 lazy_static = "1.4.0"
 libc = "0.2"
 serde = { version = "1.0", features = ["derive"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,8 @@ valkey-module = { version = "0.1.5", features = ["min-valkey-compatibility-versi
 valkey-module-macros = "0"
 linkme = "0"
 bloomfilter = { version = "3.0.1", features = ["serde"] }
-heavykeeper = "0.6.7"
+# TODO: This is a temporary solution until we add this functionality to the original heavykeeper crate.
+heavykeeper = { git = "https://github.com/detemmienation/heavykeeper-rs.git", branch = "copy" }
 lazy_static = "1.4.0"
 libc = "0.2"
 serde = { version = "1.0", features = ["derive"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,8 @@ valkey-module = { version = "0.1.5", features = ["min-valkey-compatibility-versi
 valkey-module-macros = "0"
 linkme = "0"
 bloomfilter = { version = "3.0.1", features = ["serde"] }
-heavykeeper = "0.6.9"
+# TODO: This is a temporary solution until we add this functionality to the original heavykeeper crate.
+heavykeeper = { git = "https://github.com/detemmienation/heavykeeper-rs.git", branch = "mem" }
 lazy_static = "1.4.0"
 libc = "0.2"
 serde = { version = "1.0", features = ["derive"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,8 @@ valkey-module = { version = "0.1.5", features = ["min-valkey-compatibility-versi
 valkey-module-macros = "0"
 linkme = "0"
 bloomfilter = { version = "3.0.1", features = ["serde"] }
-heavykeeper = "0.6.8"
+# TODO: This is a temporary solution until we add this functionality to the original heavykeeper crate.
+heavykeeper = { git = "https://github.com/detemmienation/heavykeeper-rs.git", branch = "memory" }
 lazy_static = "1.4.0"
 libc = "0.2"
 serde = { version = "1.0", features = ["derive"] }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,4 @@
-use metrics::bloom_info_handler;
+use metrics::{bloom_info_handler, topk_info_handler};
 use valkey_module::{
     configuration::ConfigurationFlags, valkey_module, Context, InfoContext, Status, ValkeyResult,
     ValkeyString,
@@ -133,7 +133,8 @@ fn topk_query_command(ctx: &Context, args: Vec<ValkeyString>) -> ValkeyResult {
 ///
 #[info_command_handler]
 fn info_handler(ctx: &InfoContext, _for_crash_report: bool) -> ValkeyResult<()> {
-    bloom_info_handler(ctx)
+    bloom_info_handler(ctx)?;
+    topk_info_handler(ctx)
 }
 
 //////////////////////////////////////////////////////

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -12,7 +12,7 @@ lazy_static! {
     pub static ref BLOOM_DEFRAG_MISSES: AtomicU64 = AtomicU64::new(0);
     pub static ref TOPK_NUM_OBJECTS: AtomicU64 = AtomicU64::new(0);
     pub static ref TOPK_OBJECT_TOTAL_MEMORY_BYTES: AtomicUsize = AtomicUsize::new(0);
-    pub static ref TOPK_NUM_ITEMS_ACROSS_OBJECTS: AtomicU64 = AtomicU64::new(0);
+    pub static ref TOPK_TOTAL_ITEMS_ADDED_ACROSS_OBJECTS: AtomicU64 = AtomicU64::new(0);
     pub static ref TOPK_SUM_K_ACROSS_OBJECTS: AtomicU64 = AtomicU64::new(0);
 }
 
@@ -77,8 +77,8 @@ pub fn topk_info_handler(ctx: &InfoContext) -> ValkeyResult<()> {
             TOPK_NUM_OBJECTS.load(Ordering::Relaxed).to_string(),
         )?
         .field(
-            "topk_num_items_across_objects",
-            TOPK_NUM_ITEMS_ACROSS_OBJECTS
+            "topk_total_items_added_across_objects",
+            TOPK_TOTAL_ITEMS_ADDED_ACROSS_OBJECTS
                 .load(Ordering::Relaxed)
                 .to_string(),
         )?

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -10,6 +10,10 @@ lazy_static! {
     pub static ref BLOOM_CAPACITY_ACROSS_OBJECTS: AtomicU64 = AtomicU64::new(0);
     pub static ref BLOOM_DEFRAG_HITS: AtomicU64 = AtomicU64::new(0);
     pub static ref BLOOM_DEFRAG_MISSES: AtomicU64 = AtomicU64::new(0);
+    pub static ref TOPK_NUM_OBJECTS: AtomicU64 = AtomicU64::new(0);
+    pub static ref TOPK_OBJECT_TOTAL_MEMORY_BYTES: AtomicUsize = AtomicUsize::new(0);
+    pub static ref TOPK_NUM_ITEMS_ACROSS_OBJECTS: AtomicU64 = AtomicU64::new(0);
+    pub static ref TOPK_SUM_K_ACROSS_OBJECTS: AtomicU64 = AtomicU64::new(0);
 }
 
 pub fn bloom_info_handler(ctx: &InfoContext) -> ValkeyResult<()> {
@@ -52,6 +56,37 @@ pub fn bloom_info_handler(ctx: &InfoContext) -> ValkeyResult<()> {
         .field(
             "bloom_defrag_misses",
             BLOOM_DEFRAG_MISSES.load(Ordering::Relaxed).to_string(),
+        )?
+        .build_section()?
+        .build_info()?;
+
+    Ok(())
+}
+
+pub fn topk_info_handler(ctx: &InfoContext) -> ValkeyResult<()> {
+    ctx.builder()
+        .add_section("topk_core_metrics")
+        .field(
+            "topk_total_memory_bytes",
+            TOPK_OBJECT_TOTAL_MEMORY_BYTES
+                .load(Ordering::Relaxed)
+                .to_string(),
+        )?
+        .field(
+            "topk_num_objects",
+            TOPK_NUM_OBJECTS.load(Ordering::Relaxed).to_string(),
+        )?
+        .field(
+            "topk_num_items_across_objects",
+            TOPK_NUM_ITEMS_ACROSS_OBJECTS
+                .load(Ordering::Relaxed)
+                .to_string(),
+        )?
+        .field(
+            "topk_sum_k_across_objects",
+            TOPK_SUM_K_ACROSS_OBJECTS
+                .load(Ordering::Relaxed)
+                .to_string(),
         )?
         .build_section()?
         .build_info()?;

--- a/src/topk/command_handler.rs
+++ b/src/topk/command_handler.rs
@@ -255,8 +255,8 @@ pub fn topk_incrby(ctx: &Context, input_args: &[ValkeyString]) -> ValkeyResult {
 /// Syntax:
 ///     TOPK.INFO key
 ///
-/// Returns the number of required items (k), width, depth, and decay of the
-/// sketch stored at `key`.
+/// Returns the number of required items (k), width, depth, decay, and the
+/// estimated memory size (in bytes) of the sketch stored at `key`.
 pub fn topk_info(ctx: &Context, input_args: &[ValkeyString]) -> ValkeyResult {
     if input_args.len() != 2 {
         return Err(ValkeyError::WrongArity);
@@ -279,6 +279,8 @@ pub fn topk_info(ctx: &Context, input_args: &[ValkeyString]) -> ValkeyResult {
         ValkeyValue::Integer(topk.depth() as i64),
         ValkeyValue::SimpleStringStatic("decay"),
         ValkeyValue::Float(topk.decay()),
+        ValkeyValue::SimpleStringStatic("size"),
+        ValkeyValue::Integer(topk.memory_usage() as i64),
     ];
     Ok(ValkeyValue::Array(result))
 }

--- a/src/topk/utils.rs
+++ b/src/topk/utils.rs
@@ -84,6 +84,15 @@ impl TopKObject {
         topk
     }
 
+    /// Estimated total memory (in bytes) of this object: the wrapper struct
+    /// plus the heap the underlying sketch owns (lobby/heavy cell arrays, the
+    /// decay-threshold table, and the priority-queue allocations). Excludes the
+    /// variable byte contents of individual tracked keys, which `mem_bytes`
+    /// does not account for.
+    pub fn memory_usage(&self) -> usize {
+        std::mem::size_of::<TopKObject>() + self.sketch.mem_bytes()
+    }
+
     /// Increments metrics related to object count, memory, and summed k upon creation of a new object.
     fn topk_object_incr_metrics_on_new_create(&self) {
         metrics::TOPK_NUM_OBJECTS.fetch_add(1, Ordering::Relaxed);

--- a/src/topk/utils.rs
+++ b/src/topk/utils.rs
@@ -84,13 +84,11 @@ impl TopKObject {
         topk
     }
 
-    /// Estimated total memory (in bytes) of this object: the wrapper struct
-    /// plus the heap the underlying sketch owns (lobby/heavy cell arrays, the
-    /// decay-threshold table, and the priority-queue allocations). Excludes the
-    /// variable byte contents of individual tracked keys, which `mem_bytes`
-    /// does not account for.
+    /// Estimated heap size of this object: wrapper struct + sketch internals
+    /// (cell arrays, decay table, priority queue) + per-item buffer capacity.
+    /// The remaining undercount is allocator overhead and HashMap metadata.
     pub fn memory_usage(&self) -> usize {
-        std::mem::size_of::<TopKObject>() + self.sketch.mem_bytes()
+        std::mem::size_of::<TopKObject>() + self.sketch.mem_bytes_with(|item| item.capacity())
     }
 
     /// Increments metrics related to object count, memory, and summed k upon creation of a new object.
@@ -133,7 +131,22 @@ impl TopKObject {
         let delta = new_num_items - self.num_items;
         self.num_items = new_num_items;
         metrics::TOPK_TOTAL_ITEMS_ADDED_ACROSS_OBJECTS.fetch_add(delta, Ordering::Relaxed);
-        self.sketch.add_with_evicted(item, increment)
+        // Diffing memory_usage() before/after makes this O(width·depth + k) ×2
+        // instead of O(1).
+        // TODO: have upstream add_with_evicted report whether an item was
+        // inserted (or the memory delta) so we can update the gauge in
+        // O(item bytes) and keep add O(1).
+        let mem_before = self.memory_usage();
+        let evicted = self.sketch.add_with_evicted(item, increment);
+        let mem_after = self.memory_usage();
+        if mem_after >= mem_before {
+            metrics::TOPK_OBJECT_TOTAL_MEMORY_BYTES
+                .fetch_add(mem_after - mem_before, Ordering::Relaxed);
+        } else {
+            metrics::TOPK_OBJECT_TOTAL_MEMORY_BYTES
+                .fetch_sub(mem_before - mem_after, Ordering::Relaxed);
+        }
+        evicted
     }
 
     /// Return the estimated count for `item`, or 0 if it has no residual

--- a/src/topk/utils.rs
+++ b/src/topk/utils.rs
@@ -96,8 +96,7 @@ impl TopKObject {
     /// Increments metrics related to object count, memory, and summed k upon creation of a new object.
     fn topk_object_incr_metrics_on_new_create(&self) {
         metrics::TOPK_NUM_OBJECTS.fetch_add(1, Ordering::Relaxed);
-        metrics::TOPK_OBJECT_TOTAL_MEMORY_BYTES
-            .fetch_add(std::mem::size_of::<TopKObject>(), Ordering::Relaxed);
+        metrics::TOPK_OBJECT_TOTAL_MEMORY_BYTES.fetch_add(self.memory_usage(), Ordering::Relaxed);
         metrics::TOPK_SUM_K_ACROSS_OBJECTS.fetch_add(self.k as u64, Ordering::Relaxed);
         metrics::TOPK_TOTAL_ITEMS_ADDED_ACROSS_OBJECTS.fetch_add(self.num_items, Ordering::Relaxed);
     }
@@ -161,8 +160,7 @@ impl TopKObject {
 impl Drop for TopKObject {
     fn drop(&mut self) {
         metrics::TOPK_NUM_OBJECTS.fetch_sub(1, Ordering::Relaxed);
-        metrics::TOPK_OBJECT_TOTAL_MEMORY_BYTES
-            .fetch_sub(std::mem::size_of::<TopKObject>(), Ordering::Relaxed);
+        metrics::TOPK_OBJECT_TOTAL_MEMORY_BYTES.fetch_sub(self.memory_usage(), Ordering::Relaxed);
         metrics::TOPK_SUM_K_ACROSS_OBJECTS.fetch_sub(self.k as u64, Ordering::Relaxed);
         metrics::TOPK_TOTAL_ITEMS_ADDED_ACROSS_OBJECTS.fetch_sub(self.num_items, Ordering::Relaxed);
     }

--- a/src/topk/utils.rs
+++ b/src/topk/utils.rs
@@ -1,4 +1,6 @@
+use crate::metrics;
 use heavykeeper::CuckooTopK;
+use std::sync::atomic::Ordering;
 
 /// KeySpace Notification Events
 pub const RESERVE_EVENT: &str = "topk.reserve";
@@ -44,6 +46,7 @@ pub struct TopKObject {
     decay: f64,
     seed: u64,
     sketch: CuckooTopK<Vec<u8>>,
+    num_items: u64,
 }
 
 impl TopKObject {
@@ -51,14 +54,25 @@ impl TopKObject {
     /// after the handler has parsed and validated all parameters.
     pub fn new_reserved(k: u32, width: u32, depth: u32, decay: f64, seed: u64) -> TopKObject {
         let sketch = CuckooTopK::with_seed(k as usize, width as usize, depth as usize, decay, seed);
-        TopKObject {
+        let topk = TopKObject {
             k,
             width,
             depth,
             decay,
             seed,
             sketch,
-        }
+            num_items: 0,
+        };
+        topk.topk_object_incr_metrics_on_new_create();
+        topk
+    }
+
+    /// Increments metrics related to object count, memory, and summed k upon creation of a new object.
+    fn topk_object_incr_metrics_on_new_create(&self) {
+        metrics::TOPK_NUM_OBJECTS.fetch_add(1, Ordering::Relaxed);
+        metrics::TOPK_OBJECT_TOTAL_MEMORY_BYTES
+            .fetch_add(std::mem::size_of::<TopKObject>(), Ordering::Relaxed);
+        metrics::TOPK_SUM_K_ACROSS_OBJECTS.fetch_add(self.k as u64, Ordering::Relaxed);
     }
 
     pub fn k(&self) -> u32 {
@@ -87,6 +101,12 @@ impl TopKObject {
     /// heavy-slot resident displaced by this insertion (if any). At most one
     /// item can be evicted per call.
     pub fn add(&mut self, item: &[u8], increment: u64) -> Option<Vec<u8>> {
+        // Saturate like the underlying sketch (heavykeeper uses saturating_add),
+        // and feed the gauge the actual delta so Drop's subtraction stays balanced.
+        let new_num_items = self.num_items.saturating_add(increment);
+        let delta = new_num_items - self.num_items;
+        self.num_items = new_num_items;
+        metrics::TOPK_NUM_ITEMS_ACROSS_OBJECTS.fetch_add(delta, Ordering::Relaxed);
         self.sketch.add_with_evicted(item, increment)
     }
 
@@ -108,6 +128,16 @@ impl TopKObject {
             .into_iter()
             .map(|node| (node.item, node.count))
             .collect()
+    }
+}
+
+impl Drop for TopKObject {
+    fn drop(&mut self) {
+        metrics::TOPK_NUM_OBJECTS.fetch_sub(1, Ordering::Relaxed);
+        metrics::TOPK_OBJECT_TOTAL_MEMORY_BYTES
+            .fetch_sub(std::mem::size_of::<TopKObject>(), Ordering::Relaxed);
+        metrics::TOPK_SUM_K_ACROSS_OBJECTS.fetch_sub(self.k as u64, Ordering::Relaxed);
+        metrics::TOPK_NUM_ITEMS_ACROSS_OBJECTS.fetch_sub(self.num_items, Ordering::Relaxed);
     }
 }
 

--- a/src/topk/utils.rs
+++ b/src/topk/utils.rs
@@ -67,12 +67,30 @@ impl TopKObject {
         topk
     }
 
+    /// Build a deep copy of `src` for the COPY command. Clones the sketch
+    /// contents (heavy/lobby cells and priority queue) and carries over the
+    /// running item count.
+    pub fn create_copy_from(src: &TopKObject) -> TopKObject {
+        let topk = TopKObject {
+            k: src.k,
+            width: src.width,
+            depth: src.depth,
+            decay: src.decay,
+            seed: src.seed,
+            sketch: src.sketch.clone(),
+            num_items: src.num_items,
+        };
+        topk.topk_object_incr_metrics_on_new_create();
+        topk
+    }
+
     /// Increments metrics related to object count, memory, and summed k upon creation of a new object.
     fn topk_object_incr_metrics_on_new_create(&self) {
         metrics::TOPK_NUM_OBJECTS.fetch_add(1, Ordering::Relaxed);
         metrics::TOPK_OBJECT_TOTAL_MEMORY_BYTES
             .fetch_add(std::mem::size_of::<TopKObject>(), Ordering::Relaxed);
         metrics::TOPK_SUM_K_ACROSS_OBJECTS.fetch_add(self.k as u64, Ordering::Relaxed);
+        metrics::TOPK_NUM_ITEMS_ACROSS_OBJECTS.fetch_add(self.num_items, Ordering::Relaxed);
     }
 
     pub fn k(&self) -> u32 {

--- a/src/topk/utils.rs
+++ b/src/topk/utils.rs
@@ -90,7 +90,7 @@ impl TopKObject {
         metrics::TOPK_OBJECT_TOTAL_MEMORY_BYTES
             .fetch_add(std::mem::size_of::<TopKObject>(), Ordering::Relaxed);
         metrics::TOPK_SUM_K_ACROSS_OBJECTS.fetch_add(self.k as u64, Ordering::Relaxed);
-        metrics::TOPK_NUM_ITEMS_ACROSS_OBJECTS.fetch_add(self.num_items, Ordering::Relaxed);
+        metrics::TOPK_TOTAL_ITEMS_ADDED_ACROSS_OBJECTS.fetch_add(self.num_items, Ordering::Relaxed);
     }
 
     pub fn k(&self) -> u32 {
@@ -124,7 +124,7 @@ impl TopKObject {
         let new_num_items = self.num_items.saturating_add(increment);
         let delta = new_num_items - self.num_items;
         self.num_items = new_num_items;
-        metrics::TOPK_NUM_ITEMS_ACROSS_OBJECTS.fetch_add(delta, Ordering::Relaxed);
+        metrics::TOPK_TOTAL_ITEMS_ADDED_ACROSS_OBJECTS.fetch_add(delta, Ordering::Relaxed);
         self.sketch.add_with_evicted(item, increment)
     }
 
@@ -155,7 +155,7 @@ impl Drop for TopKObject {
         metrics::TOPK_OBJECT_TOTAL_MEMORY_BYTES
             .fetch_sub(std::mem::size_of::<TopKObject>(), Ordering::Relaxed);
         metrics::TOPK_SUM_K_ACROSS_OBJECTS.fetch_sub(self.k as u64, Ordering::Relaxed);
-        metrics::TOPK_NUM_ITEMS_ACROSS_OBJECTS.fetch_sub(self.num_items, Ordering::Relaxed);
+        metrics::TOPK_TOTAL_ITEMS_ADDED_ACROSS_OBJECTS.fetch_sub(self.num_items, Ordering::Relaxed);
     }
 }
 

--- a/src/wrapper/topk_callback.rs
+++ b/src/wrapper/topk_callback.rs
@@ -9,13 +9,13 @@ pub unsafe extern "C" fn topk_free(value: *mut c_void) {
 }
 
 /// # Safety
-/// Approximate memory usage for the MEMORY USAGE command. Currently reports
-/// only the size of the wrapper struct; the heap allocations CuckooTopK
-/// performs internally (lobby + heavy slots) are not yet accounted for.
-/// Refine when TOPK.ADD lands and we have a stable view into the sketch.
+/// Approximate memory usage for the MEMORY USAGE command. Reports the wrapper
+/// struct plus the sketch's heap allocations (lobby/heavy cell arrays, decay
+/// table, and priority-queue containers). Excludes the variable byte contents
+/// of individual tracked keys.
 pub unsafe extern "C" fn topk_mem_usage(value: *const c_void) -> usize {
-    let _v = &*value.cast::<TopKObject>();
-    std::mem::size_of::<TopKObject>()
+    let v = &*value.cast::<TopKObject>();
+    v.memory_usage()
 }
 
 /// # Safety

--- a/src/wrapper/topk_callback.rs
+++ b/src/wrapper/topk_callback.rs
@@ -19,23 +19,16 @@ pub unsafe extern "C" fn topk_mem_usage(value: *const c_void) -> usize {
 }
 
 /// # Safety
-/// Raw handler for the COPY command. Builds a fresh TopKObject with the same
-/// parameters as the source. The sketch is empty after copy, which is
-/// correct today because we don't persist sketch contents yet — when
-/// TOPK.ADD lands this needs a real deep copy of the heavy/lobby arrays.
+/// Raw handler for the COPY command. Builds a deep copy of the source
+/// TopKObject, duplicating the sketch contents and item count so the copy is
+/// a faithful clone rather than an empty sketch.
 pub unsafe extern "C" fn topk_copy(
     _from_key: *mut RedisModuleString,
     _to_key: *mut RedisModuleString,
     value: *const c_void,
 ) -> *mut c_void {
     let curr = &*value.cast::<TopKObject>();
-    let new_item = TopKObject::new_reserved(
-        curr.k(),
-        curr.width(),
-        curr.depth(),
-        curr.decay(),
-        curr.seed(),
-    );
+    let new_item = TopKObject::create_copy_from(curr);
     let bb = Box::new(new_item);
     Box::into_raw(bb).cast::<libc::c_void>()
 }

--- a/src/wrapper/topk_callback.rs
+++ b/src/wrapper/topk_callback.rs
@@ -11,8 +11,8 @@ pub unsafe extern "C" fn topk_free(value: *mut c_void) {
 /// # Safety
 /// Approximate memory usage for the MEMORY USAGE command. Reports the wrapper
 /// struct plus the sketch's heap allocations (lobby/heavy cell arrays, decay
-/// table, and priority-queue containers). Excludes the variable byte contents
-/// of individual tracked keys.
+/// table, priority-queue containers, and the buffers of tracked items). See
+/// `TopKObject::memory_usage` for what the estimate still omits.
 pub unsafe extern "C" fn topk_mem_usage(value: *const c_void) -> usize {
     let v = &*value.cast::<TopKObject>();
     v.memory_usage()

--- a/tests/test_topk_acl_category.py
+++ b/tests/test_topk_acl_category.py
@@ -13,7 +13,7 @@ class TestTopkACLCategory(ValkeyBloomTestCaseBase):
             ('TOPK.QUERY reserve_key item', [1]),
             ('TOPK.COUNT reserve_key item', [6]),
             ('TOPK.LIST reserve_key', [b'item']),
-            ('TOPK.INFO reserve_key', 8),
+            ('TOPK.INFO reserve_key', 10),
         ]
         client = self.server.get_new_client()
         # Get a list of all commands with the acl category topk

--- a/tests/test_topk_basic.py
+++ b/tests/test_topk_basic.py
@@ -1,15 +1,146 @@
+import time
+from valkeytestframework.util.waiters import *
+from valkey import ResponseError
 from valkeytestframework.conftest import resource_port_tracker  # noqa: F401
 from valkey_bloom_test_case import ValkeyBloomTestCaseBase
 
 
 class TestTopkBasic(ValkeyBloomTestCaseBase):
-    """
-    Basic behavioral coverage for TOPK.ADD eviction semantics.
 
-    These tests exercise which item (if any) is displaced from the top-k by
-    an insertion. The displaced item depends on the sketch's hash seed, so we
-    reserve with an explicit SEED to keep results deterministic across runs.
-    """
+    def test_basic(self):
+        client = self.server.get_new_client()
+        # Validate that the valkey-bloom module is loaded.
+        module_list_data = client.execute_command('MODULE LIST')
+        module_loaded = any(module[b'name'] == b'bf' for module in module_list_data)
+        assert module_loaded
+        # Validate that all the TOPK.* commands are supported on the server.
+        command_cmd_result = client.execute_command('COMMAND')
+        topk_cmds = ["TOPK.RESERVE", "TOPK.ADD", "TOPK.INCRBY", "TOPK.INFO", "TOPK.LIST", "TOPK.COUNT", "TOPK.QUERY"]
+        assert all(item in command_cmd_result for item in topk_cmds)
+        # Basic create, add, and membership query.
+        assert client.execute_command('TOPK.RESERVE tk 3 50 4 0.9 SEED 42') == b'OK'
+        assert client.execute_command('TOPK.ADD tk apple banana cherry') == [None, None, None]
+        assert client.execute_command('TOPK.QUERY tk apple') == [1]
+        assert client.execute_command('TOPK.QUERY tk missing') == [0]
+
+    def test_copy(self):
+        client = self.server.get_new_client()
+        assert client.execute_command('TOPK.RESERVE tk 3 50 4 0.9 SEED 42') == b'OK'
+        client.execute_command('TOPK.INCRBY tk apple 5 banana 3 cherry 1')
+        # COPY is a deep copy
+        assert client.execute_command('COPY tk tk_copy') == 1
+        assert client.execute_command('EXISTS tk_copy') == 1
+        assert client.execute_command('TOPK.LIST tk') == client.execute_command('TOPK.LIST tk_copy')
+        assert client.execute_command('TOPK.LIST tk WITHCOUNT') == client.execute_command('TOPK.LIST tk_copy WITHCOUNT')
+
+    def test_module_data_type(self):
+        # Validate the name of the Module data type and its encoding.
+        client = self.server.get_new_client()
+        assert client.execute_command('TOPK.RESERVE tk 3 50 4 0.9') == b'OK'
+        assert client.execute_command('TYPE tk') == b"topk-type"
+        assert client.execute_command('OBJECT ENCODING tk') == b"raw"
+
+    def test_topk_obj_access(self):
+        client = self.server.get_new_client()
+        # TopK keys work with generic key commands.
+        assert client.execute_command('TOPK.RESERVE key1 3 50 4 0.9') == b'OK'
+        assert client.execute_command('TOPK.RESERVE key2 3 50 4 0.9') == b'OK'
+        assert client.execute_command('TOUCH key1 key2') == 2
+        assert client.execute_command('TOUCH key3') == 0
+        self.verify_server_key_count(client, 2)
+        assert client.execute_command('DBSIZE') == 2
+        random_key = client.execute_command('RANDOMKEY')
+        assert random_key == b"key1" or random_key == b"key2"
+
+    def test_topk_transaction(self):
+        client = self.server.get_new_client()
+        assert client.execute_command('MULTI') == b'OK'
+        assert client.execute_command('TOPK.RESERVE M1 3 50 4 0.9') == b'QUEUED'
+        assert client.execute_command('TOPK.ADD M1 V1') == b'QUEUED'
+        assert client.execute_command('TOPK.QUERY M1 V1') == b'QUEUED'
+        assert client.execute_command('DEL M1') == b'QUEUED'
+        results = client.execute_command('EXEC')
+        # RESERVE -> OK, ADD -> [nil], QUERY -> [1], DEL -> 1.
+        assert results == [b'OK', [None], [1], 1]
+        self.verify_server_key_count(client, 0)
+
+    def test_topk_lua(self):
+        client = self.server.get_new_client()
+        load = """
+        redis.call('TOPK.RESERVE', 'LUA1', '3', '50', '4', '0.9');
+        redis.call('TOPK.ADD', 'LUA1', 'ITEM1');
+        redis.call('TOPK.INCRBY', 'LUA1', 'ITEM2', '5');
+        """
+        client.eval(load, 0)
+        assert client.execute_command('TOPK.QUERY LUA1 ITEM1 ITEM2 MISSING') == [1, 1, 0]
+        self.verify_server_key_count(client, 1)
+
+    def test_topk_deletes(self):
+        client = self.server.get_new_client()
+        # delete
+        assert client.execute_command('TOPK.RESERVE filter1 3 50 4 0.9') == b'OK'
+        self.verify_server_key_count(client, 1)
+        assert client.execute_command('DEL filter1') == 1
+        self.verify_server_key_count(client, 0)
+
+        # flush
+        for i in range(10):
+            assert client.execute_command(f'TOPK.RESERVE SAMPLE{i} 3 50 4 0.9') == b'OK'
+        self.verify_server_key_count(client, 10)
+        assert client.execute_command('FLUSHALL')
+        self.verify_server_key_count(client, 0)
+
+        # unlink
+        assert client.execute_command('TOPK.RESERVE A 3 50 4 0.9') == b'OK'
+        assert client.execute_command('TOPK.RESERVE B 3 50 4 0.9') == b'OK'
+        self.verify_server_key_count(client, 2)
+        assert client.execute_command('UNLINK A B C') == 2
+        self.verify_server_key_count(client, 0)
+
+    def test_topk_expiration(self):
+        client = self.server.get_new_client()
+        self.verify_server_key_count(client, 0)
+        # cmd object idletime
+        assert client.execute_command('TOPK.RESERVE TEST_IDLE 3 50 4 0.9') == b'OK'
+        self.verify_server_key_count(client, 1)
+        time.sleep(1)
+        assert client.execute_command('OBJECT IDLETIME TEST_IDLE') > 0
+        # cmd ttl, expireat
+        assert client.execute_command('TOPK.RESERVE TEST_EXP 3 50 4 0.9') == b'OK'
+        assert client.execute_command('TTL TEST_EXP') == -1
+        self.verify_server_key_count(client, 2)
+        curr_time = int(time.time())
+        assert client.execute_command(f'EXPIREAT TEST_EXP {curr_time + 5}') == 1
+        wait_for_equal(lambda: client.execute_command('EXISTS TEST_EXP'), 0)
+        self.verify_server_key_count(client, 1)
+        # cmd persist
+        assert client.execute_command('TOPK.RESERVE TEST_PERSIST 3 50 4 0.9') == b'OK'
+        assert client.execute_command('TTL TEST_PERSIST') == -1
+        assert client.execute_command(f'EXPIREAT TEST_PERSIST {curr_time + 100000}') == 1
+        assert client.execute_command('TTL TEST_PERSIST') > 0
+        assert client.execute_command('PERSIST TEST_PERSIST') == 1
+        assert client.execute_command('TTL TEST_PERSIST') == -1
+
+    def test_topk_wrong_type(self):
+        topk_commands = [
+            'TOPK.RESERVE key 3 50 4 0.9',
+            'TOPK.ADD key item',
+            'TOPK.INCRBY key item 1',
+            'TOPK.QUERY key item',
+            'TOPK.COUNT key item',
+            'TOPK.LIST key',
+            'TOPK.INFO key',
+        ]
+        client = self.server.get_new_client()
+        # Set the key we try to perform topk commands on to a string.
+        client.execute_command("set key value")
+        for cmd in topk_commands:
+            cmd_name = cmd.split()[0]
+            try:
+                result = client.execute_command(cmd)
+                assert False, f"{cmd_name} on existing non topk object should fail, instead: {result}"
+            except ResponseError as e:
+                assert str(e) == "WRONGTYPE Operation against a key holding the wrong kind of value"
 
     def test_topk_add_no_eviction(self):
         assert self.client.execute_command('TOPK.RESERVE tk 3 50 4 0.9 SEED 42') == b'OK'

--- a/tests/test_topk_basic.py
+++ b/tests/test_topk_basic.py
@@ -33,6 +33,28 @@ class TestTopkBasic(ValkeyBloomTestCaseBase):
         assert client.execute_command('TOPK.LIST tk') == client.execute_command('TOPK.LIST tk_copy')
         assert client.execute_command('TOPK.LIST tk WITHCOUNT') == client.execute_command('TOPK.LIST tk_copy WITHCOUNT')
 
+        for cmd in [
+            'TOPK.ADD tk date',
+            'TOPK.INCRBY tk date 10',
+            'TOPK.ADD tk apple banana',
+            'TOPK.INCRBY tk elderberry 8 fig 6',
+        ]:
+            copy_cmd = cmd.replace('tk ', 'tk_copy ', 1)
+            assert client.execute_command(cmd) == client.execute_command(copy_cmd)
+
+        # Final membership, ordering, and per-item counts all still agree.
+        assert client.execute_command('TOPK.LIST tk WITHCOUNT') == client.execute_command('TOPK.LIST tk_copy WITHCOUNT')
+        for item in ['apple', 'banana', 'cherry', 'date', 'elderberry', 'fig', 'missing']:
+            assert client.execute_command(f'TOPK.COUNT tk {item}') == \
+                client.execute_command(f'TOPK.COUNT tk_copy {item}')
+            assert client.execute_command(f'TOPK.QUERY tk {item}') == \
+                client.execute_command(f'TOPK.QUERY tk_copy {item}')
+
+        # The two sketches are independent
+        before = client.execute_command('TOPK.LIST tk WITHCOUNT')
+        client.execute_command('TOPK.INCRBY tk_copy grape 100')
+        assert client.execute_command('TOPK.LIST tk WITHCOUNT') == before
+
     def test_module_data_type(self):
         # Validate the name of the Module data type and its encoding.
         client = self.server.get_new_client()

--- a/tests/test_topk_basic.py
+++ b/tests/test_topk_basic.py
@@ -121,27 +121,6 @@ class TestTopkBasic(ValkeyBloomTestCaseBase):
         assert client.execute_command('PERSIST TEST_PERSIST') == 1
         assert client.execute_command('TTL TEST_PERSIST') == -1
 
-    def test_topk_wrong_type(self):
-        topk_commands = [
-            'TOPK.RESERVE key 3 50 4 0.9',
-            'TOPK.ADD key item',
-            'TOPK.INCRBY key item 1',
-            'TOPK.QUERY key item',
-            'TOPK.COUNT key item',
-            'TOPK.LIST key',
-            'TOPK.INFO key',
-        ]
-        client = self.server.get_new_client()
-        # Set the key we try to perform topk commands on to a string.
-        client.execute_command("set key value")
-        for cmd in topk_commands:
-            cmd_name = cmd.split()[0]
-            try:
-                result = client.execute_command(cmd)
-                assert False, f"{cmd_name} on existing non topk object should fail, instead: {result}"
-            except ResponseError as e:
-                assert str(e) == "WRONGTYPE Operation against a key holding the wrong kind of value"
-
     def test_topk_add_no_eviction(self):
         assert self.client.execute_command('TOPK.RESERVE tk 3 50 4 0.9 SEED 42') == b'OK'
         assert self.client.execute_command(

--- a/tests/test_topk_command.py
+++ b/tests/test_topk_command.py
@@ -152,7 +152,7 @@ class TestTopkCommand(ValkeyBloomTestCaseBase):
         for cmd, expected_len in incrby_success_cases:
             assert len(self.client.execute_command(cmd)) == expected_len
 
-        # TOPK.INFO reports k, width, depth, and decay of an existing sketch.
+        # TOPK.INFO reports k, width, depth, decay, and size of an existing sketch.
         def info_dict(key):
             raw = self.client.execute_command(f'TOPK.INFO {key}')
             it = iter(raw)
@@ -162,12 +162,17 @@ class TestTopkCommand(ValkeyBloomTestCaseBase):
         assert info[b'width'] == 8
         assert info[b'depth'] == 7
         assert info[b'decay'] == b'0.9'
+        # size is the object's estimated memory in bytes.
+        # TODO: assert size <= MEMORY USAGE once that callback also uses
+        # memory_usage(); today it still reports only size_of::<TopKObject>().
+        assert info[b'size'] > 0
 
         info = info_dict('tk5')
         assert info[b'k'] == 10
         assert info[b'width'] == 200
         assert info[b'depth'] == 5
         assert info[b'decay'] == b'0.5'
+        assert info[b'size'] > 0
 
         # TOPK.LIST returns tracked items by descending count, at most k.
         assert self.client.execute_command('TOPK.RESERVE tk_list 3 50 4 0.9 SEED 42') == b'OK'

--- a/tests/test_topk_command.py
+++ b/tests/test_topk_command.py
@@ -162,10 +162,8 @@ class TestTopkCommand(ValkeyBloomTestCaseBase):
         assert info[b'width'] == 8
         assert info[b'depth'] == 7
         assert info[b'decay'] == b'0.9'
-        # size is the object's estimated memory in bytes.
-        # TODO: assert size <= MEMORY USAGE once that callback also uses
-        # memory_usage(); today it still reports only size_of::<TopKObject>().
         assert info[b'size'] > 0
+        assert info[b'size'] <= self.client.execute_command('MEMORY USAGE tk1')
 
         info = info_dict('tk5')
         assert info[b'k'] == 10
@@ -173,6 +171,7 @@ class TestTopkCommand(ValkeyBloomTestCaseBase):
         assert info[b'depth'] == 5
         assert info[b'decay'] == b'0.5'
         assert info[b'size'] > 0
+        assert info[b'size'] <= self.client.execute_command('MEMORY USAGE tk5')
 
         # TOPK.LIST returns tracked items by descending count, at most k.
         assert self.client.execute_command('TOPK.RESERVE tk_list 3 50 4 0.9 SEED 42') == b'OK'

--- a/tests/test_topk_metrics.py
+++ b/tests/test_topk_metrics.py
@@ -1,0 +1,49 @@
+from valkey_bloom_test_case import ValkeyBloomTestCaseBase
+from valkeytestframework.conftest import resource_port_tracker  # noqa: F401
+from valkeytestframework.util.waiters import *
+
+# Placeholder per-object memory: size_of::<TopKObject>(), excluding the sketch
+# heap, so it is fixed regardless of k/width/depth.
+DEFAULT_TOPK_SIZE = 360
+
+
+class TestTopkMetrics(ValkeyBloomTestCaseBase):
+
+    def test_basic_command_metrics(self):
+        # Metrics start at 0.
+        self.verify_topk_metrics(self.client.execute_command("INFO bf"), 0, 0, 0, 0)
+        self.verify_topk_metrics(self.client.execute_command("INFO Modules"), 0, 0, 0, 0)
+
+        # Reserve a TopK (k=5). One object, no items yet, sum_k = 5.
+        assert self.client.execute_command('TOPK.RESERVE key 5 50 4 0.9 SEED 42') == b'OK'
+        self.verify_topk_metrics(self.client.execute_command("INFO bf"), DEFAULT_TOPK_SIZE, 1, 0, 5)
+
+        # TOPK.ADD counts +1 per item. Three items -> num_items = 3.
+        self.client.execute_command('TOPK.ADD key apple banana cherry')
+        self.verify_topk_metrics(self.client.execute_command("INFO bf"), DEFAULT_TOPK_SIZE, 1, 3, 5)
+
+        # TOPK.INCRBY counts += increment. +5 and +4 -> num_items = 3 + 9 = 12.
+        self.client.execute_command('TOPK.INCRBY key apple 5 banana 4')
+        self.verify_topk_metrics(self.client.execute_command("INFO bf"), DEFAULT_TOPK_SIZE, 1, 12, 5)
+
+        # Read-only commands must not move any gauge.
+        self.client.execute_command('TOPK.QUERY key apple missing')
+        self.client.execute_command('TOPK.COUNT key apple')
+        self.client.execute_command('TOPK.LIST key')
+        self.client.execute_command('TOPK.INFO key')
+        self.verify_topk_metrics(self.client.execute_command("INFO bf"), DEFAULT_TOPK_SIZE, 1, 12, 5)
+
+        # A second object (k=4) adds to num_objects, memory, and sum_k (5 + 4 = 9).
+        assert self.client.execute_command('TOPK.RESERVE key2 4 50 4 0.9 SEED 42') == b'OK'
+        self.client.execute_command('TOPK.ADD key2 x y')
+        self.verify_topk_metrics(self.client.execute_command("INFO bf"), DEFAULT_TOPK_SIZE * 2, 2, 14, 9)
+
+        # Deleting a key removes its full contribution (memory, k=4, its 2 items).
+        self.client.execute_command('DEL key2')
+        self.verify_topk_metrics(self.client.execute_command("INFO bf"), DEFAULT_TOPK_SIZE, 1, 12, 5)
+
+        # FLUSHDB drops everything; all gauges return to 0.
+        self.client.execute_command('FLUSHDB')
+        wait_for_equal(lambda: self.client.execute_command('DBSIZE'), 0)
+        self.verify_topk_metrics(self.client.execute_command("INFO bf"), 0, 0, 0, 0)
+        self.verify_topk_metrics(self.client.execute_command("INFO Modules"), 0, 0, 0, 0)

--- a/tests/test_topk_metrics.py
+++ b/tests/test_topk_metrics.py
@@ -16,10 +16,12 @@ class TestTopkMetrics(ValkeyBloomTestCaseBase):
 
         # TOPK.ADD counts +1 per item. Three items -> num_items = 3.
         self.client.execute_command('TOPK.ADD key apple banana cherry')
+        key_size = self.client.execute_command('TOPK.INFO key')[9]
         self.verify_topk_metrics(self.client.execute_command("INFO bf"), key_size, 1, 3, 5)
 
         # TOPK.INCRBY counts += increment. +5 and +4 -> num_items = 3 + 9 = 12.
         self.client.execute_command('TOPK.INCRBY key apple 5 banana 4')
+        key_size = self.client.execute_command('TOPK.INFO key')[9]
         self.verify_topk_metrics(self.client.execute_command("INFO bf"), key_size, 1, 12, 5)
 
         # Read-only commands must not move any gauge.
@@ -32,8 +34,8 @@ class TestTopkMetrics(ValkeyBloomTestCaseBase):
         # A second object (k=4) adds to num_objects, memory, and sum_k (5 + 4 = 9).
         # The gauge must equal the sum of both objects' reported sizes.
         assert self.client.execute_command('TOPK.RESERVE key2 4 50 4 0.9 SEED 42') == b'OK'
-        key2_size = self.client.execute_command('TOPK.INFO key2')[9]
         self.client.execute_command('TOPK.ADD key2 x y')
+        key2_size = self.client.execute_command('TOPK.INFO key2')[9]
         self.verify_topk_metrics(self.client.execute_command("INFO bf"), key_size + key2_size, 2, 14, 9)
 
         # Deleting a key removes its full contribution (memory, k=4, its 2 items).

--- a/tests/test_topk_metrics.py
+++ b/tests/test_topk_metrics.py
@@ -47,3 +47,26 @@ class TestTopkMetrics(ValkeyBloomTestCaseBase):
         wait_for_equal(lambda: self.client.execute_command('DBSIZE'), 0)
         self.verify_topk_metrics(self.client.execute_command("INFO bf"), 0, 0, 0, 0)
         self.verify_topk_metrics(self.client.execute_command("INFO Modules"), 0, 0, 0, 0)
+
+    def test_copy_metrics(self):
+        # Reserve a TopK (k=5), add 3 items, then increment by 5 -> num_items = 8.
+        assert self.client.execute_command('TOPK.RESERVE orig 5 50 4 0.9 SEED 42') == b'OK'
+        self.client.execute_command('TOPK.ADD orig apple banana cherry')
+        self.client.execute_command('TOPK.INCRBY orig apple 5')
+        self.verify_topk_metrics(self.client.execute_command("INFO bf"), DEFAULT_TOPK_SIZE, 1, 8, 5)
+
+        # Deep copy
+        assert self.client.execute_command('COPY orig copied') == 1
+        self.verify_topk_metrics(self.client.execute_command("INFO bf"), DEFAULT_TOPK_SIZE * 2, 2, 16, 10)
+
+        # The copy holds the same Top-K members as the source.
+        assert self.client.execute_command('TOPK.LIST orig') == self.client.execute_command('TOPK.LIST copied')
+
+        # Deleting the source leaves the copy's contribution intact.
+        self.client.execute_command('DEL orig')
+        self.verify_topk_metrics(self.client.execute_command("INFO bf"), DEFAULT_TOPK_SIZE, 1, 8, 5)
+
+        # Perform a FLUSHALL which should set all metrics data to 0
+        self.client.execute_command('FLUSHALL')
+        wait_for_equal(lambda: self.client.execute_command('DBSIZE'), 0)
+        self.verify_topk_metrics(self.client.execute_command("INFO bf"), 0, 0, 0, 0)

--- a/tests/test_topk_metrics.py
+++ b/tests/test_topk_metrics.py
@@ -2,11 +2,6 @@ from valkey_bloom_test_case import ValkeyBloomTestCaseBase
 from valkeytestframework.conftest import resource_port_tracker  # noqa: F401
 from valkeytestframework.util.waiters import *
 
-# Placeholder per-object memory: size_of::<TopKObject>(), excluding the sketch
-# heap, so it is fixed regardless of k/width/depth.
-DEFAULT_TOPK_SIZE = 360
-
-
 class TestTopkMetrics(ValkeyBloomTestCaseBase):
 
     def test_basic_command_metrics(self):
@@ -16,31 +11,34 @@ class TestTopkMetrics(ValkeyBloomTestCaseBase):
 
         # Reserve a TopK (k=5). One object, no items yet, sum_k = 5.
         assert self.client.execute_command('TOPK.RESERVE key 5 50 4 0.9 SEED 42') == b'OK'
-        self.verify_topk_metrics(self.client.execute_command("INFO bf"), DEFAULT_TOPK_SIZE, 1, 0, 5)
+        key_size = self.client.execute_command('TOPK.INFO key')[9]
+        self.verify_topk_metrics(self.client.execute_command("INFO bf"), key_size, 1, 0, 5)
 
         # TOPK.ADD counts +1 per item. Three items -> num_items = 3.
         self.client.execute_command('TOPK.ADD key apple banana cherry')
-        self.verify_topk_metrics(self.client.execute_command("INFO bf"), DEFAULT_TOPK_SIZE, 1, 3, 5)
+        self.verify_topk_metrics(self.client.execute_command("INFO bf"), key_size, 1, 3, 5)
 
         # TOPK.INCRBY counts += increment. +5 and +4 -> num_items = 3 + 9 = 12.
         self.client.execute_command('TOPK.INCRBY key apple 5 banana 4')
-        self.verify_topk_metrics(self.client.execute_command("INFO bf"), DEFAULT_TOPK_SIZE, 1, 12, 5)
+        self.verify_topk_metrics(self.client.execute_command("INFO bf"), key_size, 1, 12, 5)
 
         # Read-only commands must not move any gauge.
         self.client.execute_command('TOPK.QUERY key apple missing')
         self.client.execute_command('TOPK.COUNT key apple')
         self.client.execute_command('TOPK.LIST key')
         self.client.execute_command('TOPK.INFO key')
-        self.verify_topk_metrics(self.client.execute_command("INFO bf"), DEFAULT_TOPK_SIZE, 1, 12, 5)
+        self.verify_topk_metrics(self.client.execute_command("INFO bf"), key_size, 1, 12, 5)
 
         # A second object (k=4) adds to num_objects, memory, and sum_k (5 + 4 = 9).
+        # The gauge must equal the sum of both objects' reported sizes.
         assert self.client.execute_command('TOPK.RESERVE key2 4 50 4 0.9 SEED 42') == b'OK'
+        key2_size = self.client.execute_command('TOPK.INFO key2')[9]
         self.client.execute_command('TOPK.ADD key2 x y')
-        self.verify_topk_metrics(self.client.execute_command("INFO bf"), DEFAULT_TOPK_SIZE * 2, 2, 14, 9)
+        self.verify_topk_metrics(self.client.execute_command("INFO bf"), key_size + key2_size, 2, 14, 9)
 
         # Deleting a key removes its full contribution (memory, k=4, its 2 items).
         self.client.execute_command('DEL key2')
-        self.verify_topk_metrics(self.client.execute_command("INFO bf"), DEFAULT_TOPK_SIZE, 1, 12, 5)
+        self.verify_topk_metrics(self.client.execute_command("INFO bf"), key_size, 1, 12, 5)
 
         # FLUSHDB drops everything; all gauges return to 0.
         self.client.execute_command('FLUSHDB')
@@ -53,18 +51,20 @@ class TestTopkMetrics(ValkeyBloomTestCaseBase):
         assert self.client.execute_command('TOPK.RESERVE orig 5 50 4 0.9 SEED 42') == b'OK'
         self.client.execute_command('TOPK.ADD orig apple banana cherry')
         self.client.execute_command('TOPK.INCRBY orig apple 5')
-        self.verify_topk_metrics(self.client.execute_command("INFO bf"), DEFAULT_TOPK_SIZE, 1, 8, 5)
+        orig_size = self.client.execute_command('TOPK.INFO orig')[9]
+        self.verify_topk_metrics(self.client.execute_command("INFO bf"), orig_size, 1, 8, 5)
 
         # Deep copy
         assert self.client.execute_command('COPY orig copied') == 1
-        self.verify_topk_metrics(self.client.execute_command("INFO bf"), DEFAULT_TOPK_SIZE * 2, 2, 16, 10)
+        copied_size = self.client.execute_command('TOPK.INFO copied')[9]
+        self.verify_topk_metrics(self.client.execute_command("INFO bf"), orig_size + copied_size, 2, 16, 10)
 
         # The copy holds the same Top-K members as the source.
         assert self.client.execute_command('TOPK.LIST orig') == self.client.execute_command('TOPK.LIST copied')
 
-        # Deleting the source leaves the copy's contribution intact.
+        # Deleting the source removes exactly its contribution; the copy stays.
         self.client.execute_command('DEL orig')
-        self.verify_topk_metrics(self.client.execute_command("INFO bf"), DEFAULT_TOPK_SIZE, 1, 8, 5)
+        self.verify_topk_metrics(self.client.execute_command("INFO bf"), copied_size, 1, 8, 5)
 
         # Perform a FLUSHALL which should set all metrics data to 0
         self.client.execute_command('FLUSHALL')

--- a/tests/valkey_bloom_test_case.py
+++ b/tests/valkey_bloom_test_case.py
@@ -269,6 +269,37 @@ class ValkeyBloomTestCaseBase(ValkeyTestCase):
         assert num_items == expected_num_items
         assert sum_capacity == expected_sum_capacity
 
+    def verify_topk_metrics(self, info_response, expected_memory, expected_num_objects, expected_num_items, expected_sum_k):
+        """
+            Verify the TopK metric values are recorded properly:
+            expected_memory: total bytes used by all TopK objects. Memory is
+                currently a placeholder: a fixed size_of::<TopKObject>() per
+                object (DEFAULT_TOPK_SIZE), not including the sketch heap.
+            expected_num_objects: number of TopK keys
+            expected_num_items: total increments applied across all objects (ADD = +1, INCRBY = +increment)
+            expected_sum_k: sum of k across all objects
+        """
+        response_str = info_response.decode('utf-8')
+        lines = response_str.split('\r\n')
+        total_memory_bytes = -1
+        num_objects = -1
+        num_items = -1
+        sum_k = -1
+        for line in lines:
+            if line.startswith('bf_topk_total_memory_bytes:'):
+                total_memory_bytes = int(line.split(':')[1])
+            elif line.startswith('bf_topk_num_objects:'):
+                num_objects = int(line.split(':')[1])
+            elif line.startswith('bf_topk_num_items_across_objects:'):
+                num_items = int(line.split(':')[1])
+            elif line.startswith('bf_topk_sum_k_across_objects:'):
+                sum_k = int(line.split(':')[1])
+
+        assert total_memory_bytes == expected_memory
+        assert num_objects == expected_num_objects
+        assert num_items == expected_num_items
+        assert sum_k == expected_sum_k
+
     """
     This method will parse the return of an INFO command and return a python dict where each metric is a key value pair.
     We can pass in specific sections in order to not have the dict store irrelevant fields related to what we want to check.

--- a/tests/valkey_bloom_test_case.py
+++ b/tests/valkey_bloom_test_case.py
@@ -290,7 +290,7 @@ class ValkeyBloomTestCaseBase(ValkeyTestCase):
                 total_memory_bytes = int(line.split(':')[1])
             elif line.startswith('bf_topk_num_objects:'):
                 num_objects = int(line.split(':')[1])
-            elif line.startswith('bf_topk_num_items_across_objects:'):
+            elif line.startswith('bf_topk_total_items_added_across_objects:'):
                 num_items = int(line.split(':')[1])
             elif line.startswith('bf_topk_sum_k_across_objects:'):
                 sum_k = int(line.split(':')[1])


### PR DESCRIPTION
## Summary

Builds on the existing TopK commands by adding observability metrics, making the `COPY` command produce a true deep copy, and broadening integration test coverage.

## Changes

### Metrics
- Expose four TopK metrics in a new `topk_core_metrics` INFO section:
  - `topk_total_memory_bytes` – total bytes across all TopK objects
  - `topk_num_objects` – number of TopK keys
  - `topk_num_items_across_objects` – total increments (ADD = +1, INCRBY = +increment)
  - `topk_sum_k_across_objects` – sum of `k` across all objects
- Metrics are incremented on object create / item add and decremented on `Drop`, so deleting a key removes its full contribution.

### Deep-copy COPY
- `TopKObject::create_copy_from` now clones the sketch contents (heavy/lobby cells and priority queue) and carries over the running item count.
- Requires `Clone` on the upstream `CuckooTopK`.

### Memory tracking
- `topk_total_memory_bytes`, `MEMORY USAGE`, and the new `TOPK.INFO` `size` field all derive from one source: `TopKObject::memory_usage()` = `size_of::<TopKObject>()` + the sketch's reported heap usage.

- **Before:** we used the upstream crate's `mem_bytes()`, which counts the sketch's container allocations (lobby/heavy cell arrays, decay-threshold table, priority-queue containers) but only `size_of::<T>()` for each tracked item. Since our items are `Vec<u8>`, that counts the 24-byte vector header but **not the bytes each item points to**, so a sketch tracking short items and one tracking long items reported the same size. This was the largest source of under-counting, and it grew with item length and `k` (up to ~16% in measurements below).

- **After:** the upstream crate now exposes `mem_bytes_with(|item| ...)`, which takes a closure for the per-item heap size. Since our `T` is fixed to `Vec<u8>`, we pass `|item| item.capacity()`, so the variable-length item contents are now counted. This drops the under-count to ~1–4%.

- **Why it is still an estimate:** the remaining gap is the priority queue's `HashMap`. Std's `HashMap` is hashbrown under the hood, but hashbrown does not expose its real allocation size as public API. We could model it exactly (bucket count = `next_power_of_two(capacity * 8 / 7)` plus the control-byte region) and hit 100% accuracy vs dhat — but that hardcodes hashbrown internals (the 7/8 load factor, the 16-byte SSE2 group width) that aren't part of any public contract, so it would break silently on other platforms or if std changes its implementation.

To quantify both estimates, I used [dhat](https://docs.rs/dhat) as the global allocator and compared its live-heap bytes against the sketch's reported usage, varying one dimension at a time off a baseline (`Vec<u8>` items, depth=4, decay=0.9, 200k distinct items):

| Config | `mem_bytes()` | dhat actual | Under-count | `mem_bytes_with()` | Under-count |
|---|--:|--:|--:|--:|--:|
| baseline (k=1k, w=8k, item=12) | 793,048 B | 827,560 B | +34,512 B (+4.2%) | 817,048 B | +10,512 B (+1.3%) |
| long items (item=32) | 793,048 B | 867,560 B | +74,512 B (+8.6%) | 857,048 B | +10,512 B (+1.2%) |
| long items (item=64) | 793,048 B | 931,560 B | +138,512 B (+14.9%) | 921,048 B | +10,512 B (+1.1%) |
| large k (k=10k) | 1,811,352 B | 2,135,336 B | +323,984 B (+15.2%) | 2,051,352 B | +83,984 B (+3.9%) |
| large k (k=50k) | 5,814,680 B | 6,951,856 B | +1,137,176 B (+16.4%) | 6,615,968 B | +335,888 B (+4.8%) |
| small width (w=1k) | 219,608 B | 254,120 B | +34,512 B (+13.6%) | 243,608 B | +10,512 B (+4.1%) |
| large width (w=64k) | 5,380,568 B | 5,415,080 B | +34,512 B (+0.6%) | 5,404,568 B | +10,512 B (+0.2%) |

`mem_bytes()`'s under-count grows with item length and `k`, since neither is reflected in `size_of::<T>()`. `mem_bytes_with()` removes the item-length component entirely, only scales with `k` (the `HashMap` rounding described above).

### TOPK.INFO
- Add a `size` field reporting the object's estimated memory in bytes, so per-object memory is observable from the command path. Comes from the same `TopKObject::memory_usage()` described above.

### Tests
- `test_topk_metrics.py`: metric accounting across RESERVE/ADD/INCRBY, read-only commands, DEL, COPY, and FLUSH.
- `test_topk_basic.py`: module load & command registration, data type name/encoding, generic key access, MULTI/EXEC, Lua, DEL/UNLINK/FLUSHALL, expiration, and WRONGTYPE errors.
- `test_topk_command.py`: asserts the `TOPK.INFO` `size` field is positive and within `MEMORY USAGE`.

### TODO: TOPK.ADD/INCRBY overhead

Counting per-item bytes means memory now changes on add, so the add path diffs `memory_usage()` before/after to keep the metric correct because `add_with_evicted` doesn't tell us whether an item was inserted. This makes add O(width·depth + k) ×2 instead of O(1). 
Follow-up: have the upstream `add_with_evicted` report whether an item was inserted  so the gauge can update in O(item bytes) and add stays O(1).

