### PR TITLE
Add TopK defrag support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ valkey-module-macros = "0"
 linkme = "0"
 bloomfilter = { version = "3.0.1", features = ["serde"] }
 # TODO: This is a temporary solution until we add this functionality to the original heavykeeper crate.
-heavykeeper = { git = "https://github.com/detemmienation/heavykeeper-rs.git", branch = "rdb-rng" }
+heavykeeper = { git = "https://github.com/detemmienation/heavykeeper-rs.git", branch = "rdb-defrag" }
 lazy_static = "1.4.0"
 libc = "0.2"
 serde = { version = "1.0", features = ["derive"] }

--- a/src/configs.rs
+++ b/src/configs.rs
@@ -30,6 +30,8 @@ pub const BLOOM_USE_RANDOM_SEED_DEFAULT: bool = true;
 
 pub const BLOOM_DEFRAG_DEFAULT: bool = true;
 
+pub const TOPK_DEFRAG_DEFAULT: bool = true;
+
 // Max Memory usage allowed overall within a bloom object (128MB).
 // Beyond this threshold, a bloom object is classified as large.
 // Write operations that result in bloom object allocation larger than this size will be rejected.
@@ -44,6 +46,7 @@ lazy_static! {
         AtomicI64::new(BLOOM_MEMORY_LIMIT_PER_OBJECT_DEFAULT);
     pub static ref BLOOM_USE_RANDOM_SEED: AtomicBool = AtomicBool::default();
     pub static ref BLOOM_DEFRAG: AtomicBool = AtomicBool::new(BLOOM_DEFRAG_DEFAULT);
+    pub static ref TOPK_DEFRAG: AtomicBool = AtomicBool::new(TOPK_DEFRAG_DEFAULT);
     pub static ref BLOOM_FP_RATE_F64: Mutex<f64> = Mutex::new(
         BLOOM_FP_RATE_DEFAULT
             .parse::<f64>()

--- a/src/configs.rs
+++ b/src/configs.rs
@@ -32,6 +32,12 @@ pub const BLOOM_DEFRAG_DEFAULT: bool = true;
 
 pub const TOPK_DEFRAG_DEFAULT: bool = true;
 
+// Max memory allowed for a single TopK object (128MB). A TOPK.RESERVE whose
+// sketch would exceed this is rejected.
+pub const TOPK_MEMORY_LIMIT_PER_OBJECT_DEFAULT: i64 = 128 * 1024 * 1024;
+pub const TOPK_MEMORY_LIMIT_PER_OBJECT_MIN: i64 = 0;
+pub const TOPK_MEMORY_LIMIT_PER_OBJECT_MAX: i64 = i64::MAX;
+
 // Max Memory usage allowed overall within a bloom object (128MB).
 // Beyond this threshold, a bloom object is classified as large.
 // Write operations that result in bloom object allocation larger than this size will be rejected.
@@ -47,6 +53,8 @@ lazy_static! {
     pub static ref BLOOM_USE_RANDOM_SEED: AtomicBool = AtomicBool::default();
     pub static ref BLOOM_DEFRAG: AtomicBool = AtomicBool::new(BLOOM_DEFRAG_DEFAULT);
     pub static ref TOPK_DEFRAG: AtomicBool = AtomicBool::new(TOPK_DEFRAG_DEFAULT);
+    pub static ref TOPK_MEMORY_LIMIT_PER_OBJECT: AtomicI64 =
+        AtomicI64::new(TOPK_MEMORY_LIMIT_PER_OBJECT_DEFAULT);
     pub static ref BLOOM_FP_RATE_F64: Mutex<f64> = Mutex::new(
         BLOOM_FP_RATE_DEFAULT
             .parse::<f64>()

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -185,6 +185,7 @@ valkey_module! {
         bool: [
             ["bloom-use-random-seed", &*configs::BLOOM_USE_RANDOM_SEED, configs::BLOOM_USE_RANDOM_SEED_DEFAULT, ConfigurationFlags::DEFAULT, None],
             ["bloom-defrag-enabled", &*configs::BLOOM_DEFRAG, configs::BLOOM_DEFRAG_DEFAULT,  ConfigurationFlags::DEFAULT, None],
+            ["topk-defrag-enabled", &*configs::TOPK_DEFRAG, configs::TOPK_DEFRAG_DEFAULT,  ConfigurationFlags::DEFAULT, None],
         ],
         enum: [
         ],

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -177,6 +177,7 @@ valkey_module! {
             ["bloom-capacity", &*configs::BLOOM_CAPACITY, configs::BLOOM_CAPACITY_DEFAULT, configs::BLOOM_CAPACITY_MIN, configs::BLOOM_CAPACITY_MAX, ConfigurationFlags::DEFAULT, None],
             ["bloom-expansion", &*configs::BLOOM_EXPANSION, configs::BLOOM_EXPANSION_DEFAULT, 0, configs::BLOOM_EXPANSION_MAX as i64, ConfigurationFlags::DEFAULT, None],
             ["bloom-memory-usage-limit", &*configs::BLOOM_MEMORY_LIMIT_PER_OBJECT, configs::BLOOM_MEMORY_LIMIT_PER_OBJECT_DEFAULT, configs::BLOOM_MEMORY_LIMIT_PER_OBJECT_MIN, configs::BLOOM_MEMORY_LIMIT_PER_OBJECT_MAX, ConfigurationFlags::DEFAULT, None],
+            ["topk-memory-usage-limit", &*configs::TOPK_MEMORY_LIMIT_PER_OBJECT, configs::TOPK_MEMORY_LIMIT_PER_OBJECT_DEFAULT, configs::TOPK_MEMORY_LIMIT_PER_OBJECT_MIN, configs::TOPK_MEMORY_LIMIT_PER_OBJECT_MAX, ConfigurationFlags::DEFAULT, None],
         ],
         string: [
             ["bloom-fp-rate", &*configs::BLOOM_FP_RATE, configs::BLOOM_FP_RATE_DEFAULT, ConfigurationFlags::DEFAULT, None, Some(Box::new(configs::on_string_config_set))],

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -14,6 +14,8 @@ lazy_static! {
     pub static ref TOPK_OBJECT_TOTAL_MEMORY_BYTES: AtomicUsize = AtomicUsize::new(0);
     pub static ref TOPK_TOTAL_ITEMS_ADDED_ACROSS_OBJECTS: AtomicU64 = AtomicU64::new(0);
     pub static ref TOPK_SUM_K_ACROSS_OBJECTS: AtomicU64 = AtomicU64::new(0);
+    pub static ref TOPK_DEFRAG_HITS: AtomicU64 = AtomicU64::new(0);
+    pub static ref TOPK_DEFRAG_MISSES: AtomicU64 = AtomicU64::new(0);
 }
 
 pub fn bloom_info_handler(ctx: &InfoContext) -> ValkeyResult<()> {
@@ -87,6 +89,16 @@ pub fn topk_info_handler(ctx: &InfoContext) -> ValkeyResult<()> {
             TOPK_SUM_K_ACROSS_OBJECTS
                 .load(Ordering::Relaxed)
                 .to_string(),
+        )?
+        .build_section()?
+        .add_section("topk_defrag_metrics")
+        .field(
+            "topk_defrag_hits",
+            TOPK_DEFRAG_HITS.load(Ordering::Relaxed).to_string(),
+        )?
+        .field(
+            "topk_defrag_misses",
+            TOPK_DEFRAG_MISSES.load(Ordering::Relaxed).to_string(),
         )?
         .build_section()?
         .build_info()?;

--- a/src/topk/command_handler.rs
+++ b/src/topk/command_handler.rs
@@ -141,6 +141,12 @@ pub fn topk_reserve(ctx: &Context, input_args: &[ValkeyString]) -> ValkeyResult 
         Err(_) => return Err(ValkeyError::WrongType),
     };
 
+    // Reject before new_reserved allocates if the sketch would exceed the
+    // per-object memory limit.
+    if !TopKObject::validate_size(k, width, depth) {
+        return Err(ValkeyError::Str(utils::EXCEEDS_MAX_TOPK_SIZE));
+    }
+
     let seed = user_seed.unwrap_or_else(random_seed);
 
     let topk = TopKObject::new_reserved(k, width, depth, decay, seed);

--- a/src/topk/data_type.rs
+++ b/src/topk/data_type.rs
@@ -34,7 +34,7 @@ pub static TOPK_TYPE: ValkeyType = ValkeyType::new(
         free_effort: Some(topk_callback::topk_free_effort),
         unlink: None,
         copy: Some(topk_callback::topk_copy),
-        defrag: None,
+        defrag: Some(topk_callback::topk_defrag),
 
         mem_usage2: None,
         free_effort2: None,

--- a/src/topk/utils.rs
+++ b/src/topk/utils.rs
@@ -1,3 +1,4 @@
+use crate::configs;
 use crate::metrics;
 use heavykeeper::CuckooTopK;
 use std::sync::atomic::Ordering;
@@ -9,11 +10,9 @@ pub const DEFAULT_WIDTH: u32 = 8;
 pub const DEFAULT_DEPTH: u32 = 7;
 pub const DEFAULT_DECAY: f64 = 0.9;
 
-/// Per-argument bounds.
-/// The minimums are 1,The maximums are placeholders covering the
-/// full u32 range until topk-specific configs are introduced; tighten them
-/// once dedicated config knobs land.
-// TODO: replace these with configurable bounds once topk configs exist.
+/// Per-argument bounds. The minimums are 1; the maximums span the full u32
+/// range because oversized sketches are bounded by the topk-memory-usage-limit
+/// config (see `TopKObject::estimated_size`), not by per-argument caps.
 pub const TOPK_K_MIN: u32 = 1;
 pub const TOPK_K_MAX: u32 = u32::MAX;
 pub const TOPK_WIDTH_MIN: u32 = 1;
@@ -36,6 +35,7 @@ pub const TOPK_LARGER_THAN_0: &str = "ERR (topk should be larger than 0)";
 pub const WIDTH_LARGER_THAN_0: &str = "ERR (width should be larger than 0)";
 pub const DEPTH_LARGER_THAN_0: &str = "ERR (depth should be larger than 0)";
 pub const DECAY_RANGE: &str = "ERR (0 < decay < 1)";
+pub const EXCEEDS_MAX_TOPK_SIZE: &str = "ERR operation exceeds topk object memory limit";
 
 /// TopKObject wraps the underlying CuckooTopK sketch together with the
 /// parameters used to construct it.
@@ -113,6 +113,27 @@ impl TopKObject {
     /// The remaining undercount is allocator overhead and HashMap metadata.
     pub fn memory_usage(&self) -> usize {
         std::mem::size_of::<TopKObject>() + self.sketch.mem_bytes(|item| item.capacity())
+    }
+
+    /// Bytes the sketch allocates up front: `width` + `width * depth` cells
+    /// (16 bytes each), a 1024-entry u64 decay table, and the priority queue
+    /// reserved to capacity `k` (~128 bytes per entry, a conservative estimate).
+    pub fn estimated_size(k: u32, width: u32, depth: u32) -> u64 {
+        let (k, width, depth) = (k as u64, width as u64, depth as u64);
+        // Saturate: products can overflow u64 at u32::MAX, and wrapping would
+        // let an oversized sketch slip under the limit.
+        let heavy = width.saturating_mul(depth).saturating_mul(16);
+        (std::mem::size_of::<TopKObject>() as u64)
+            .saturating_add(width.saturating_mul(16))
+            .saturating_add(heavy)
+            .saturating_add(1024 * 8)
+            .saturating_add(k.saturating_mul(128))
+    }
+
+    /// Whether these params fit within the configured topk-memory-usage-limit.
+    pub fn validate_size(k: u32, width: u32, depth: u32) -> bool {
+        let limit = configs::TOPK_MEMORY_LIMIT_PER_OBJECT.load(Ordering::Relaxed) as u64;
+        Self::estimated_size(k, width, depth) <= limit
     }
 
     /// Increments metrics related to object count, memory, and summed k upon creation of a new object.

--- a/src/topk/utils.rs
+++ b/src/topk/utils.rs
@@ -1,6 +1,6 @@
 use crate::configs;
 use crate::metrics;
-use heavykeeper::CuckooTopK;
+use heavykeeper::{CuckooTopK, Reallocator};
 use std::sync::atomic::Ordering;
 
 /// KeySpace Notification Events
@@ -113,6 +113,15 @@ impl TopKObject {
     /// The remaining undercount is allocator overhead and HashMap metadata.
     pub fn memory_usage(&self) -> usize {
         std::mem::size_of::<TopKObject>() + self.sketch.mem_bytes(|item| item.capacity())
+    }
+
+    /// Relocate the sketch's heap allocations through `reallocator` (for active
+    /// defrag) and reconcile the memory gauge. 
+    pub fn defrag_sketch<R: Reallocator>(&mut self, reallocator: &mut R) {
+        let before = self.memory_usage();
+        self.sketch.realloc_large_heap_allocated_objects(reallocator);
+        let after = self.memory_usage();
+        metrics::TOPK_OBJECT_TOTAL_MEMORY_BYTES.fetch_sub(before - after, Ordering::Relaxed);
     }
 
     /// Bytes the sketch allocates up front: `width` + `width * depth` cells

--- a/src/topk/utils.rs
+++ b/src/topk/utils.rs
@@ -1,6 +1,6 @@
 use crate::configs;
 use crate::metrics;
-use heavykeeper::{CuckooTopK, Reallocator};
+use heavykeeper::CuckooTopK;
 use std::sync::atomic::Ordering;
 
 /// KeySpace Notification Events
@@ -110,16 +110,6 @@ impl TopKObject {
     /// The remaining undercount is allocator overhead and HashMap metadata.
     pub fn memory_usage(&self) -> usize {
         std::mem::size_of::<TopKObject>() + self.sketch.mem_bytes(|item| item.capacity())
-    }
-
-    /// Relocate the sketch's heap allocations through `reallocator` (for active
-    /// defrag) and reconcile the memory gauge.
-    pub fn defrag_sketch<R: Reallocator>(&mut self, reallocator: &mut R) {
-        let before = self.memory_usage();
-        self.sketch
-            .realloc_large_heap_allocated_objects(reallocator);
-        let after = self.memory_usage();
-        metrics::TOPK_OBJECT_TOTAL_MEMORY_BYTES.fetch_sub(before - after, Ordering::Relaxed);
     }
 
     /// Bytes the sketch allocates up front.

--- a/src/topk/utils.rs
+++ b/src/topk/utils.rs
@@ -10,9 +10,6 @@ pub const DEFAULT_WIDTH: u32 = 8;
 pub const DEFAULT_DEPTH: u32 = 7;
 pub const DEFAULT_DECAY: f64 = 0.9;
 
-/// Per-argument bounds. The minimums are 1; the maximums span the full u32
-/// range because oversized sketches are bounded by the topk-memory-usage-limit
-/// config (see `TopKObject::estimated_size`), not by per-argument caps.
 pub const TOPK_K_MIN: u32 = 1;
 pub const TOPK_K_MAX: u32 = u32::MAX;
 pub const TOPK_WIDTH_MIN: u32 = 1;
@@ -116,33 +113,32 @@ impl TopKObject {
     }
 
     /// Relocate the sketch's heap allocations through `reallocator` (for active
-    /// defrag) and reconcile the memory gauge. 
+    /// defrag) and reconcile the memory gauge.
     pub fn defrag_sketch<R: Reallocator>(&mut self, reallocator: &mut R) {
         let before = self.memory_usage();
-        self.sketch.realloc_large_heap_allocated_objects(reallocator);
+        self.sketch
+            .realloc_large_heap_allocated_objects(reallocator);
         let after = self.memory_usage();
         metrics::TOPK_OBJECT_TOTAL_MEMORY_BYTES.fetch_sub(before - after, Ordering::Relaxed);
     }
 
-    /// Bytes the sketch allocates up front: `width` + `width * depth` cells
-    /// (16 bytes each), a 1024-entry u64 decay table, and the priority queue
-    /// reserved to capacity `k` (~128 bytes per entry, a conservative estimate).
+    /// Bytes the sketch allocates up front.
     pub fn estimated_size(k: u32, width: u32, depth: u32) -> u64 {
         let (k, width, depth) = (k as u64, width as u64, depth as u64);
         // Saturate: products can overflow u64 at u32::MAX, and wrapping would
         // let an oversized sketch slip under the limit.
-        let heavy = width.saturating_mul(depth).saturating_mul(16);
-        (std::mem::size_of::<TopKObject>() as u64)
-            .saturating_add(width.saturating_mul(16))
+        let heavy = width.saturating_mul(depth).saturating_mul(16); // heavy cells: width × depth × 16 bytes
+        (std::mem::size_of::<TopKObject>() as u64) // wrapper struct
+            .saturating_add(width.saturating_mul(16)) // lobby cells: width × 16 bytes
             .saturating_add(heavy)
-            .saturating_add(1024 * 8)
-            .saturating_add(k.saturating_mul(128))
+            .saturating_add(1024 * 8) // decay table: 1024 entries × 8 bytes
+            .saturating_add(k.saturating_mul(128)) // priority queue: ~128 bytes per k entry
     }
 
     /// Whether these params fit within the configured topk-memory-usage-limit.
     pub fn validate_size(k: u32, width: u32, depth: u32) -> bool {
-        let limit = configs::TOPK_MEMORY_LIMIT_PER_OBJECT.load(Ordering::Relaxed) as u64;
-        Self::estimated_size(k, width, depth) <= limit
+        let size_limit = configs::TOPK_MEMORY_LIMIT_PER_OBJECT.load(Ordering::Relaxed) as u64;
+        Self::estimated_size(k, width, depth) <= size_limit
     }
 
     /// Increments metrics related to object count, memory, and summed k upon creation of a new object.

--- a/src/wrapper/topk_callback.rs
+++ b/src/wrapper/topk_callback.rs
@@ -83,11 +83,8 @@ pub unsafe extern "C" fn topk_free_effort(
 
 /// Reallocator passed to the heavykeeper sketch during defrag. Routes each
 /// block through Valkey's defrag allocator; a null result means "not
-/// relocated", so we keep the original allocation.
-///
-/// Assumes `align_of::<T>() <= 16`, the alignment the defrag allocator
-/// guarantees. All element types the sketch passes through today
-/// satisfy this; revisit if a more strictly aligned type is added.
+/// relocated", so we keep the original allocation. Assumes `align_of::<T>()
+/// <= 16`, which the defrag allocator guarantees and every sketch type meets.
 struct Defragger;
 
 impl Reallocator for Defragger {

--- a/src/wrapper/topk_callback.rs
+++ b/src/wrapper/topk_callback.rs
@@ -117,11 +117,22 @@ pub unsafe extern "C" fn topk_defrag(
     if !configs::TOPK_DEFRAG.load(Ordering::Relaxed) {
         return 0;
     }
-    // Relocate the sketch's internal heap allocations.
+    // Relocate the sketch's internal heap allocations. The reallocation trims
+    // spare Vec capacity (into_boxed_slice), so the memory gauge is reconciled
+    // by the before/after delta to keep it balanced against Drop's subtraction.
     let topk_object: &mut TopKObject = &mut *(*value).cast::<TopKObject>();
+    let mem_before = topk_object.memory_usage();
     topk_object
         .sketch_mut()
         .realloc_large_heap_allocated_objects(&mut Defragger);
+    let mem_after = topk_object.memory_usage();
+    if mem_before > mem_after {
+        metrics::TOPK_OBJECT_TOTAL_MEMORY_BYTES
+            .fetch_sub(mem_before - mem_after, Ordering::Relaxed);
+    } else {
+        metrics::TOPK_OBJECT_TOTAL_MEMORY_BYTES
+            .fetch_add(mem_after - mem_before, Ordering::Relaxed);
+    }
     // Relocate the TopKObject allocation itself.
     let defrag = Defrag::new(defrag_ctx);
     let val = defrag.alloc(*value);

--- a/src/wrapper/topk_callback.rs
+++ b/src/wrapper/topk_callback.rs
@@ -117,11 +117,11 @@ pub unsafe extern "C" fn topk_defrag(
     if !configs::TOPK_DEFRAG.load(Ordering::Relaxed) {
         return 0;
     }
-    // Relocate the sketch's internal heap allocations (reconciles the memory
-    // gauge for any spare Vec capacity trimmed during relocation).
+    // Defrag the sketch's internal heap allocations (reconciles the memory
+    // gauge for any spare Vec capacity trimmed during defrag).
     let topk_object: &mut TopKObject = &mut *(*value).cast::<TopKObject>();
     topk_object.defrag_sketch(&mut Defragger);
-    // Relocate the TopKObject allocation itself.
+    // Attempt to defrag the TopKObject allocation itself.
     let defrag = Defrag::new(defrag_ctx);
     let val = defrag.alloc(*value);
     if !val.is_null() {

--- a/src/wrapper/topk_callback.rs
+++ b/src/wrapper/topk_callback.rs
@@ -1,11 +1,15 @@
+use crate::configs;
+use crate::metrics;
 use crate::topk::data_type::ValkeyDataType;
 use crate::topk::utils::TopKObject;
 use std::os::raw::{c_int, c_void};
 use std::ptr::null_mut;
+use std::sync::atomic::Ordering;
+use valkey_module::defrag::Defrag;
 use valkey_module::digest::Digest;
 use valkey_module::logging;
 use valkey_module::raw;
-use valkey_module::RedisModuleString;
+use valkey_module::{RedisModuleDefragCtx, RedisModuleString};
 
 /// # Safety
 pub unsafe extern "C" fn topk_rdb_save(rdb: *mut raw::RedisModuleIO, value: *mut c_void) {
@@ -74,4 +78,48 @@ pub unsafe extern "C" fn topk_free_effort(
     _value: *const c_void,
 ) -> usize {
     1
+}
+
+/// Reallocation callback passed to the heavykeeper sketch. Routes each block
+/// through Valkey's defrag allocator; a null result means "not relocated", so
+/// we return the original pointer.
+fn topk_realloc(ptr: *mut u8, _size: usize, _align: usize) -> *mut u8 {
+    let defrag = Defrag::new(core::ptr::null_mut());
+    let new = unsafe { defrag.alloc(ptr as *mut c_void) };
+    if new.is_null() {
+        metrics::TOPK_DEFRAG_MISSES.fetch_add(1, Ordering::Relaxed);
+        ptr
+    } else {
+        metrics::TOPK_DEFRAG_HITS.fetch_add(1, Ordering::Relaxed);
+        new as *mut u8
+    }
+}
+
+/// # Safety
+/// Raw handler for the TopK object's defrag callback. A TopKObject holds one
+/// sketch inline, so we defrag its heap allocations and then the object itself
+/// in a single pass, always returning 0 (complete).
+pub unsafe extern "C" fn topk_defrag(
+    defrag_ctx: *mut RedisModuleDefragCtx,
+    _from_key: *mut RedisModuleString,
+    value: *mut *mut c_void,
+) -> i32 {
+    if !configs::TOPK_DEFRAG.load(Ordering::Relaxed) {
+        return 0;
+    }
+    // Relocate the sketch's internal heap allocations.
+    let topk_object: &mut TopKObject = &mut *(*value).cast::<TopKObject>();
+    topk_object
+        .sketch_mut()
+        .realloc_large_heap_allocated_objects(topk_realloc);
+    // Relocate the TopKObject allocation itself.
+    let defrag = Defrag::new(defrag_ctx);
+    let val = defrag.alloc(*value);
+    if !val.is_null() {
+        metrics::TOPK_DEFRAG_HITS.fetch_add(1, Ordering::Relaxed);
+        *value = val;
+    } else {
+        metrics::TOPK_DEFRAG_MISSES.fetch_add(1, Ordering::Relaxed);
+    }
+    0
 }

--- a/src/wrapper/topk_callback.rs
+++ b/src/wrapper/topk_callback.rs
@@ -2,6 +2,7 @@ use crate::configs;
 use crate::metrics;
 use crate::topk::data_type::ValkeyDataType;
 use crate::topk::utils::TopKObject;
+use heavykeeper::Reallocator;
 use std::os::raw::{c_int, c_void};
 use std::ptr::null_mut;
 use std::sync::atomic::Ordering;
@@ -80,18 +81,30 @@ pub unsafe extern "C" fn topk_free_effort(
     1
 }
 
-/// Reallocation callback passed to the heavykeeper sketch. Routes each block
-/// through Valkey's defrag allocator; a null result means "not relocated", so
-/// we return the original pointer.
-fn topk_realloc(ptr: *mut u8, _size: usize, _align: usize) -> *mut u8 {
-    let defrag = Defrag::new(core::ptr::null_mut());
-    let new = unsafe { defrag.alloc(ptr as *mut c_void) };
-    if new.is_null() {
-        metrics::TOPK_DEFRAG_MISSES.fetch_add(1, Ordering::Relaxed);
-        ptr
-    } else {
-        metrics::TOPK_DEFRAG_HITS.fetch_add(1, Ordering::Relaxed);
-        new as *mut u8
+/// Reallocator passed to the heavykeeper sketch during defrag. Routes each
+/// block through Valkey's defrag allocator; a null result means "not
+/// relocated", so we keep the original allocation.
+///
+/// Assumes `align_of::<T>() <= 16`, the alignment the defrag allocator
+/// guarantees. All element types the sketch passes through today
+/// satisfy this; revisit if a more strictly aligned type is added.
+struct Defragger;
+
+impl Reallocator for Defragger {
+    fn realloc<T>(&mut self, boxed: Box<[T]>) -> Box<[T]> {
+        let len = boxed.len();
+        if len == 0 || core::mem::size_of::<T>() == 0 {
+            return boxed;
+        }
+        let old = Box::into_raw(boxed) as *mut c_void;
+        let new = unsafe { Defrag::new(core::ptr::null_mut()).alloc(old) };
+        if new.is_null() {
+            metrics::TOPK_DEFRAG_MISSES.fetch_add(1, Ordering::Relaxed);
+            unsafe { Box::from_raw(core::ptr::slice_from_raw_parts_mut(old as *mut T, len)) }
+        } else {
+            metrics::TOPK_DEFRAG_HITS.fetch_add(1, Ordering::Relaxed);
+            unsafe { Box::from_raw(core::ptr::slice_from_raw_parts_mut(new as *mut T, len)) }
+        }
     }
 }
 
@@ -111,7 +124,7 @@ pub unsafe extern "C" fn topk_defrag(
     let topk_object: &mut TopKObject = &mut *(*value).cast::<TopKObject>();
     topk_object
         .sketch_mut()
-        .realloc_large_heap_allocated_objects(topk_realloc);
+        .realloc_large_heap_allocated_objects(&mut Defragger);
     // Relocate the TopKObject allocation itself.
     let defrag = Defrag::new(defrag_ctx);
     let val = defrag.alloc(*value);

--- a/src/wrapper/topk_callback.rs
+++ b/src/wrapper/topk_callback.rs
@@ -117,10 +117,11 @@ pub unsafe extern "C" fn topk_defrag(
     if !configs::TOPK_DEFRAG.load(Ordering::Relaxed) {
         return 0;
     }
-    // Defrag the sketch's internal heap allocations (reconciles the memory
-    // gauge for any spare Vec capacity trimmed during defrag).
+    // Defrag the sketch's internal heap allocations.
     let topk_object: &mut TopKObject = &mut *(*value).cast::<TopKObject>();
-    topk_object.defrag_sketch(&mut Defragger);
+    topk_object
+        .sketch_mut()
+        .realloc_large_heap_allocated_objects(&mut Defragger);
     // Attempt to defrag the TopKObject allocation itself.
     let defrag = Defrag::new(defrag_ctx);
     let val = defrag.alloc(*value);

--- a/src/wrapper/topk_callback.rs
+++ b/src/wrapper/topk_callback.rs
@@ -118,6 +118,9 @@ pub unsafe extern "C" fn topk_defrag(
         return 0;
     }
     // Defrag the sketch's internal heap allocations.
+    // The internal vecs shrink after defrag but are reallocated to their original
+    // capacity (k) on the next add. Since memory usage is calculated from capacity,
+    // this will cause a temporary overcount until the next add restores the capacity.
     let topk_object: &mut TopKObject = &mut *(*value).cast::<TopKObject>();
     topk_object
         .sketch_mut()

--- a/src/wrapper/topk_callback.rs
+++ b/src/wrapper/topk_callback.rs
@@ -117,22 +117,10 @@ pub unsafe extern "C" fn topk_defrag(
     if !configs::TOPK_DEFRAG.load(Ordering::Relaxed) {
         return 0;
     }
-    // Relocate the sketch's internal heap allocations. The reallocation trims
-    // spare Vec capacity (into_boxed_slice), so the memory gauge is reconciled
-    // by the before/after delta to keep it balanced against Drop's subtraction.
+    // Relocate the sketch's internal heap allocations (reconciles the memory
+    // gauge for any spare Vec capacity trimmed during relocation).
     let topk_object: &mut TopKObject = &mut *(*value).cast::<TopKObject>();
-    let mem_before = topk_object.memory_usage();
-    topk_object
-        .sketch_mut()
-        .realloc_large_heap_allocated_objects(&mut Defragger);
-    let mem_after = topk_object.memory_usage();
-    if mem_before > mem_after {
-        metrics::TOPK_OBJECT_TOTAL_MEMORY_BYTES
-            .fetch_sub(mem_before - mem_after, Ordering::Relaxed);
-    } else {
-        metrics::TOPK_OBJECT_TOTAL_MEMORY_BYTES
-            .fetch_add(mem_after - mem_before, Ordering::Relaxed);
-    }
+    topk_object.defrag_sketch(&mut Defragger);
     // Relocate the TopKObject allocation itself.
     let defrag = Defrag::new(defrag_ctx);
     let val = defrag.alloc(*value);

--- a/tests/test_topk_basic.py
+++ b/tests/test_topk_basic.py
@@ -209,3 +209,20 @@ class TestTopkBasic(SkipSeedParameterizationMixin, ValkeyBloomTestCaseBase):
         for item, estimate in zip(items, estimates):
             assert estimate <= true_counts[item], f'{item}: {estimate} > {true_counts[item]}'
 
+    def test_too_large_topk_obj(self):
+        obj_exceeds_size_err = "operation exceeds topk object memory limit"
+        # Normal sizes are within the default 128MB limit.
+        assert self.client.execute_command('TOPK.RESERVE tk_ok 5 200 5 0.9') == b'OK'
+
+        # A huge width*depth is rejected before allocating.
+        self.verify_error_response(self.client, 'TOPK.RESERVE tk_big 5 4000000000 1000 0.9', obj_exceeds_size_err)
+        assert self.client.execute_command('EXISTS tk_big') == 0
+
+        # A huge k is also rejected (the priority queue reserves capacity k).
+        self.verify_error_response(self.client, 'TOPK.RESERVE tk_big_k 4000000000 50 4 0.9', obj_exceeds_size_err)
+        assert self.client.execute_command('EXISTS tk_big_k') == 0
+
+        # Lowering the limit rejects a sketch that was previously allowed.
+        self.client.config_set('bf.topk-memory-usage-limit', '10000')
+        self.verify_error_response(self.client, 'TOPK.RESERVE tk_small 5 200 5 0.9', obj_exceeds_size_err)
+

--- a/tests/test_topk_basic.py
+++ b/tests/test_topk_basic.py
@@ -209,6 +209,13 @@ class TestTopkBasic(SkipSeedParameterizationMixin, ValkeyBloomTestCaseBase):
         for item, estimate in zip(items, estimates):
             assert estimate <= true_counts[item], f'{item}: {estimate} > {true_counts[item]}'
 
+    def test_memory_usage_cmd(self):
+        assert self.client.execute_command('TOPK.RESERVE tk 5 50 4 0.9 SEED 42') == b'OK'
+        self.client.execute_command('TOPK.ADD tk apple banana cherry')
+        info = self.client.execute_command('TOPK.INFO tk')
+        info_size = dict(zip(info[::2], info[1::2]))[b'Size']
+        assert self.client.execute_command('MEMORY USAGE tk') >= info_size and info_size > 0
+
     def test_too_large_topk_obj(self):
         obj_exceeds_size_err = "operation exceeds topk object memory limit"
         # Normal sizes are within the default 128MB limit.

--- a/tests/test_topk_command.py
+++ b/tests/test_topk_command.py
@@ -172,7 +172,6 @@ class TestTopkCommand(SkipSeedParameterizationMixin, ValkeyBloomTestCaseBase):
         assert info[b'Depth'] == 7
         assert info[b'Decay'] == b'0.9'
         assert info[b'Size'] > 0
-        assert info[b'Size'] <= self.client.execute_command('MEMORY USAGE tk1')
         # tk1 was re-reserved with no items, so nothing has been added yet.
         assert info[b'Total items added'] == 0
 
@@ -182,7 +181,6 @@ class TestTopkCommand(SkipSeedParameterizationMixin, ValkeyBloomTestCaseBase):
         assert info[b'Depth'] == 5
         assert info[b'Decay'] == b'0.5'
         assert info[b'Size'] > 0
-        assert info[b'Size'] <= self.client.execute_command('MEMORY USAGE tk5')
         assert info[b'Total items added'] == 0
 
         info = info_dict('tk_incr')

--- a/tests/test_topk_defrag.py
+++ b/tests/test_topk_defrag.py
@@ -73,7 +73,25 @@ class TestTopkDefrag(SkipSeedParameterizationMixin, ValkeyBloomTestCaseBase):
         info_results = self.client.info("bf")
         assert info_results['bf_topk_defrag_hits'] + info_results['bf_topk_defrag_misses'] > 0
 
-        # Round-trip through RDB and confirm the defragged objects still match.
+        # A defragged object must still behave correctly under writes.
+        sample_keys = remaining_keys[:20]
+        evicted_any = False
+        for key in sample_keys:
+            # 'hot' is new to this sketch; repeated adds beat the count-1 residents.
+            result = self.client.execute_command(f'TOPK.ADD {key} ' + ' '.join(['hot'] * 10))
+            assert len(result) == 10, f"unexpected TOPK.ADD reply for {key}: {result}"
+            evicted_any = evicted_any or any(item is not None for item in result)
+            # 'hot' is now tracked, and the sketch still holds no more than k items.
+            assert self.client.execute_command(f'TOPK.QUERY {key} hot') == [1], f"hot not tracked in {key}"
+            listed = self.client.execute_command(f'TOPK.LIST {key}')
+            assert len(listed) <= 20, f"{key} exceeds k after post-defrag adds: {len(listed)}"
+        assert evicted_any, "no eviction observed on any defragged object"
+
+        # Snapshot the post-write state so the RDB round-trip is checked against
+        # the objects as they stand now.
+        digests_after_writes = {key: self.client.execute_command(f'DEBUG DIGEST-VALUE {key}') for key in remaining_keys}
+
+        # Round-trip through RDB and confirm the defragged, mutated objects survive.
         self.client.execute_command('BGSAVE')
         self.server.wait_for_save_done()
 
@@ -82,4 +100,4 @@ class TestTopkDefrag(SkipSeedParameterizationMixin, ValkeyBloomTestCaseBase):
         wait_for_equal(lambda: self.server.is_rdb_done_loading(), True)
 
         digests_after_rdb_load = {key: self.client.execute_command(f'DEBUG DIGEST-VALUE {key}') for key in remaining_keys}
-        assert digests_before_defrag == digests_after_rdb_load, "Digest mismatch after RDB load"
+        assert digests_after_writes == digests_after_rdb_load, "Digest mismatch after RDB load"

--- a/tests/test_topk_defrag.py
+++ b/tests/test_topk_defrag.py
@@ -1,0 +1,106 @@
+import time
+from valkey_bloom_test_case import ValkeyBloomTestCaseBase
+from valkeytestframework.conftest import resource_port_tracker
+from valkeytestframework.util.waiters import *
+import pytest
+
+@pytest.mark.skip_for_asan(reason="These tests are skipped due to not being able to set activedefrag to yes when valkey server is an ASAN build")
+class TestTopkDefrag(ValkeyBloomTestCaseBase):
+
+    def test_topk_defrag(self):
+        # Set defragmentation thresholds
+        self.client.config_set('activedefrag', 'no')
+        self.client.config_set('active-defrag-ignore-bytes', '1')
+        self.client.config_set('active-defrag-threshold-lower', '2')
+        max_memory = 300 * 1024 * 1024
+        self.client.config_set('maxmemory', str(max_memory))
+
+        # Initial stats
+        stats = self.parse_valkey_info("STATS")
+        initial_defrag_hits = int(stats.get('active_defrag_hits', 0))
+
+        # Create list of key names we will operate with. A wide sketch makes the
+        # lobby/heavy cell arrays large enough to be worth relocating.
+        key_names = [f'topk_{i}' for i in range(1, 1500)]
+
+        # Insert data. Use the key name as item prefix so each sketch is distinct.
+        for key in key_names:
+            self.client.execute_command(f'TOPK.RESERVE {key} 20 200 5 0.9')
+            self.client.execute_command(
+                f'TOPK.ADD {key} ' + ' '.join(f'{key}_{i}' for i in range(1, 40))
+            )
+
+        # Delete every other object to create fragmentation.
+        for key in key_names[::2]:
+            self.client.execute_command(f'DEL {key}')
+        remaining_keys = key_names[1::2]
+
+        # Capture per-key state before defrag for a strict equality check after.
+        digests_before_defrag = {key: self.client.execute_command(f'DEBUG DIGEST-VALUE {key}') for key in remaining_keys}
+        lists_before_defrag = {key: self.client.execute_command(f'TOPK.LIST {key} WITHCOUNT') for key in remaining_keys}
+
+        # Add a wait due to lazy delete where if we call info too early we wont get the correct memory info
+        time.sleep(5)
+
+        # Enable defragmentation and wait until the topk callback has relocated something.
+        self.client.config_set('activedefrag', 'yes')
+        wait_for_equal(lambda: self.client.info("bf")['bf_topk_defrag_hits'] > 0, True)
+
+        first_defrag_stats = self.parse_valkey_info("STATS")
+        first_defrag_hits = int(first_defrag_stats.get('active_defrag_hits', 0))
+
+        # The valkey-level defrag ran and our topk callback relocated allocations.
+        assert first_defrag_hits > initial_defrag_hits
+
+        # Data must be unchanged by defrag: digests and top-k lists match exactly.
+        digests_after_defrag = {key: self.client.execute_command(f'DEBUG DIGEST-VALUE {key}') for key in remaining_keys}
+        assert digests_before_defrag == digests_after_defrag, "Digest mismatch after defrag"
+        lists_after_defrag = {key: self.client.execute_command(f'TOPK.LIST {key} WITHCOUNT') for key in remaining_keys}
+        assert lists_before_defrag == lists_after_defrag, "TOPK.LIST mismatch after defrag"
+
+        # The module-level defrag callback ran for the topk data type.
+        info_results = self.client.info("bf")
+        assert info_results['bf_topk_defrag_hits'] + info_results['bf_topk_defrag_misses'] > 0
+
+        # Round-trip through RDB and confirm the defragged objects still match.
+        self.client.execute_command('BGSAVE')
+        self.server.wait_for_save_done()
+
+        self.server.restart(remove_rdb=False, remove_nodes_conf=False, connect_client=True)
+        assert self.server.is_alive()
+        wait_for_equal(lambda: self.server.is_rdb_done_loading(), True)
+
+        digests_after_rdb_load = {key: self.client.execute_command(f'DEBUG DIGEST-VALUE {key}') for key in remaining_keys}
+        assert digests_before_defrag == digests_after_rdb_load, "Digest mismatch after RDB load"
+
+    def test_topk_defrag_disabled(self):
+        # With topk-defrag-enabled off, the topk callback is a no-op: it must not
+        # register any topk defrag hits/misses even while active defrag runs.
+        self.client.config_set('activedefrag', 'no')
+        self.client.config_set('active-defrag-ignore-bytes', '1')
+        self.client.config_set('active-defrag-threshold-lower', '2')
+        self.client.config_set('maxmemory', str(300 * 1024 * 1024))
+        self.client.config_set('bf.topk-defrag-enabled', 'no')
+
+        key_names = [f'topk_off_{i}' for i in range(1, 1500)]
+        for key in key_names:
+            self.client.execute_command(f'TOPK.RESERVE {key} 20 200 5 0.9')
+            self.client.execute_command(
+                f'TOPK.ADD {key} ' + ' '.join(f'{key}_{i}' for i in range(1, 40))
+            )
+        for key in key_names[::2]:
+            self.client.execute_command(f'DEL {key}')
+        remaining_keys = key_names[1::2]
+        digests_before_defrag = {key: self.client.execute_command(f'DEBUG DIGEST-VALUE {key}') for key in remaining_keys}
+
+        time.sleep(5)
+        topk_hits_before = self.client.info("bf")['bf_topk_defrag_hits']
+
+        self.client.config_set('activedefrag', 'yes')
+        wait_for_equal(lambda: int(self.parse_valkey_info("STATS").get('total_active_defrag_time')) > 5000, True)
+
+        # No topk defrag activity while disabled, and data is untouched.
+        info_results = self.client.info("bf")
+        assert info_results['bf_topk_defrag_hits'] == topk_hits_before
+        digests_after_defrag = {key: self.client.execute_command(f'DEBUG DIGEST-VALUE {key}') for key in remaining_keys}
+        assert digests_before_defrag == digests_after_defrag, "Digest mismatch with defrag disabled"

--- a/tests/test_topk_defrag.py
+++ b/tests/test_topk_defrag.py
@@ -1,11 +1,11 @@
 import time
-from valkey_bloom_test_case import ValkeyBloomTestCaseBase
+from valkey_bloom_test_case import SkipSeedParameterizationMixin, ValkeyBloomTestCaseBase
 from valkeytestframework.conftest import resource_port_tracker
 from valkeytestframework.util.waiters import *
 import pytest
 
 @pytest.mark.skip_for_asan(reason="These tests are skipped due to not being able to set activedefrag to yes when valkey server is an ASAN build")
-class TestTopkDefrag(ValkeyBloomTestCaseBase):
+class TestTopkDefrag(SkipSeedParameterizationMixin, ValkeyBloomTestCaseBase):
 
     def test_topk_defrag(self):
         # Set defragmentation thresholds
@@ -42,6 +42,9 @@ class TestTopkDefrag(ValkeyBloomTestCaseBase):
         # Add a wait due to lazy delete where if we call info too early we wont get the correct memory info
         time.sleep(5)
 
+        # Fragmentation before defrag, for a strict before/after comparison.
+        frag_ratio_before = float(self.parse_valkey_info("MEMORY").get('allocator_frag_ratio', 0))
+
         # Enable defragmentation and wait until the topk callback has relocated something.
         self.client.config_set('activedefrag', 'yes')
         wait_for_equal(lambda: self.client.info("bf")['bf_topk_defrag_hits'] > 0, True)
@@ -51,6 +54,14 @@ class TestTopkDefrag(ValkeyBloomTestCaseBase):
 
         # The valkey-level defrag ran and our topk callback relocated allocations.
         assert first_defrag_hits > initial_defrag_hits
+
+        # Fragmentation must actually drop once defrag has done its work. We wait
+        # on the ratio itself (rather than sampling once) since defrag runs
+        # asynchronously; a timeout here means fragmentation was never reduced.
+        wait_for_equal(
+            lambda: float(self.parse_valkey_info("MEMORY").get('allocator_frag_ratio', 0)) < frag_ratio_before,
+            True,
+        )
 
         # Data must be unchanged by defrag: digests and top-k lists match exactly.
         digests_after_defrag = {key: self.client.execute_command(f'DEBUG DIGEST-VALUE {key}') for key in remaining_keys}
@@ -72,35 +83,3 @@ class TestTopkDefrag(ValkeyBloomTestCaseBase):
 
         digests_after_rdb_load = {key: self.client.execute_command(f'DEBUG DIGEST-VALUE {key}') for key in remaining_keys}
         assert digests_before_defrag == digests_after_rdb_load, "Digest mismatch after RDB load"
-
-    def test_topk_defrag_disabled(self):
-        # With topk-defrag-enabled off, the topk callback is a no-op: it must not
-        # register any topk defrag hits/misses even while active defrag runs.
-        self.client.config_set('activedefrag', 'no')
-        self.client.config_set('active-defrag-ignore-bytes', '1')
-        self.client.config_set('active-defrag-threshold-lower', '2')
-        self.client.config_set('maxmemory', str(300 * 1024 * 1024))
-        self.client.config_set('bf.topk-defrag-enabled', 'no')
-
-        key_names = [f'topk_off_{i}' for i in range(1, 1500)]
-        for key in key_names:
-            self.client.execute_command(f'TOPK.RESERVE {key} 20 200 5 0.9')
-            self.client.execute_command(
-                f'TOPK.ADD {key} ' + ' '.join(f'{key}_{i}' for i in range(1, 40))
-            )
-        for key in key_names[::2]:
-            self.client.execute_command(f'DEL {key}')
-        remaining_keys = key_names[1::2]
-        digests_before_defrag = {key: self.client.execute_command(f'DEBUG DIGEST-VALUE {key}') for key in remaining_keys}
-
-        time.sleep(5)
-        topk_hits_before = self.client.info("bf")['bf_topk_defrag_hits']
-
-        self.client.config_set('activedefrag', 'yes')
-        wait_for_equal(lambda: int(self.parse_valkey_info("STATS").get('total_active_defrag_time')) > 5000, True)
-
-        # No topk defrag activity while disabled, and data is untouched.
-        info_results = self.client.info("bf")
-        assert info_results['bf_topk_defrag_hits'] == topk_hits_before
-        digests_after_defrag = {key: self.client.execute_command(f'DEBUG DIGEST-VALUE {key}') for key in remaining_keys}
-        assert digests_before_defrag == digests_after_defrag, "Digest mismatch with defrag disabled"


### PR DESCRIPTION
## Summary

Adds defrag support for the TopK data type, so a TopK sketch's memory can be relocated out of fragmented allocator regions during the background defrag pass. The relocation itself is delegated to the [heavykeeper fork](https://github.com/detemmienation/heavykeeper-rs/tree/rdb-defrag)'s `Reallocator` trait.

It also adds a per-object memory-usage limit config, guarding against a single TOPK.RESERVE allocating unbounded memory.


## Changes

### Defrag callback
- Wire up the `defrag` type callback.
- Add a `Defragger` implementing heavykeeper's `Reallocator`, backed by Valkey's defrag allocator. A null allocator result means "not relocated", so it keeps the original allocation.
- `topk_defrag` relocates the sketch's heap allocations via `realloc_large_heap_allocated_objects`, then the `TopKObject` itself, in a single pass. No cursor: unlike the bloom, relocation is cheap enough to finish in one pass.
- Reconcile the memory gauge across a defrag: relocation trims spare `Vec` capacity (`into_boxed_slice`), which `memory_usage()` counts, so `topk_defrag` recomputes it before/after and applies the delta to keep the gauge balanced against `Drop`.


### Config
- Add the `topk-defrag-enabled` boolean config (default `true`). When off, the callback is a no-op.
- Add the `topk-memory-usage-limit` config (default 128MB, mirroring `bloom-memory-usage-limit`). A `TOPK.RESERVE` whose sketch would exceed it is rejected before allocating. `TopKObject::estimated_size` estimates the up-front allocation from `k`, `width`, and `depth` (cell arrays, decay table, and the priority queue reserved to capacity `k`), saturating so oversized params cannot wrap under the limit.


### Metrics
- Add `bf_topk_defrag_hits` / `bf_topk_defrag_misses`, exposed via a new `topk_defrag_metrics` INFO section.

### Tests
- `test_topk_defrag.py`: create many TopK objects, delete half to fragment the heap, run active defrag, and assert the callback ran (`bf_topk_defrag_hits > 0`), fragmentation dropped (`allocator_frag_ratio` below its pre-defrag value), and data is unchanged (`DEBUG DIGEST-VALUE` / `TOPK.LIST` equal before/after and across an RDB round-trip).
- `test_topk_basic.py`:
  - `test_too_large_topk_obj` asserts an oversized `TOPK.RESERVE` (huge `width * depth`, or a huge `k` alone) is rejected, and that lowering the limit rejects a sketch that was previously allowed.
  - `test_memory_usage_cmd` asserts a TopK object's engine-reported `MEMORY USAGE` is at least its `TOPK.INFO` Size.


