### PR TITLE
Match bloom memory tracking by small over count of bytes after a defrag operation

### DIFF
--- a/src/bloom/utils.rs
+++ b/src/bloom/utils.rs
@@ -446,6 +446,14 @@ impl BloomObject {
         );
     }
 
+    pub fn decrement_metrics_on_defrag(&self, predefrag_filters_capacity: usize) {
+        metrics::BLOOM_OBJECT_TOTAL_MEMORY_BYTES.fetch_sub(
+            (predefrag_filters_capacity - self.num_filters())
+                * std::mem::size_of::<Box<BloomFilter>>(),
+            std::sync::atomic::Ordering::Relaxed,
+        );
+    }
+
     /// Deserialize a byte array to bloom filter.
     /// We will need to handle any current or previous version and deserializing the bytes into a bloom object of the running Module's current version `BLOOM_OBJECT_VERSION`.
     pub fn decode_object(

--- a/src/wrapper/bloom_callback.rs
+++ b/src/wrapper/bloom_callback.rs
@@ -229,7 +229,7 @@ pub unsafe extern "C" fn bloom_defrag(
     let bloom_object: &mut BloomObject = &mut *(*value).cast::<BloomObject>();
 
     let num_filters = bloom_object.num_filters();
-    let filters_capacity = bloom_object.filters().capacity();
+    let predefrag_filters_capacity = bloom_object.filters().capacity();
 
     // While we are within a timeframe decided from should_stop_defrag and not over the number of filters defrag the next filter
     while !defrag.should_stop_defrag() && cursor < num_filters as u64 {
@@ -317,10 +317,7 @@ pub unsafe extern "C" fn bloom_defrag(
     }
     // As we drop some capcity we need to change the memory usage to avoid showing a higher memory usage than what is really used.
     // This will be the difference in capacity and number of filters only * size of the box of bloom filters.
-    metrics::BLOOM_OBJECT_TOTAL_MEMORY_BYTES.fetch_sub(
-        (filters_capacity - num_filters) * std::mem::size_of::<Box<BloomFilter>>(),
-        std::sync::atomic::Ordering::Relaxed,
-    );
+    bloom_object.decrement_metrics_on_defrag(predefrag_filters_capacity);
     // Finally, attempt to defragment the BloomObject itself
     let val = defrag.alloc(*value);
     if !val.is_null() {

--- a/src/wrapper/bloom_callback.rs
+++ b/src/wrapper/bloom_callback.rs
@@ -229,6 +229,7 @@ pub unsafe extern "C" fn bloom_defrag(
     let bloom_object: &mut BloomObject = &mut *(*value).cast::<BloomObject>();
 
     let num_filters = bloom_object.num_filters();
+    let filters_capacity = bloom_object.filters().capacity();
 
     // While we are within a timeframe decided from should_stop_defrag and not over the number of filters defrag the next filter
     while !defrag.should_stop_defrag() && cursor < num_filters as u64 {
@@ -314,6 +315,12 @@ pub unsafe extern "C" fn bloom_defrag(
             )
         };
     }
+    // As we drop some capcity we need to change the memory usage to avoid showing a higher memory usage than what is really used.
+    // This will be the difference in capacity and number of filters only * size of the box of bloom filters.
+    metrics::BLOOM_OBJECT_TOTAL_MEMORY_BYTES.fetch_sub(
+        (filters_capacity - num_filters) * std::mem::size_of::<Box<BloomFilter>>(),
+        std::sync::atomic::Ordering::Relaxed,
+    );
     // Finally, attempt to defragment the BloomObject itself
     let val = defrag.alloc(*value);
     if !val.is_null() {


### PR DESCRIPTION
This commit does a quick reallocation of size after a defrag on the vecs in bloom. This is needed due to dropping excess capacity which was initially tracked by memory metric. As we were silently dropping this we would have a very slight overcount in memory used by bloom in certain cases.