### PR TITLE
Add TopK RDB save/load support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ valkey-module-macros = "0"
 linkme = "0"
 bloomfilter = { version = "3.0.1", features = ["serde"] }
 # TODO: This is a temporary solution until we add this functionality to the original heavykeeper crate.
-heavykeeper = { git = "https://github.com/detemmienation/heavykeeper-rs.git", branch = "mem" }
+heavykeeper = { git = "https://github.com/detemmienation/heavykeeper-rs.git", branch = "mem-rdb" }
 lazy_static = "1.4.0"
 libc = "0.2"
 serde = { version = "1.0", features = ["derive"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ valkey-module-macros = "0"
 linkme = "0"
 bloomfilter = { version = "3.0.1", features = ["serde"] }
 # TODO: This is a temporary solution until we add this functionality to the original heavykeeper crate.
-heavykeeper = { git = "https://github.com/detemmienation/heavykeeper-rs.git", branch = "rdb" }
+heavykeeper = { git = "https://github.com/detemmienation/heavykeeper-rs.git", branch = "rdb-rng" }
 lazy_static = "1.4.0"
 libc = "0.2"
 serde = { version = "1.0", features = ["derive"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ valkey-module-macros = "0"
 linkme = "0"
 bloomfilter = { version = "3.0.1", features = ["serde"] }
 # TODO: This is a temporary solution until we add this functionality to the original heavykeeper crate.
-heavykeeper = { git = "https://github.com/detemmienation/heavykeeper-rs.git", branch = "mem-rdb" }
+heavykeeper = { git = "https://github.com/detemmienation/heavykeeper-rs.git", branch = "rdb" }
 lazy_static = "1.4.0"
 libc = "0.2"
 serde = { version = "1.0", features = ["derive"] }

--- a/src/topk/command_handler.rs
+++ b/src/topk/command_handler.rs
@@ -255,8 +255,9 @@ pub fn topk_incrby(ctx: &Context, input_args: &[ValkeyString]) -> ValkeyResult {
 /// Syntax:
 ///     TOPK.INFO key
 ///
-/// Returns the number of required items (k), width, depth, decay, and the
-/// estimated memory size (in bytes) of the sketch stored at `key`.
+/// Returns the number of required items (k), width, depth, decay, the
+/// estimated memory size (in bytes), and the total number of items added
+/// (total_items_added) for the sketch stored at `key`.
 pub fn topk_info(ctx: &Context, input_args: &[ValkeyString]) -> ValkeyResult {
     if input_args.len() != 2 {
         return Err(ValkeyError::WrongArity);
@@ -281,6 +282,8 @@ pub fn topk_info(ctx: &Context, input_args: &[ValkeyString]) -> ValkeyResult {
         ValkeyValue::Float(topk.decay()),
         ValkeyValue::SimpleStringStatic("size"),
         ValkeyValue::Integer(topk.memory_usage() as i64),
+        ValkeyValue::SimpleStringStatic("total items added"),
+        ValkeyValue::Integer(topk.num_items() as i64),
     ];
     Ok(ValkeyValue::Array(result))
 }

--- a/src/topk/command_handler.rs
+++ b/src/topk/command_handler.rs
@@ -289,17 +289,17 @@ pub fn topk_info(ctx: &Context, input_args: &[ValkeyString]) -> ValkeyResult {
     }
 
     let result = vec![
-        ValkeyValue::SimpleStringStatic("k"),
+        ValkeyValue::SimpleStringStatic("K"),
         ValkeyValue::Integer(topk.k() as i64),
-        ValkeyValue::SimpleStringStatic("width"),
+        ValkeyValue::SimpleStringStatic("Width"),
         ValkeyValue::Integer(topk.width() as i64),
-        ValkeyValue::SimpleStringStatic("depth"),
+        ValkeyValue::SimpleStringStatic("Depth"),
         ValkeyValue::Integer(topk.depth() as i64),
-        ValkeyValue::SimpleStringStatic("decay"),
+        ValkeyValue::SimpleStringStatic("Decay"),
         ValkeyValue::Float(topk.decay()),
-        ValkeyValue::SimpleStringStatic("size"),
+        ValkeyValue::SimpleStringStatic("Size"),
         ValkeyValue::Integer(topk.memory_usage() as i64),
-        ValkeyValue::SimpleStringStatic("total items added"),
+        ValkeyValue::SimpleStringStatic("Total items added"),
         ValkeyValue::Integer(topk.num_items() as i64),
     ];
     Ok(ValkeyValue::Array(result))

--- a/src/topk/command_handler.rs
+++ b/src/topk/command_handler.rs
@@ -253,13 +253,15 @@ pub fn topk_incrby(ctx: &Context, input_args: &[ValkeyString]) -> ValkeyResult {
 /// Handle TOPK.INFO.
 ///
 /// Syntax:
-///     TOPK.INFO key
+///     TOPK.INFO key [K | WIDTH | DEPTH | DECAY | SIZE | TOTALITEMSADDED]
 ///
-/// Returns the number of required items (k), width, depth, decay, the
-/// estimated memory size (in bytes), and the total number of items added
-/// (total_items_added) for the sketch stored at `key`.
+/// Without a field argument, returns the number of required items (k), width,
+/// depth, decay, the estimated memory size (in bytes), and the total number of
+/// items added for the sketch stored at `key`.
+/// With a field argument, returns only that single value.
 pub fn topk_info(ctx: &Context, input_args: &[ValkeyString]) -> ValkeyResult {
-    if input_args.len() != 2 {
+    let argc = input_args.len();
+    if !(2..=3).contains(&argc) {
         return Err(ValkeyError::WrongArity);
     }
 
@@ -270,6 +272,21 @@ pub fn topk_info(ctx: &Context, input_args: &[ValkeyString]) -> ValkeyResult {
         Ok(None) => return Err(ValkeyError::Str(utils::NOT_FOUND)),
         Err(_) => return Err(ValkeyError::WrongType),
     };
+
+    // A single-field request returns just that value; the full reply emits
+    // every label/value pair in order.
+    if argc == 3 {
+        let value = match input_args[2].to_string_lossy().to_uppercase().as_str() {
+            "K" => ValkeyValue::Integer(topk.k() as i64),
+            "WIDTH" => ValkeyValue::Integer(topk.width() as i64),
+            "DEPTH" => ValkeyValue::Integer(topk.depth() as i64),
+            "DECAY" => ValkeyValue::Float(topk.decay()),
+            "SIZE" => ValkeyValue::Integer(topk.memory_usage() as i64),
+            "TOTALITEMSADDED" => ValkeyValue::Integer(topk.num_items() as i64),
+            _ => return Err(ValkeyError::Str(utils::INVALID_INFO_VALUE)),
+        };
+        return Ok(value);
+    }
 
     let result = vec![
         ValkeyValue::SimpleStringStatic("k"),

--- a/src/topk/data_type.rs
+++ b/src/topk/data_type.rs
@@ -1,10 +1,15 @@
+use crate::topk::utils::{
+    TopKObject, TOPK_DEPTH_MAX, TOPK_DEPTH_MIN, TOPK_K_MAX, TOPK_K_MIN, TOPK_WIDTH_MAX,
+    TOPK_WIDTH_MIN,
+};
 use crate::wrapper::topk_callback;
+use crate::MODULE_NAME;
+use heavykeeper::CuckooTopK;
 use valkey_module::native_types::ValkeyType;
-use valkey_module::raw;
+use valkey_module::{logging, raw};
 
 /// Module data type encoding version for TopK. Bump this whenever the
-/// on-disk layout changes. RDB save/load callbacks are intentionally left
-/// `None` until TOPK.ADD lands and we can round-trip sketch contents.
+/// on-disk layout changes.
 const TOPK_TYPE_ENCODING_VERSION: i32 = 1;
 
 pub static TOPK_TYPE: ValkeyType = ValkeyType::new(
@@ -12,10 +17,8 @@ pub static TOPK_TYPE: ValkeyType = ValkeyType::new(
     TOPK_TYPE_ENCODING_VERSION,
     raw::RedisModuleTypeMethods {
         version: raw::REDISMODULE_TYPE_METHOD_VERSION as u64,
-        // RDB, AOF, digest, and defrag are wired up alongside TOPK.ADD when
-        // we have sketch contents to persist and a stable layout to walk.
-        rdb_load: None,
-        rdb_save: None,
+        rdb_load: Some(topk_callback::topk_rdb_load),
+        rdb_save: Some(topk_callback::topk_rdb_save),
         aof_rewrite: None,
         digest: None,
 
@@ -38,3 +41,63 @@ pub static TOPK_TYPE: ValkeyType = ValkeyType::new(
         copy2: None,
     },
 );
+
+pub trait ValkeyDataType {
+    fn load_from_rdb(rdb: *mut raw::RedisModuleIO, encver: i32) -> Option<TopKObject>;
+}
+
+impl ValkeyDataType for TopKObject {
+    /// Callback to load and parse RDB data of a TopK item and create it.
+    fn load_from_rdb(rdb: *mut raw::RedisModuleIO, encver: i32) -> Option<TopKObject> {
+        if encver > TOPK_TYPE_ENCODING_VERSION {
+            logging::log_warning(format!("{}: Cannot load topk-type data type of version {} because it is greater than the loaded module's topk-type supported version {}", MODULE_NAME, encver, TOPK_TYPE_ENCODING_VERSION).as_str());
+            return None;
+        }
+        let Ok(seed) = raw::load_unsigned(rdb) else {
+            return None;
+        };
+        let Ok(num_items) = raw::load_unsigned(rdb) else {
+            return None;
+        };
+        let Ok(sketch_bytes) = raw::load_string_buffer(rdb) else {
+            return None;
+        };
+        let sketch = match CuckooTopK::<Vec<u8>>::from_bytes(sketch_bytes.as_ref(), seed) {
+            Ok(sketch) => sketch,
+            Err(err) => {
+                logging::log_warning(format!("Failed to restore topk object: {}", err).as_str());
+                return None;
+            }
+        };
+        let k = sketch.top_items() as u64;
+        let width = sketch.width() as u64;
+        let depth = sketch.depth() as u64;
+        if !(TOPK_K_MIN as u64..=TOPK_K_MAX as u64).contains(&k) {
+            logging::log_warning("Failed to restore topk object: k out of range");
+            return None;
+        }
+        if !(TOPK_WIDTH_MIN as u64..=TOPK_WIDTH_MAX as u64).contains(&width) {
+            logging::log_warning("Failed to restore topk object: width out of range");
+            return None;
+        }
+        if !(TOPK_DEPTH_MIN as u64..=TOPK_DEPTH_MAX as u64).contains(&depth) {
+            logging::log_warning("Failed to restore topk object: depth out of range");
+            return None;
+        }
+        let decay = sketch.decay();
+        if !(decay > 0.0 && decay < 1.0) {
+            logging::log_warning("Failed to restore topk object: decay out of range");
+            return None;
+        }
+        let item = TopKObject::from_existing(
+            k as u32,
+            width as u32,
+            depth as u32,
+            decay,
+            seed,
+            sketch,
+            num_items,
+        );
+        Some(item)
+    }
+}

--- a/src/topk/data_type.rs
+++ b/src/topk/data_type.rs
@@ -5,6 +5,7 @@ use crate::topk::utils::{
 use crate::wrapper::topk_callback;
 use crate::MODULE_NAME;
 use heavykeeper::CuckooTopK;
+use valkey_module::digest::Digest;
 use valkey_module::native_types::ValkeyType;
 use valkey_module::{logging, raw};
 
@@ -20,7 +21,7 @@ pub static TOPK_TYPE: ValkeyType = ValkeyType::new(
         rdb_load: Some(topk_callback::topk_rdb_load),
         rdb_save: Some(topk_callback::topk_rdb_save),
         aof_rewrite: None,
-        digest: None,
+        digest: Some(topk_callback::topk_digest),
 
         mem_usage: Some(topk_callback::topk_mem_usage),
         free: Some(topk_callback::topk_free),
@@ -44,6 +45,7 @@ pub static TOPK_TYPE: ValkeyType = ValkeyType::new(
 
 pub trait ValkeyDataType {
     fn load_from_rdb(rdb: *mut raw::RedisModuleIO, encver: i32) -> Option<TopKObject>;
+    fn debug_digest(&self, dig: Digest);
 }
 
 impl ValkeyDataType for TopKObject {
@@ -99,5 +101,13 @@ impl ValkeyDataType for TopKObject {
             num_items,
         );
         Some(item)
+    }
+
+    /// Function that is used to generate a digest on the Topk Object.
+    fn debug_digest(&self, mut dig: Digest) {
+        dig.add_long_long(self.seed() as i64);
+        dig.add_long_long(self.num_items() as i64);
+        dig.add_string_buffer(&self.sketch().to_bytes());
+        dig.end_sequence();
     }
 }

--- a/src/topk/utils.rs
+++ b/src/topk/utils.rs
@@ -157,20 +157,15 @@ impl TopKObject {
         let delta = new_num_items - self.num_items;
         self.num_items = new_num_items;
         metrics::TOPK_TOTAL_ITEMS_ADDED_ACROSS_OBJECTS.fetch_add(delta, Ordering::Relaxed);
-        // Diffing memory_usage() before/after makes this O(width·depth + k) ×2
-        // instead of O(1).
-        // TODO: have upstream add_with_evicted report whether an item was
-        // inserted (or the memory delta) so we can update the gauge in
-        // O(item bytes) and keep add O(1).
-        let mem_before = self.memory_usage();
-        let evicted = self.sketch.add_with_evicted(item, increment);
-        let mem_after = self.memory_usage();
-        if mem_after >= mem_before {
+        let (evicted, inserted) = self.sketch.add_with_evicted(item, increment);
+        let added = if inserted { item.len() } else { 0 };
+        let removed = evicted.as_ref().map_or(0, Vec::len);
+        if added >= removed {
             metrics::TOPK_OBJECT_TOTAL_MEMORY_BYTES
-                .fetch_add(mem_after - mem_before, Ordering::Relaxed);
+                .fetch_add(2 * (added - removed), Ordering::Relaxed);
         } else {
             metrics::TOPK_OBJECT_TOTAL_MEMORY_BYTES
-                .fetch_sub(mem_before - mem_after, Ordering::Relaxed);
+                .fetch_sub(2 * (removed - added), Ordering::Relaxed);
         }
         evicted
     }

--- a/src/topk/utils.rs
+++ b/src/topk/utils.rs
@@ -111,7 +111,7 @@ impl TopKObject {
     /// (cell arrays, decay table, priority queue) + per-item buffer capacity.
     /// The remaining undercount is allocator overhead and HashMap metadata.
     pub fn memory_usage(&self) -> usize {
-        std::mem::size_of::<TopKObject>() + self.sketch.mem_bytes_with(|item| item.capacity())
+        std::mem::size_of::<TopKObject>() + self.sketch.mem_bytes(|item| item.capacity())
     }
 
     /// Increments metrics related to object count, memory, and summed k upon creation of a new object.

--- a/src/topk/utils.rs
+++ b/src/topk/utils.rs
@@ -161,6 +161,8 @@ impl TopKObject {
         let (evicted, inserted) = self.sketch.add_with_evicted(item, increment);
         let added = if inserted { item.len() } else { 0 };
         let removed = evicted.as_ref().map_or(0, Vec::len);
+        // The priority queue stores each item's bytes twice (HashMap key +
+        // item_store), so scale the byte delta by 2.
         if added >= removed {
             metrics::TOPK_OBJECT_TOTAL_MEMORY_BYTES
                 .fetch_add(2 * (added - removed), Ordering::Relaxed);

--- a/src/topk/utils.rs
+++ b/src/topk/utils.rs
@@ -67,6 +67,29 @@ impl TopKObject {
         topk
     }
 
+    /// Create a new TopK object from existing data.
+    pub fn from_existing(
+        k: u32,
+        width: u32,
+        depth: u32,
+        decay: f64,
+        seed: u64,
+        sketch: CuckooTopK<Vec<u8>>,
+        num_items: u64,
+    ) -> TopKObject {
+        let topk = TopKObject {
+            k,
+            width,
+            depth,
+            decay,
+            seed,
+            sketch,
+            num_items,
+        };
+        topk.topk_object_incr_metrics_on_new_create();
+        topk
+    }
+
     /// Build a deep copy of `src` for the COPY command. Clones the sketch
     /// contents (heavy/lobby cells and priority queue) and carries over the
     /// running item count.
@@ -113,6 +136,9 @@ impl TopKObject {
     }
     pub fn seed(&self) -> u64 {
         self.seed
+    }
+    pub fn num_items(&self) -> u64 {
+        self.num_items
     }
     pub fn sketch(&self) -> &CuckooTopK<Vec<u8>> {
         &self.sketch

--- a/src/topk/utils.rs
+++ b/src/topk/utils.rs
@@ -24,6 +24,7 @@ pub const TOPK_DEPTH_MAX: u32 = u32::MAX;
 /// Client Errors
 pub const ERROR: &str = "ERROR";
 pub const NOT_FOUND: &str = "ERR TopK: key does not exist";
+pub const INVALID_INFO_VALUE: &str = "ERR invalid information value";
 pub const KEY_EXISTS: &str = "BUSYKEY Target key name already exists.";
 pub const BAD_TOPK: &str = "ERR bad topk";
 pub const BAD_WIDTH: &str = "ERR bad width";

--- a/src/wrapper/topk_callback.rs
+++ b/src/wrapper/topk_callback.rs
@@ -1,6 +1,29 @@
+use crate::topk::data_type::ValkeyDataType;
 use crate::topk::utils::TopKObject;
-use std::os::raw::c_void;
+use std::os::raw::{c_int, c_void};
+use std::ptr::null_mut;
+use valkey_module::logging;
+use valkey_module::raw;
 use valkey_module::RedisModuleString;
+
+/// # Safety
+pub unsafe extern "C" fn topk_rdb_save(rdb: *mut raw::RedisModuleIO, value: *mut c_void) {
+    let v = &*value.cast::<TopKObject>();
+    raw::save_unsigned(rdb, v.seed());
+    raw::save_unsigned(rdb, v.num_items());
+    raw::save_slice(rdb, &v.sketch().to_bytes());
+}
+
+/// # Safety
+pub unsafe extern "C" fn topk_rdb_load(rdb: *mut raw::RedisModuleIO, encver: c_int) -> *mut c_void {
+    if let Some(item) = <TopKObject as ValkeyDataType>::load_from_rdb(rdb, encver) {
+        let bb = Box::new(item);
+        Box::into_raw(bb).cast::<libc::c_void>()
+    } else {
+        logging::log_warning("Failed to restore topk object.");
+        null_mut()
+    }
+}
 
 /// # Safety
 /// Drop the TopKObject when its key is deleted or replaced.

--- a/src/wrapper/topk_callback.rs
+++ b/src/wrapper/topk_callback.rs
@@ -2,6 +2,7 @@ use crate::topk::data_type::ValkeyDataType;
 use crate::topk::utils::TopKObject;
 use std::os::raw::{c_int, c_void};
 use std::ptr::null_mut;
+use valkey_module::digest::Digest;
 use valkey_module::logging;
 use valkey_module::raw;
 use valkey_module::RedisModuleString;
@@ -54,6 +55,14 @@ pub unsafe extern "C" fn topk_copy(
     let new_item = TopKObject::create_copy_from(curr);
     let bb = Box::new(new_item);
     Box::into_raw(bb).cast::<libc::c_void>()
+}
+
+/// # Safety
+/// Raw handler for the TopK digest callback.
+pub unsafe extern "C" fn topk_digest(md: *mut raw::RedisModuleDigest, value: *mut c_void) {
+    let dig = Digest::new(md);
+    let val = &*(value.cast::<TopKObject>());
+    val.debug_digest(dig);
 }
 
 /// # Safety

--- a/tests/test_bloom_replication.py
+++ b/tests/test_bloom_replication.py
@@ -2,6 +2,7 @@ import pytest, os
 from valkey import ResponseError
 from valkeytestframework.valkey_test_case import ReplicationTestCase
 from valkeytestframework.conftest import resource_port_tracker
+from valkey_bloom_test_case import setup_replication_servers
 
 class TestBloomReplication(ReplicationTestCase):
 
@@ -10,33 +11,7 @@ class TestBloomReplication(ReplicationTestCase):
 
     @pytest.fixture(autouse=True)
     def setup_test(self, setup):
-        use_external = os.environ.get("VALKEY_EXTERNAL_SERVER", "false").lower() == "true"
-        
-        if use_external:
-            master_host = os.environ.get("VALKEY_HOST", "localhost")
-            master_port = int(os.environ.get("VALKEY_PORT", "6379"))
-            self.server, self.client = self.create_server(
-                testdir=self.testdir,
-                bind_ip=master_host,
-                port=master_port,
-                external_server=True
-            )
-            
-            replica_host = os.environ.get("VALKEY_REPLICA_HOST", "localhost")
-            replica_port = int(os.environ.get("VALKEY_REPLICA_PORT", "6380"))
-            replica_server, replica_client = self.create_server(
-                testdir=self.testdir,
-                bind_ip=replica_host,
-                port=replica_port,
-                external_server=True
-            )
-            
-            self.replicas = [replica_server]
-            self.num_replicas = 1
-        else:
-            self.args = {"enable-debug-command":"yes", 'loadmodule': os.getenv('MODULE_PATH'),'bf.bloom-use-random-seed': self.use_random_seed}
-            server_path = f"{os.path.dirname(os.path.realpath(__file__))}/build/binaries/{os.environ['SERVER_VERSION']}/valkey-server"
-            self.server, self.client = self.create_server(testdir = self.testdir,  server_path=server_path, args=self.args)
+        setup_replication_servers(self, self.use_random_seed)
 
     @pytest.fixture(autouse=True)
     def use_random_seed_fixture(self, bloom_config_parameterization):

--- a/tests/test_topk_acl_category.py
+++ b/tests/test_topk_acl_category.py
@@ -1,8 +1,8 @@
 from valkeytestframework.conftest import resource_port_tracker
-from valkey_bloom_test_case import ValkeyBloomTestCaseBase
+from valkey_bloom_test_case import TopkFixedSeedMixin, ValkeyBloomTestCaseBase
 from valkeytestframework.util.waiters import *
 
-class TestTopkACLCategory(ValkeyBloomTestCaseBase):
+class TestTopkACLCategory(TopkFixedSeedMixin, ValkeyBloomTestCaseBase):
 
     def test_topk_acl_category_permissions(self):
         # List of topk commands and the expected returns if the command is valid.

--- a/tests/test_topk_acl_category.py
+++ b/tests/test_topk_acl_category.py
@@ -13,7 +13,7 @@ class TestTopkACLCategory(ValkeyBloomTestCaseBase):
             ('TOPK.QUERY reserve_key item', [1]),
             ('TOPK.COUNT reserve_key item', [6]),
             ('TOPK.LIST reserve_key', [b'item']),
-            ('TOPK.INFO reserve_key', 10),
+            ('TOPK.INFO reserve_key', 12),
         ]
         client = self.server.get_new_client()
         # Get a list of all commands with the acl category topk

--- a/tests/test_topk_acl_category.py
+++ b/tests/test_topk_acl_category.py
@@ -1,8 +1,8 @@
 from valkeytestframework.conftest import resource_port_tracker
-from valkey_bloom_test_case import TopkFixedSeedMixin, ValkeyBloomTestCaseBase
+from valkey_bloom_test_case import SkipSeedParameterizationMixin, ValkeyBloomTestCaseBase
 from valkeytestframework.util.waiters import *
 
-class TestTopkACLCategory(TopkFixedSeedMixin, ValkeyBloomTestCaseBase):
+class TestTopkACLCategory(SkipSeedParameterizationMixin, ValkeyBloomTestCaseBase):
 
     def test_topk_acl_category_permissions(self):
         # List of topk commands and the expected returns if the command is valid.

--- a/tests/test_topk_basic.py
+++ b/tests/test_topk_basic.py
@@ -23,15 +23,24 @@ class TestTopkBasic(ValkeyBloomTestCaseBase):
         assert client.execute_command('TOPK.QUERY tk apple') == [1]
         assert client.execute_command('TOPK.QUERY tk missing') == [0]
 
-    def test_copy(self):
+    def test_copy_and_exists_cmd(self):
         client = self.server.get_new_client()
         assert client.execute_command('TOPK.RESERVE tk 3 50 4 0.9 SEED 42') == b'OK'
         client.execute_command('TOPK.INCRBY tk apple 5 banana 3 cherry 1')
+        # cmd debug digest
+        server_digest = client.execute_command('DEBUG', 'DIGEST')
+        assert server_digest != None or 0000000000000000000000000000000000000000
+        object_digest = client.execute_command('DEBUG DIGEST-VALUE tk')
         # COPY is a deep copy
         assert client.execute_command('COPY tk tk_copy') == 1
+        copied_server_digest = client.execute_command('DEBUG', 'DIGEST')
+        assert copied_server_digest != None or 0000000000000000000000000000000000000000
+        copied_object_digest = client.execute_command('DEBUG DIGEST-VALUE tk_copy')
         assert client.execute_command('EXISTS tk_copy') == 1
         assert client.execute_command('TOPK.LIST tk') == client.execute_command('TOPK.LIST tk_copy')
         assert client.execute_command('TOPK.LIST tk WITHCOUNT') == client.execute_command('TOPK.LIST tk_copy WITHCOUNT')
+        assert server_digest != copied_server_digest
+        assert copied_object_digest == object_digest
 
         for cmd in [
             'TOPK.ADD tk date',
@@ -54,6 +63,8 @@ class TestTopkBasic(ValkeyBloomTestCaseBase):
         before = client.execute_command('TOPK.LIST tk WITHCOUNT')
         client.execute_command('TOPK.INCRBY tk_copy grape 100')
         assert client.execute_command('TOPK.LIST tk WITHCOUNT') == before
+        assert client.execute_command('DEBUG DIGEST-VALUE tk_copy') != \
+            client.execute_command('DEBUG DIGEST-VALUE tk')
 
     def test_module_data_type(self):
         # Validate the name of the Module data type and its encoding.

--- a/tests/test_topk_basic.py
+++ b/tests/test_topk_basic.py
@@ -2,10 +2,10 @@ import time
 from valkeytestframework.util.waiters import *
 from valkey import ResponseError
 from valkeytestframework.conftest import resource_port_tracker  # noqa: F401
-from valkey_bloom_test_case import ValkeyBloomTestCaseBase
+from valkey_bloom_test_case import TopkFixedSeedMixin, ValkeyBloomTestCaseBase
 
 
-class TestTopkBasic(ValkeyBloomTestCaseBase):
+class TestTopkBasic(TopkFixedSeedMixin, ValkeyBloomTestCaseBase):
 
     def test_basic(self):
         client = self.server.get_new_client()

--- a/tests/test_topk_basic.py
+++ b/tests/test_topk_basic.py
@@ -2,10 +2,10 @@ import time
 from valkeytestframework.util.waiters import *
 from valkey import ResponseError
 from valkeytestframework.conftest import resource_port_tracker  # noqa: F401
-from valkey_bloom_test_case import TopkFixedSeedMixin, ValkeyBloomTestCaseBase
+from valkey_bloom_test_case import SkipSeedParameterizationMixin, ValkeyBloomTestCaseBase
 
 
-class TestTopkBasic(TopkFixedSeedMixin, ValkeyBloomTestCaseBase):
+class TestTopkBasic(SkipSeedParameterizationMixin, ValkeyBloomTestCaseBase):
 
     def test_basic(self):
         client = self.server.get_new_client()

--- a/tests/test_topk_command.py
+++ b/tests/test_topk_command.py
@@ -1,7 +1,7 @@
-from valkey_bloom_test_case import ValkeyBloomTestCaseBase
+from valkey_bloom_test_case import TopkFixedSeedMixin, ValkeyBloomTestCaseBase
 from valkeytestframework.conftest import resource_port_tracker  # noqa: F401
 
-class TestTopkCommand(ValkeyBloomTestCaseBase):
+class TestTopkCommand(TopkFixedSeedMixin, ValkeyBloomTestCaseBase):
 
     def test_topk_command_arity(self):
         self.verify_command_arity('TOPK.RESERVE', -1)

--- a/tests/test_topk_command.py
+++ b/tests/test_topk_command.py
@@ -153,6 +153,12 @@ class TestTopkCommand(ValkeyBloomTestCaseBase):
         ]
         for cmd, expected_len in incrby_success_cases:
             assert len(self.client.execute_command(cmd)) == expected_len
+        # Total items added is the sum of every increment
+        tk_incr_total = sum(
+            int(inc)
+            for cmd, _ in incrby_success_cases
+            for inc in cmd.split()[3::2]
+        )
 
         # TOPK.INFO reports k, width, depth, decay, size, and total items added
         # for an existing sketch.
@@ -179,10 +185,8 @@ class TestTopkCommand(ValkeyBloomTestCaseBase):
         assert info[b'Size'] <= self.client.execute_command('MEMORY USAGE tk5')
         assert info[b'Total items added'] == 0
 
-        # tk_incr accumulates every increment:
-        # 1 + (5+3) + (1+2+3) + (7+2) + 1000000 + (2+3) = 1000029.
         info = info_dict('tk_incr')
-        assert info[b'Total items added'] == 1000029
+        assert info[b'Total items added'] == tk_incr_total
 
         # TOPK.INFO key <field> returns just that single value.
         assert self.client.execute_command('TOPK.INFO tk5 K') == 10
@@ -190,7 +194,7 @@ class TestTopkCommand(ValkeyBloomTestCaseBase):
         assert self.client.execute_command('TOPK.INFO tk5 depth') == 5
         assert self.client.execute_command('TOPK.INFO tk5 DECAY') == b'0.5'
         assert self.client.execute_command('TOPK.INFO tk5 SIZE') == info_dict('tk5')[b'Size']
-        assert self.client.execute_command('TOPK.INFO tk_incr TOTALITEMSADDED') == 1000029
+        assert self.client.execute_command('TOPK.INFO tk_incr TOTALITEMSADDED') == tk_incr_total
 
         # TOPK.LIST returns tracked items by descending count, at most k.
         assert self.client.execute_command('TOPK.RESERVE tk_list 3 50 4 0.9 SEED 42') == b'OK'

--- a/tests/test_topk_command.py
+++ b/tests/test_topk_command.py
@@ -161,35 +161,35 @@ class TestTopkCommand(ValkeyBloomTestCaseBase):
             it = iter(raw)
             return dict(zip(it, it))
         info = info_dict('tk1')
-        assert info[b'k'] == 5
-        assert info[b'width'] == 8
-        assert info[b'depth'] == 7
-        assert info[b'decay'] == b'0.9'
-        assert info[b'size'] > 0
-        assert info[b'size'] <= self.client.execute_command('MEMORY USAGE tk1')
+        assert info[b'K'] == 5
+        assert info[b'Width'] == 8
+        assert info[b'Depth'] == 7
+        assert info[b'Decay'] == b'0.9'
+        assert info[b'Size'] > 0
+        assert info[b'Size'] <= self.client.execute_command('MEMORY USAGE tk1')
         # tk1 was re-reserved with no items, so nothing has been added yet.
-        assert info[b'total items added'] == 0
+        assert info[b'Total items added'] == 0
 
         info = info_dict('tk5')
-        assert info[b'k'] == 10
-        assert info[b'width'] == 200
-        assert info[b'depth'] == 5
-        assert info[b'decay'] == b'0.5'
-        assert info[b'size'] > 0
-        assert info[b'size'] <= self.client.execute_command('MEMORY USAGE tk5')
-        assert info[b'total items added'] == 0
+        assert info[b'K'] == 10
+        assert info[b'Width'] == 200
+        assert info[b'Depth'] == 5
+        assert info[b'Decay'] == b'0.5'
+        assert info[b'Size'] > 0
+        assert info[b'Size'] <= self.client.execute_command('MEMORY USAGE tk5')
+        assert info[b'Total items added'] == 0
 
         # tk_incr accumulates every increment:
         # 1 + (5+3) + (1+2+3) + (7+2) + 1000000 + (2+3) = 1000029.
         info = info_dict('tk_incr')
-        assert info[b'total items added'] == 1000029
+        assert info[b'Total items added'] == 1000029
 
         # TOPK.INFO key <field> returns just that single value.
         assert self.client.execute_command('TOPK.INFO tk5 K') == 10
         assert self.client.execute_command('TOPK.INFO tk5 WIDTH') == 200
         assert self.client.execute_command('TOPK.INFO tk5 depth') == 5
         assert self.client.execute_command('TOPK.INFO tk5 DECAY') == b'0.5'
-        assert self.client.execute_command('TOPK.INFO tk5 SIZE') == info_dict('tk5')[b'size']
+        assert self.client.execute_command('TOPK.INFO tk5 SIZE') == info_dict('tk5')[b'Size']
         assert self.client.execute_command('TOPK.INFO tk_incr TOTALITEMSADDED') == 1000029
 
         # TOPK.LIST returns tracked items by descending count, at most k.

--- a/tests/test_topk_command.py
+++ b/tests/test_topk_command.py
@@ -78,9 +78,11 @@ class TestTopkCommand(ValkeyBloomTestCaseBase):
             ('TOPK.INFO missing', 'TopK: key does not exist'),
             # wrong type
             ('TOPK.INFO strkey', 'WRONGTYPE Operation against a key holding the wrong kind of value'),
-            # wrong number of arguments 
+            # an unrecognized field token is rejected.
+            ('TOPK.INFO dup bogus', 'invalid information value'),
+            # wrong number of arguments: key plus at most one field token.
             ('TOPK.INFO', "wrong number of arguments for 'TOPK.INFO' command"),
-            ('TOPK.INFO dup extra', "wrong number of arguments for 'TOPK.INFO' command"),
+            ('TOPK.INFO dup K extra', "wrong number of arguments for 'TOPK.INFO' command"),
             # key must exist.
             ('TOPK.LIST missing', 'TopK: key does not exist'),
             # wrong type
@@ -181,6 +183,14 @@ class TestTopkCommand(ValkeyBloomTestCaseBase):
         # 1 + (5+3) + (1+2+3) + (7+2) + 1000000 + (2+3) = 1000029.
         info = info_dict('tk_incr')
         assert info[b'total items added'] == 1000029
+
+        # TOPK.INFO key <field> returns just that single value.
+        assert self.client.execute_command('TOPK.INFO tk5 K') == 10
+        assert self.client.execute_command('TOPK.INFO tk5 WIDTH') == 200
+        assert self.client.execute_command('TOPK.INFO tk5 depth') == 5
+        assert self.client.execute_command('TOPK.INFO tk5 DECAY') == b'0.5'
+        assert self.client.execute_command('TOPK.INFO tk5 SIZE') == info_dict('tk5')[b'size']
+        assert self.client.execute_command('TOPK.INFO tk_incr TOTALITEMSADDED') == 1000029
 
         # TOPK.LIST returns tracked items by descending count, at most k.
         assert self.client.execute_command('TOPK.RESERVE tk_list 3 50 4 0.9 SEED 42') == b'OK'

--- a/tests/test_topk_command.py
+++ b/tests/test_topk_command.py
@@ -152,7 +152,8 @@ class TestTopkCommand(ValkeyBloomTestCaseBase):
         for cmd, expected_len in incrby_success_cases:
             assert len(self.client.execute_command(cmd)) == expected_len
 
-        # TOPK.INFO reports k, width, depth, decay, and size of an existing sketch.
+        # TOPK.INFO reports k, width, depth, decay, size, and total items added
+        # for an existing sketch.
         def info_dict(key):
             raw = self.client.execute_command(f'TOPK.INFO {key}')
             it = iter(raw)
@@ -164,6 +165,8 @@ class TestTopkCommand(ValkeyBloomTestCaseBase):
         assert info[b'decay'] == b'0.9'
         assert info[b'size'] > 0
         assert info[b'size'] <= self.client.execute_command('MEMORY USAGE tk1')
+        # tk1 was re-reserved with no items, so nothing has been added yet.
+        assert info[b'total items added'] == 0
 
         info = info_dict('tk5')
         assert info[b'k'] == 10
@@ -172,6 +175,12 @@ class TestTopkCommand(ValkeyBloomTestCaseBase):
         assert info[b'decay'] == b'0.5'
         assert info[b'size'] > 0
         assert info[b'size'] <= self.client.execute_command('MEMORY USAGE tk5')
+        assert info[b'total items added'] == 0
+
+        # tk_incr accumulates every increment:
+        # 1 + (5+3) + (1+2+3) + (7+2) + 1000000 + (2+3) = 1000029.
+        info = info_dict('tk_incr')
+        assert info[b'total items added'] == 1000029
 
         # TOPK.LIST returns tracked items by descending count, at most k.
         assert self.client.execute_command('TOPK.RESERVE tk_list 3 50 4 0.9 SEED 42') == b'OK'

--- a/tests/test_topk_command.py
+++ b/tests/test_topk_command.py
@@ -1,7 +1,7 @@
-from valkey_bloom_test_case import TopkFixedSeedMixin, ValkeyBloomTestCaseBase
+from valkey_bloom_test_case import SkipSeedParameterizationMixin, ValkeyBloomTestCaseBase
 from valkeytestframework.conftest import resource_port_tracker  # noqa: F401
 
-class TestTopkCommand(TopkFixedSeedMixin, ValkeyBloomTestCaseBase):
+class TestTopkCommand(SkipSeedParameterizationMixin, ValkeyBloomTestCaseBase):
 
     def test_topk_command_arity(self):
         self.verify_command_arity('TOPK.RESERVE', -1)

--- a/tests/test_topk_keyspace.py
+++ b/tests/test_topk_keyspace.py
@@ -1,7 +1,7 @@
-from valkey_bloom_test_case import TopkFixedSeedMixin, ValkeyBloomTestCaseBase
+from valkey_bloom_test_case import SkipSeedParameterizationMixin, ValkeyBloomTestCaseBase
 from valkeytestframework.conftest import resource_port_tracker
 
-class TestTopkKeyEventNotifications(TopkFixedSeedMixin, ValkeyBloomTestCaseBase):
+class TestTopkKeyEventNotifications(SkipSeedParameterizationMixin, ValkeyBloomTestCaseBase):
 
     def test_keyspace_topk_commands(self):
         self.create_subscribe_clients()

--- a/tests/test_topk_keyspace.py
+++ b/tests/test_topk_keyspace.py
@@ -1,7 +1,7 @@
-from valkey_bloom_test_case import ValkeyBloomTestCaseBase
+from valkey_bloom_test_case import TopkFixedSeedMixin, ValkeyBloomTestCaseBase
 from valkeytestframework.conftest import resource_port_tracker
 
-class TestTopkKeyEventNotifications(ValkeyBloomTestCaseBase):
+class TestTopkKeyEventNotifications(TopkFixedSeedMixin, ValkeyBloomTestCaseBase):
 
     def test_keyspace_topk_commands(self):
         self.create_subscribe_clients()

--- a/tests/test_topk_metrics.py
+++ b/tests/test_topk_metrics.py
@@ -1,8 +1,8 @@
-from valkey_bloom_test_case import ValkeyBloomTestCaseBase
+from valkey_bloom_test_case import TopkFixedSeedMixin, ValkeyBloomTestCaseBase
 from valkeytestframework.conftest import resource_port_tracker  # noqa: F401
 from valkeytestframework.util.waiters import *
 
-class TestTopkMetrics(ValkeyBloomTestCaseBase):
+class TestTopkMetrics(TopkFixedSeedMixin, ValkeyBloomTestCaseBase):
 
     def test_basic_command_metrics(self):
         # Metrics start at 0.

--- a/tests/test_topk_metrics.py
+++ b/tests/test_topk_metrics.py
@@ -1,8 +1,8 @@
-from valkey_bloom_test_case import TopkFixedSeedMixin, ValkeyBloomTestCaseBase
+from valkey_bloom_test_case import SkipSeedParameterizationMixin, ValkeyBloomTestCaseBase
 from valkeytestframework.conftest import resource_port_tracker  # noqa: F401
 from valkeytestframework.util.waiters import *
 
-class TestTopkMetrics(TopkFixedSeedMixin, ValkeyBloomTestCaseBase):
+class TestTopkMetrics(SkipSeedParameterizationMixin, ValkeyBloomTestCaseBase):
 
     def test_basic_command_metrics(self):
         # Metrics start at 0.

--- a/tests/test_topk_replication.py
+++ b/tests/test_topk_replication.py
@@ -2,39 +2,13 @@ import pytest, os
 from valkey import ResponseError
 from valkeytestframework.valkey_test_case import ReplicationTestCase
 from valkeytestframework.conftest import resource_port_tracker  # noqa: F401
-from valkey_bloom_test_case import TopkFixedSeedMixin
+from valkey_bloom_test_case import setup_replication_servers, TopkFixedSeedMixin
 
 class TestTopkReplication(TopkFixedSeedMixin, ReplicationTestCase):
 
     @pytest.fixture(autouse=True)
     def setup_test(self, setup):
-        use_external = os.environ.get("VALKEY_EXTERNAL_SERVER", "false").lower() == "true"
-
-        if use_external:
-            master_host = os.environ.get("VALKEY_HOST", "localhost")
-            master_port = int(os.environ.get("VALKEY_PORT", "6379"))
-            self.server, self.client = self.create_server(
-                testdir=self.testdir,
-                bind_ip=master_host,
-                port=master_port,
-                external_server=True
-            )
-
-            replica_host = os.environ.get("VALKEY_REPLICA_HOST", "localhost")
-            replica_port = int(os.environ.get("VALKEY_REPLICA_PORT", "6380"))
-            replica_server, replica_client = self.create_server(
-                testdir=self.testdir,
-                bind_ip=replica_host,
-                port=replica_port,
-                external_server=True
-            )
-
-            self.replicas = [replica_server]
-            self.num_replicas = 1
-        else:
-            self.args = {"enable-debug-command":"yes", 'loadmodule': os.getenv('MODULE_PATH')}
-            server_path = f"{os.path.dirname(os.path.realpath(__file__))}/build/binaries/{os.environ['SERVER_VERSION']}/valkey-server"
-            self.server, self.client = self.create_server(testdir = self.testdir,  server_path=server_path, args=self.args)
+        setup_replication_servers(self)
 
     def test_replication_behavior(self):
         use_external = os.environ.get("VALKEY_EXTERNAL_SERVER", "false").lower() == "true"

--- a/tests/test_topk_replication.py
+++ b/tests/test_topk_replication.py
@@ -2,9 +2,9 @@ import pytest, os
 from valkey import ResponseError
 from valkeytestframework.valkey_test_case import ReplicationTestCase
 from valkeytestframework.conftest import resource_port_tracker  # noqa: F401
-from valkey_bloom_test_case import setup_replication_servers, TopkFixedSeedMixin
+from valkey_bloom_test_case import setup_replication_servers, SkipSeedParameterizationMixin
 
-class TestTopkReplication(TopkFixedSeedMixin, ReplicationTestCase):
+class TestTopkReplication(SkipSeedParameterizationMixin, ReplicationTestCase):
 
     @pytest.fixture(autouse=True)
     def setup_test(self, setup):

--- a/tests/test_topk_replication.py
+++ b/tests/test_topk_replication.py
@@ -1,0 +1,146 @@
+import pytest, os
+from valkey import ResponseError
+from valkeytestframework.valkey_test_case import ReplicationTestCase
+from valkeytestframework.conftest import resource_port_tracker  # noqa: F401
+from valkey_bloom_test_case import TopkFixedSeedMixin
+
+class TestTopkReplication(TopkFixedSeedMixin, ReplicationTestCase):
+
+    @pytest.fixture(autouse=True)
+    def setup_test(self, setup):
+        use_external = os.environ.get("VALKEY_EXTERNAL_SERVER", "false").lower() == "true"
+
+        if use_external:
+            master_host = os.environ.get("VALKEY_HOST", "localhost")
+            master_port = int(os.environ.get("VALKEY_PORT", "6379"))
+            self.server, self.client = self.create_server(
+                testdir=self.testdir,
+                bind_ip=master_host,
+                port=master_port,
+                external_server=True
+            )
+
+            replica_host = os.environ.get("VALKEY_REPLICA_HOST", "localhost")
+            replica_port = int(os.environ.get("VALKEY_REPLICA_PORT", "6380"))
+            replica_server, replica_client = self.create_server(
+                testdir=self.testdir,
+                bind_ip=replica_host,
+                port=replica_port,
+                external_server=True
+            )
+
+            self.replicas = [replica_server]
+            self.num_replicas = 1
+        else:
+            self.args = {"enable-debug-command":"yes", 'loadmodule': os.getenv('MODULE_PATH')}
+            server_path = f"{os.path.dirname(os.path.realpath(__file__))}/build/binaries/{os.environ['SERVER_VERSION']}/valkey-server"
+            self.server, self.client = self.create_server(testdir = self.testdir,  server_path=server_path, args=self.args)
+
+    def test_replication_behavior(self):
+        use_external = os.environ.get("VALKEY_EXTERNAL_SERVER", "false").lower() == "true"
+        if use_external:
+            self.wait_for_primary_link_up_all_replicas()
+        else:
+            self.setup_replication(num_replicas=1)
+
+        # Test replication for write commands.
+        topk_write_cmds = [
+            ('TOPK.RESERVE', 'TOPK.RESERVE key 5 50 4 0.9 SEED 42'),
+            ('TOPK.ADD', 'TOPK.ADD key item'),
+            ('TOPK.INCRBY', 'TOPK.INCRBY key item 3'),
+        ]
+        for test_case in topk_write_cmds:
+            prefix = test_case[0]
+            cmd = test_case[1]
+            self.client.execute_command(cmd)
+            assert self.client.execute_command('EXISTS key') == 1
+            self.waitForReplicaToSyncUp(self.replicas[0])
+            assert self.replicas[0].client.execute_command('EXISTS key') == 1
+            # The command was replayed on the replica under its own name.
+            assert ('cmdstat_' + prefix) in self.replicas[0].client.info("Commandstats")
+
+            # cmd debug digest
+            server_digest_primary = self.client.execute_command('DEBUG', 'DIGEST')
+            server_digest_replica = self.replicas[0].client.execute_command('DEBUG', 'DIGEST')
+            assert server_digest_primary == server_digest_replica
+            object_digest_primary = self.client.execute_command('DEBUG', 'DIGEST-VALUE', 'key')
+            debug_digest_replica = self.replicas[0].client.execute_command('DEBUG', 'DIGEST-VALUE', 'key')
+            assert object_digest_primary == debug_digest_replica
+
+        self.client.execute_command('CONFIG RESETSTAT')
+        self.replicas[0].client.execute_command('CONFIG RESETSTAT')
+
+        # Read commands executed on the primary will not be replicated.
+        read_commands = [
+            ('TOPK.QUERY', 'TOPK.QUERY key item'),
+            ('TOPK.COUNT', 'TOPK.COUNT key item'),
+            ('TOPK.LIST', 'TOPK.LIST key'),
+            ('TOPK.INFO', 'TOPK.INFO key'),
+        ]
+        for test_case in read_commands:
+            prefix = test_case[0]
+            cmd = test_case[1]
+            self.client.execute_command(cmd)
+            assert ('cmdstat_' + prefix) in self.client.info("Commandstats")
+            assert ('cmdstat_' + prefix) not in self.replicas[0].client.info("Commandstats")
+
+        # Deletes of topk objects are replicated
+        assert self.client.execute_command("EXISTS key") == 1
+        assert self.replicas[0].client.execute_command('EXISTS key') == 1
+        assert self.client.execute_command("DEL key") == 1
+        self.waitForReplicaToSyncUp(self.replicas[0])
+        assert self.client.execute_command("EXISTS key") == 0
+        assert self.replicas[0].client.execute_command('EXISTS key') == 0
+
+        # Write commands with errors are not replicated.
+        invalid_topk_write_cmds = [
+            ('TOPK.RESERVE', 'TOPK.RESERVE key 5 50 4 5'),
+            ('TOPK.ADD', 'TOPK.ADD missing item'),
+            ('TOPK.INCRBY', 'TOPK.INCRBY missing item 1'),
+        ]
+        for test_case in invalid_topk_write_cmds:
+            prefix = test_case[0]
+            cmd = test_case[1]
+            self.client.execute_command('CONFIG RESETSTAT')
+            self.replicas[0].client.execute_command('CONFIG RESETSTAT')
+            try:
+                self.client.execute_command(cmd)
+                assert False
+            except ResponseError:
+                pass
+            primary_cmd_stats = self.client.info("Commandstats")['cmdstat_' + prefix]
+            assert primary_cmd_stats["calls"] == 1
+            assert primary_cmd_stats["failed_calls"] == 1
+            assert ('cmdstat_' + prefix) not in self.replicas[0].client.info("Commandstats")
+
+    def test_topk_digest_consistency_after_many_adds(self):
+        use_external = os.environ.get("VALKEY_EXTERNAL_SERVER", "false").lower() == "true"
+        if use_external:
+            self.wait_for_primary_link_up_all_replicas()
+        else:
+            self.setup_replication(num_replicas=1)
+
+        # Cover both seeding paths
+        reserve_cmds = [
+            ('tk_fixed', 'TOPK.RESERVE tk_fixed 50 200 5 0.9 SEED 42'),
+            ('tk_random', 'TOPK.RESERVE tk_random 50 200 5 0.9'),
+        ]
+        for key, reserve_cmd in reserve_cmds:
+            assert self.client.execute_command(reserve_cmd) == b'OK'
+            # k=50 with 800 distinct items forces heavy eviction/contention.
+            for i in range(0, 5000):
+                self.client.execute_command(f'TOPK.INCRBY {key} item{i % 800} {i % 7 + 1}')
+
+        self.waitForReplicaToSyncUp(self.replicas[0])
+
+        server_digest_primary = self.client.execute_command('DEBUG', 'DIGEST')
+        server_digest_replica = self.replicas[0].client.execute_command('DEBUG', 'DIGEST')
+        assert server_digest_primary == server_digest_replica
+
+        for key, _ in reserve_cmds:
+            object_digest_primary = self.client.execute_command('DEBUG', 'DIGEST-VALUE', key)
+            object_digest_replica = self.replicas[0].client.execute_command('DEBUG', 'DIGEST-VALUE', key)
+            assert object_digest_primary == object_digest_replica
+            # The Top-K list itself should also be identical.
+            assert self.client.execute_command(f'TOPK.LIST {key} WITHCOUNT') == \
+                self.replicas[0].client.execute_command(f'TOPK.LIST {key} WITHCOUNT')

--- a/tests/test_topk_save_and_restore.py
+++ b/tests/test_topk_save_and_restore.py
@@ -1,0 +1,63 @@
+from valkey_bloom_test_case import ValkeyBloomTestCaseBase
+from valkeytestframework.conftest import resource_port_tracker  # noqa: F401
+from valkeytestframework.util.waiters import *
+
+class TestTopkSaveRestore(ValkeyBloomTestCaseBase):
+
+    def test_basic_save_and_restore(self):
+        client = self.server.get_new_client()
+        assert client.execute_command('TOPK.RESERVE testSave 5 50 4 0.9 SEED 42') == b'OK'
+        client.execute_command('TOPK.ADD testSave apple banana cherry')
+        client.execute_command('TOPK.INCRBY testSave apple 5 banana 3')
+        list_before = client.execute_command('TOPK.LIST testSave WITHCOUNT')
+        item_count_before = self.server.num_keys(client=client)
+        # num_items is persisted in the RDB separately from the sketch
+        assert client.execute_command('TOPK.INFO testSave TOTALITEMSADDED') == 11
+        size_before = client.execute_command('TOPK.INFO testSave SIZE')
+        assert size_before > 0
+
+        # save rdb, restart server.
+        client.execute_command('BGSAVE')
+        self.server.wait_for_save_done()
+        self.server.restart(remove_rdb=False, remove_nodes_conf=False, connect_client=True)
+
+        assert self.server.is_alive()
+        wait_for_equal(lambda: self.server.is_rdb_done_loading(), True)
+        self.server.verify_string_in_logfile("Loading RDB produced by Valkey")
+        self.server.verify_string_in_logfile("Done loading RDB, keys loaded: 1, keys expired: 0")
+
+        # verify restore results
+        item_count_after = self.server.num_keys(client=client)
+        assert item_count_after == item_count_before
+        assert client.execute_command('TOPK.LIST testSave WITHCOUNT') == list_before
+        assert client.execute_command('TOPK.INFO testSave K') == 5
+        assert client.execute_command('TOPK.INFO testSave WIDTH') == 50
+        assert client.execute_command('TOPK.INFO testSave DEPTH') == 4
+        assert client.execute_command('TOPK.INFO testSave DECAY') == b'0.9'
+        assert client.execute_command('TOPK.INFO testSave TOTALITEMSADDED') == 11
+        # size may be slightly smaller after restore, as RDB reload rebuilds the sketch
+        assert 0 < client.execute_command('TOPK.INFO testSave SIZE') <= size_before
+
+    def test_basic_save_many(self):
+        client = self.server.get_new_client()
+        count = 500
+        for i in range(0, count):
+            name = str(i) + "key"
+            assert client.execute_command('TOPK.RESERVE ' + name + ' 5 50 4 0.9 SEED 42') == b'OK'
+            client.execute_command('TOPK.ADD ' + name + ' item')
+
+        item_count_before = self.server.num_keys(client=client)
+        assert item_count_before == count
+        # save rdb, restart server
+        client.execute_command('BGSAVE')
+        self.server.wait_for_save_done()
+        self.server.restart(remove_rdb=False, remove_nodes_conf=False, connect_client=True)
+
+        assert self.server.is_alive()
+        wait_for_equal(lambda: self.server.is_rdb_done_loading(), True)
+        self.server.verify_string_in_logfile("Loading RDB produced by Valkey")
+        self.server.verify_string_in_logfile("Done loading RDB, keys loaded: 500, keys expired: 0")
+
+        # verify all keys survived and remain queryable
+        assert self.server.num_keys(client=client) == count
+        assert client.execute_command('TOPK.QUERY 0key item') == [1]

--- a/tests/test_topk_save_and_restore.py
+++ b/tests/test_topk_save_and_restore.py
@@ -1,9 +1,9 @@
 from valkey import ResponseError
-from valkey_bloom_test_case import TopkFixedSeedMixin, ValkeyBloomTestCaseBase
+from valkey_bloom_test_case import SkipSeedParameterizationMixin, ValkeyBloomTestCaseBase
 from valkeytestframework.conftest import resource_port_tracker  # noqa: F401
 from valkeytestframework.util.waiters import *
 
-class TestTopkSaveRestore(TopkFixedSeedMixin, ValkeyBloomTestCaseBase):
+class TestTopkSaveRestore(SkipSeedParameterizationMixin, ValkeyBloomTestCaseBase):
 
     def test_basic_save_and_restore(self):
         client = self.server.get_new_client()

--- a/tests/test_topk_save_and_restore.py
+++ b/tests/test_topk_save_and_restore.py
@@ -1,3 +1,4 @@
+from valkey import ResponseError
 from valkey_bloom_test_case import ValkeyBloomTestCaseBase
 from valkeytestframework.conftest import resource_port_tracker  # noqa: F401
 from valkeytestframework.util.waiters import *
@@ -91,3 +92,33 @@ class TestTopkSaveRestore(ValkeyBloomTestCaseBase):
         assert self.server.num_keys(client=client) == count
         assert client.execute_command('TOPK.QUERY 0key item0') == [1]
         assert client.execute_command('TOPK.QUERY 499key item499') == [1]
+
+    def test_rdb_restore_non_topk_compatibility(self):
+        # Create an rdb on a module enabled server
+        topk_client = self.server.get_new_client()
+        topk_client.execute_command("TOPK.RESERVE key 5")
+        topk_client.execute_command("TOPK.ADD key item")
+        topk_client.execute_command("set string val")
+        assert self.server.num_keys(client=topk_client) == 2
+        assert topk_client.execute_command("del key") == 1
+        assert self.server.num_keys(client=topk_client) == 1
+        assert topk_client.get("string") == b"val"
+        topk_client.execute_command('BGSAVE')
+        self.server.wait_for_save_done()
+        rdb_file = self.server.args["dbfilename"]
+
+        # Create a server without the module
+        new_server, new_client = self.create_server(testdir=self.testdir, server_path=self.server_path, args={"dbfilename": rdb_file})
+        assert new_server.is_alive()
+        wait_for_equal(lambda: new_server.is_rdb_done_loading(), True)
+
+        # Verification
+        assert new_client.execute_command("info bf") == b''
+        try:
+            new_client.execute_command("topk.reserve test 5")
+            assert False
+        except ResponseError as e:
+            assert "unknown command" in str(e)
+
+        assert self.server.num_keys(client=new_client) == 1
+        assert new_client.get("string") == b"val"

--- a/tests/test_topk_save_and_restore.py
+++ b/tests/test_topk_save_and_restore.py
@@ -13,6 +13,10 @@ class TestTopkSaveRestore(ValkeyBloomTestCaseBase):
         list_before = client.execute_command('TOPK.LIST testSave WITHCOUNT')
         assert len(info_before) != 0
         item_count_before = self.server.num_keys(client=client)
+        # cmd debug digest
+        server_digest = client.execute_command('DEBUG', 'DIGEST')
+        assert server_digest != None or 0000000000000000000000000000000000000000
+        object_digest = client.execute_command('DEBUG DIGEST-VALUE testSave')
 
         # save rdb, restart server.
         client.execute_command('BGSAVE')
@@ -21,6 +25,10 @@ class TestTopkSaveRestore(ValkeyBloomTestCaseBase):
 
         assert self.server.is_alive()
         wait_for_equal(lambda: self.server.is_rdb_done_loading(), True)
+        restored_server_digest = client.execute_command('DEBUG', 'DIGEST')
+        restored_object_digest = client.execute_command('DEBUG DIGEST-VALUE testSave')
+        assert restored_server_digest == server_digest
+        assert restored_object_digest == object_digest
         self.server.verify_string_in_logfile("Loading RDB produced by Valkey")
         self.server.verify_string_in_logfile("Done loading RDB, keys loaded: 1, keys expired: 0")
 

--- a/tests/test_topk_save_and_restore.py
+++ b/tests/test_topk_save_and_restore.py
@@ -7,6 +7,7 @@ class TestTopkSaveRestore(ValkeyBloomTestCaseBase):
     def test_basic_save_and_restore(self):
         client = self.server.get_new_client()
         assert client.execute_command('TOPK.RESERVE testSave 5 50 4 0.9 SEED 42') == b'OK'
+        # First round: 3 items < k (5), so the priority queue is not full.
         client.execute_command('TOPK.ADD testSave apple banana cherry')
         client.execute_command('TOPK.INCRBY testSave apple 5 banana 3')
         info_before = client.execute_command('TOPK.INFO testSave')
@@ -38,13 +39,41 @@ class TestTopkSaveRestore(ValkeyBloomTestCaseBase):
         assert client.execute_command('TOPK.INFO testSave') == info_before
         assert client.execute_command('TOPK.LIST testSave WITHCOUNT') == list_before
 
+        # Second round: fill past k (5) so an item is evicted, then round-trip.
+        client.execute_command('TOPK.ADD testSave date elderberry fig grape')
+        client.execute_command('TOPK.INCRBY testSave date 4 elderberry 6')
+        info_before = client.execute_command('TOPK.INFO testSave')
+        list_before = client.execute_command('TOPK.LIST testSave WITHCOUNT')
+        server_digest = client.execute_command('DEBUG', 'DIGEST')
+        object_digest = client.execute_command('DEBUG DIGEST-VALUE testSave')
+
+        client.execute_command('BGSAVE')
+        self.server.wait_for_save_done()
+        self.server.restart(remove_rdb=False, remove_nodes_conf=False, connect_client=True)
+
+        assert self.server.is_alive()
+        wait_for_equal(lambda: self.server.is_rdb_done_loading(), True)
+        assert client.execute_command('DEBUG', 'DIGEST') == server_digest
+        assert client.execute_command('DEBUG DIGEST-VALUE testSave') == object_digest
+        assert client.execute_command('TOPK.INFO testSave') == info_before
+        assert client.execute_command('TOPK.LIST testSave WITHCOUNT') == list_before
+
     def test_basic_save_many(self):
         client = self.server.get_new_client()
         count = 500
+        configs = [
+            (5, 50, 4, 0.9, 42),
+            (10, 200, 5, 0.5, 7),
+            (3, 16, 6, 0.95, 0),
+            (8, 64, 4, 0.99, 123456789),
+        ]
         for i in range(0, count):
             name = str(i) + "key"
-            assert client.execute_command('TOPK.RESERVE ' + name + ' 5 50 4 0.9 SEED 42') == b'OK'
-            client.execute_command('TOPK.ADD ' + name + ' item')
+            k, width, depth, decay, seed = configs[i % len(configs)]
+            assert client.execute_command(
+                f'TOPK.RESERVE {name} {k} {width} {depth} {decay} SEED {seed}'
+            ) == b'OK'
+            client.execute_command(f'TOPK.ADD {name} item{i}')
 
         item_count_before = self.server.num_keys(client=client)
         assert item_count_before == count
@@ -60,4 +89,5 @@ class TestTopkSaveRestore(ValkeyBloomTestCaseBase):
 
         # verify all keys survived and remain queryable
         assert self.server.num_keys(client=client) == count
-        assert client.execute_command('TOPK.QUERY 0key item') == [1]
+        assert client.execute_command('TOPK.QUERY 0key item0') == [1]
+        assert client.execute_command('TOPK.QUERY 499key item499') == [1]

--- a/tests/test_topk_save_and_restore.py
+++ b/tests/test_topk_save_and_restore.py
@@ -1,9 +1,9 @@
 from valkey import ResponseError
-from valkey_bloom_test_case import ValkeyBloomTestCaseBase
+from valkey_bloom_test_case import TopkFixedSeedMixin, ValkeyBloomTestCaseBase
 from valkeytestframework.conftest import resource_port_tracker  # noqa: F401
 from valkeytestframework.util.waiters import *
 
-class TestTopkSaveRestore(ValkeyBloomTestCaseBase):
+class TestTopkSaveRestore(TopkFixedSeedMixin, ValkeyBloomTestCaseBase):
 
     def test_basic_save_and_restore(self):
         client = self.server.get_new_client()

--- a/tests/test_topk_save_and_restore.py
+++ b/tests/test_topk_save_and_restore.py
@@ -9,12 +9,10 @@ class TestTopkSaveRestore(ValkeyBloomTestCaseBase):
         assert client.execute_command('TOPK.RESERVE testSave 5 50 4 0.9 SEED 42') == b'OK'
         client.execute_command('TOPK.ADD testSave apple banana cherry')
         client.execute_command('TOPK.INCRBY testSave apple 5 banana 3')
+        info_before = client.execute_command('TOPK.INFO testSave')
         list_before = client.execute_command('TOPK.LIST testSave WITHCOUNT')
+        assert len(info_before) != 0
         item_count_before = self.server.num_keys(client=client)
-        # num_items is persisted in the RDB separately from the sketch
-        assert client.execute_command('TOPK.INFO testSave TOTALITEMSADDED') == 11
-        size_before = client.execute_command('TOPK.INFO testSave SIZE')
-        assert size_before > 0
 
         # save rdb, restart server.
         client.execute_command('BGSAVE')
@@ -29,14 +27,8 @@ class TestTopkSaveRestore(ValkeyBloomTestCaseBase):
         # verify restore results
         item_count_after = self.server.num_keys(client=client)
         assert item_count_after == item_count_before
+        assert client.execute_command('TOPK.INFO testSave') == info_before
         assert client.execute_command('TOPK.LIST testSave WITHCOUNT') == list_before
-        assert client.execute_command('TOPK.INFO testSave K') == 5
-        assert client.execute_command('TOPK.INFO testSave WIDTH') == 50
-        assert client.execute_command('TOPK.INFO testSave DEPTH') == 4
-        assert client.execute_command('TOPK.INFO testSave DECAY') == b'0.9'
-        assert client.execute_command('TOPK.INFO testSave TOTALITEMSADDED') == 11
-        # size may be slightly smaller after restore, as RDB reload rebuilds the sketch
-        assert 0 < client.execute_command('TOPK.INFO testSave SIZE') <= size_before
 
     def test_basic_save_many(self):
         client = self.server.get_new_client()

--- a/tests/valkey_bloom_test_case.py
+++ b/tests/valkey_bloom_test_case.py
@@ -404,3 +404,13 @@ class ValkeyBloomTestCaseBase(ValkeyTestCase):
             for category in cmd[2]:
                 assert category in cmd_info[0][6]
 
+class TopkFixedSeedMixin:
+    """Opt out of the random/fixed-seed parameterization.
+
+    TopK seeds are chosen per command (TOPK.RESERVE ... SEED), not via the
+    bf.bloom-use-random-seed config, so the bloom seed parameterization would
+    only run every test twice with identical behavior. Mixing this in overrides
+    the autouse fixture so those tests run only once."""
+    @pytest.fixture(autouse=True)
+    def use_random_seed_fixture(self):
+        self.use_random_seed = "no"

--- a/tests/valkey_bloom_test_case.py
+++ b/tests/valkey_bloom_test_case.py
@@ -435,13 +435,15 @@ def setup_replication_servers(case, use_random_seed='no'):
         case.server, case.client = case.create_server(testdir=case.testdir, server_path=server_path, args=case.args)
 
 
-class TopkFixedSeedMixin:
+class SkipSeedParameterizationMixin:
     """Opt out of the random/fixed-seed parameterization.
 
-    TopK seeds are chosen per command (TOPK.RESERVE ... SEED), not via the
-    bf.bloom-use-random-seed config, so the bloom seed parameterization would
-    only run every test twice with identical behavior. Mixing this in overrides
-    the autouse fixture so those tests run only once."""
+    The bloom seed parameterization runs every test twice, once per value of
+    the bf.bloom-use-random-seed config. Data types that don't derive their
+    behavior from that config (e.g. TopK, whose seed is chosen per command via
+    TOPK.RESERVE ... SEED) would just run every test twice with identical
+    behavior. Mixing this in overrides the autouse fixture so those tests run
+    only once with a fixed seed."""
     @pytest.fixture(autouse=True)
     def use_random_seed_fixture(self):
         self.use_random_seed = "no"

--- a/tests/valkey_bloom_test_case.py
+++ b/tests/valkey_bloom_test_case.py
@@ -404,6 +404,37 @@ class ValkeyBloomTestCaseBase(ValkeyTestCase):
             for category in cmd[2]:
                 assert category in cmd_info[0][6]
 
+def setup_replication_servers(case, use_random_seed='no'):
+    """Shared primary/replica server setup for the bloom and topk replication tests."""
+    use_external = os.environ.get("VALKEY_EXTERNAL_SERVER", "false").lower() == "true"
+
+    if use_external:
+        master_host = os.environ.get("VALKEY_HOST", "localhost")
+        master_port = int(os.environ.get("VALKEY_PORT", "6379"))
+        case.server, case.client = case.create_server(
+            testdir=case.testdir,
+            bind_ip=master_host,
+            port=master_port,
+            external_server=True
+        )
+
+        replica_host = os.environ.get("VALKEY_REPLICA_HOST", "localhost")
+        replica_port = int(os.environ.get("VALKEY_REPLICA_PORT", "6380"))
+        replica_server, replica_client = case.create_server(
+            testdir=case.testdir,
+            bind_ip=replica_host,
+            port=replica_port,
+            external_server=True
+        )
+
+        case.replicas = [replica_server]
+        case.num_replicas = 1
+    else:
+        case.args = {"enable-debug-command": "yes", 'loadmodule': os.getenv('MODULE_PATH'), 'bf.bloom-use-random-seed': use_random_seed}
+        server_path = f"{os.path.dirname(os.path.realpath(__file__))}/build/binaries/{os.environ['SERVER_VERSION']}/valkey-server"
+        case.server, case.client = case.create_server(testdir=case.testdir, server_path=server_path, args=case.args)
+
+
 class TopkFixedSeedMixin:
     """Opt out of the random/fixed-seed parameterization.
 


### PR DESCRIPTION
## Summary

Adds RDB persistence for TopK so sketches survive a server restart, plus the supporting changes: a faster `TOPK.ADD`/`TOPK.INCRBY` metric path, exact memory tracking, a richer `TOPK.INFO`, and a digest callback.

## Changes

### RDB save/load
- Wire up the `rdb_save` / `rdb_load` type callbacks .
- **Save** persists only what cannot be recomputed: `seed`, `num_items`, and the serialized sketch bytes (`sketch.to_bytes()`).
- **Load** rebuilds the sketch via `CuckooTopK::from_bytes(bytes, seed)` and reads `k` / `width` / `depth` / `decay` back off the restored sketch, so only three values live in the on-disk layout.
- Load is defensive: it rejects an encoding version newer than the module supports, a sketch that fails to deserialize, and `k` / `width` / `depth` / `decay` values that fall outside their valid ranges — logging a warning and failing the load rather than constructing a corrupt object.
- `test_topk_save_and_restore.py`: basic round-trip (params, item list via `TOPK.LIST`, and `num_items` survive a BGSAVE + restart) and a 500-key bulk-survival test.

### O(1) `TOPK.ADD` / `TOPK.INCRBY`
- The add path no longer diffs `memory_usage()` before/after to keep the memory metric correct. The upstream `add_with_evicted` now reports whether an item was inserted, so the gauge updates from the actual byte delta in O(item bytes) and add returns to O(1).

### Memory tracking
- `TopKObject::memory_usage()` now uses the upstream `mem_bytes(|item| item.capacity())`, which counts each tracked item's heap (the `Vec<u8>` contents). The upstream crate now models its `HashMap` allocation exactly, so the reported size matches actual heap usage.

### TOPK.INFO
- Add a `total items added` field, reporting the running item count (`num_items`) that is persisted in the RDB. This is the value tracked by the `topk_total_items_added_across_objects` metric, now observable per-object.
- Add an optional field argument: `TOPK.INFO key [K | WIDTH | DEPTH | DECAY | SIZE | TOTALITEMSADDED]` returns just that single value instead of the full reply. An unrecognized field token returns `invalid information value`.
- `test_topk_command.py`: `total items added` accounting and single-field `TOPK.INFO` queries, plus the unrecognized-token error path.
- `test_topk_acl_category.py`: updated `TOPK.INFO` field count for the new field.

### Digest
- Wire up the `digest` callback so `DEBUG DIGEST` / `DEBUG DIGEST-VALUE` work on TopK keys. The digest covers `seed`, `num_items`, and the serialized sketch bytes, so two equal sketches digest identically.
- `test_topk_save_and_restore.py`: assert `DEBUG DIGEST` and `DIGEST-VALUE` round-trip unchanged across an RDB save and restart.
- `test_topk_basic.py`: `test_copy_and_exists_cmd` verifies `COPY` yields a digest-equal object while a second key changes the whole-server digest and diverging contents digest differently.
- Replication tests to follow.
