### PR TITLE
Count Min Sketch Module: Implement CMS.INCRBY and CMS.QUERY

### DIFF
--- a/src/cms/cms_command_handler.rs
+++ b/src/cms/cms_command_handler.rs
@@ -179,10 +179,12 @@ pub fn cms_increment_by(ctx: &Context, args: Vec<ValkeyString>) -> ValkeyResult 
     }
 
     let mut i = 2;
-    let mut pairs: Vec<(&[u8], &ValkeyString)> = Vec::new();
+    let mut pairs: Vec<(&[u8], u64)> = Vec::new();
     while i < args_count {
         let k = args[i].as_slice();
-        let v = &args[i + 1];
+        let v = args[i + 1]
+            .parse_unsigned_integer()
+            .map_err(|_| ValkeyError::Str(utils::BAD_INCREMENT))?;
         pairs.push((k, v));
         i += 2
     }
@@ -198,13 +200,7 @@ pub fn cms_increment_by(ctx: &Context, args: Vec<ValkeyString>) -> ValkeyResult 
         None => Err(ValkeyError::nonexistent_key()),
         Some(v) => {
             for (item, increment) in pairs {
-                let item = &item;
-                let parsed_value = &increment.to_string_lossy().parse::<u64>();
-                let value = match parsed_value {
-                    Ok(v) => v,
-                    Err(_) => return Err(ValkeyError::Str(utils::BAD_INCREMENT)),
-                };
-                let count = v.increment_by(item, value.to_owned());
+                let count = v.increment_by(item, increment);
                 results.push(ValkeyValue::Integer(count as i64));
             }
             replicate_and_notify_events(ctx, key, Operation::Increment);

--- a/src/cms/cms_command_handler.rs
+++ b/src/cms/cms_command_handler.rs
@@ -179,9 +179,9 @@ pub fn cms_increment_by(ctx: &Context, args: Vec<ValkeyString>) -> ValkeyResult 
     }
 
     let mut i = 2;
-    let mut pairs: Vec<(&ValkeyString, &ValkeyString)> = Vec::new();
+    let mut pairs: Vec<(&[u8], &ValkeyString)> = Vec::new();
     while i < args_count {
-        let k = &args[i];
+        let k = args[i].as_slice();
         let v = &args[i + 1];
         pairs.push((k, v));
         i += 2
@@ -198,7 +198,7 @@ pub fn cms_increment_by(ctx: &Context, args: Vec<ValkeyString>) -> ValkeyResult 
         None => Err(ValkeyError::nonexistent_key()),
         Some(v) => {
             for (item, increment) in pairs {
-                let item = &item.to_string_lossy();
+                let item = &item;
                 let parsed_value = &increment.to_string_lossy().parse::<u64>();
                 let value = match parsed_value {
                     Ok(v) => v,
@@ -234,7 +234,7 @@ pub fn cms_query(ctx: &Context, args: Vec<ValkeyString>) -> ValkeyResult {
             let estimates: Vec<ValkeyValue> = args[2..]
                 .iter()
                 .map(|item| {
-                    let estimate = v.estimate(&item.to_string_lossy());
+                    let estimate = v.estimate(&item);
                     ValkeyValue::Integer(estimate as i64)
                 })
                 .collect();

--- a/src/cms/cms_command_handler.rs
+++ b/src/cms/cms_command_handler.rs
@@ -1,4 +1,6 @@
-use valkey_module::{Context, NotifyEvent, ValkeyError, ValkeyResult, ValkeyString, VALKEY_OK};
+use valkey_module::{
+    Context, NotifyEvent, ValkeyError, ValkeyResult, ValkeyString, ValkeyValue, VALKEY_OK,
+};
 
 use crate::cms::data_type::CMS_TYPE;
 use crate::cms::utils::{self, CMSObject};
@@ -9,18 +11,13 @@ enum Replications {
 }
 
 enum Operation {
-    Initialization,
+    Initialization { replications: Replications },
     Increment,
 }
 
-fn replicate_and_notify_events(
-    ctx: &Context,
-    key_name: &ValkeyString,
-    operation: Operation,
-    args: Replications,
-) {
+fn replicate_and_notify_events(ctx: &Context, key_name: &ValkeyString, operation: Operation) {
     match operation {
-        Operation::Initialization => match args {
+        Operation::Initialization { replications } => match replications {
             Replications::ReplicateArgsDim { width, depth } => {
                 let width_val = ValkeyString::create_from_slice(
                     std::ptr::null_mut(),
@@ -94,7 +91,11 @@ pub fn cms_initialize_by_dimensions(ctx: &Context, args: Vec<ValkeyString>) -> V
             match filter_key.set_value(&CMS_TYPE, cms) {
                 Ok(()) => {
                     let replications = Replications::ReplicateArgsDim { width, depth };
-                    replicate_and_notify_events(ctx, key, Operation::Initialization, replications);
+                    replicate_and_notify_events(
+                        ctx,
+                        key,
+                        Operation::Initialization { replications },
+                    );
                     VALKEY_OK
                 }
                 Err(_) => Err(ValkeyError::Str(utils::ERROR)),
@@ -149,11 +150,95 @@ pub fn cms_initialize_by_probability(ctx: &Context, args: Vec<ValkeyString>) -> 
                         fp_rate,
                     };
 
-                    replicate_and_notify_events(ctx, key, Operation::Initialization, replications);
+                    replicate_and_notify_events(
+                        ctx,
+                        key,
+                        Operation::Initialization { replications },
+                    );
                     VALKEY_OK
                 }
                 Err(_) => Err(ValkeyError::Str(utils::ERROR)),
             }
+        }
+    }
+}
+
+/// Function that implements logic to handle the CMS.INCRBY command.
+pub fn cms_increment_by(ctx: &Context, args: Vec<ValkeyString>) -> ValkeyResult {
+    let args_count = args.len();
+    if args_count < 4 {
+        return Err(ValkeyError::WrongArity);
+    }
+
+    let key = &args[1];
+
+    let args_left = args_count - 2;
+    let is_even = args_left % 2 == 0;
+    if !is_even {
+        return Err(ValkeyError::WrongArity);
+    }
+
+    let mut i = 2;
+    let mut pairs: Vec<(&ValkeyString, &ValkeyString)> = Vec::new();
+    while i < args_count {
+        let k = &args[i];
+        let v = &args[i + 1];
+        pairs.push((k, v));
+        i += 2
+    }
+
+    let filter_key = ctx.open_key_writable(key);
+    let value = match filter_key.get_value::<CMSObject>(&CMS_TYPE) {
+        Ok(v) => v,
+        Err(_) => return Err(ValkeyError::WrongType),
+    };
+
+    let mut results = Vec::new();
+    match value {
+        None => Err(ValkeyError::nonexistent_key()),
+        Some(v) => {
+            for (item, increment) in pairs {
+                let key = &item.to_string_lossy();
+                let parsed_value = &increment.to_string_lossy().parse::<u64>();
+                let value = match parsed_value {
+                    Ok(v) => v,
+                    Err(_) => return Err(ValkeyError::Str(utils::BAD_INCREMENT)),
+                };
+                let count = v.increment_by(key, value.to_owned());
+                results.push(ValkeyValue::Integer(count as i64));
+            }
+            replicate_and_notify_events(ctx, key, Operation::Increment);
+            Ok(ValkeyValue::Array(results))
+        }
+    }
+}
+
+/// Function that implements logic to handle the CMS.QUERY command.
+pub fn cms_query(ctx: &Context, args: Vec<ValkeyString>) -> ValkeyResult {
+    let argc = args.len();
+    if argc < 3 {
+        return Err(ValkeyError::WrongArity);
+    }
+
+    let key_name = &args[1];
+
+    let existing_key = ctx.open_key(key_name);
+    let cms = match existing_key.get_value::<CMSObject>(&CMS_TYPE) {
+        Ok(v) => v,
+        Err(_) => return Err(ValkeyError::WrongType),
+    };
+
+    match cms {
+        None => Err(ValkeyError::Str("No CMS Exists")),
+        Some(v) => {
+            let estimates: Vec<ValkeyValue> = args[2..]
+                .iter()
+                .map(|item| {
+                    let estimate = v.estimate(&item.to_string_lossy());
+                    ValkeyValue::Integer(estimate as i64)
+                })
+                .collect();
+            Ok(ValkeyValue::Array(estimates))
         }
     }
 }

--- a/src/cms/cms_command_handler.rs
+++ b/src/cms/cms_command_handler.rs
@@ -198,13 +198,13 @@ pub fn cms_increment_by(ctx: &Context, args: Vec<ValkeyString>) -> ValkeyResult 
         None => Err(ValkeyError::nonexistent_key()),
         Some(v) => {
             for (item, increment) in pairs {
-                let key = &item.to_string_lossy();
+                let item = &item.to_string_lossy();
                 let parsed_value = &increment.to_string_lossy().parse::<u64>();
                 let value = match parsed_value {
                     Ok(v) => v,
                     Err(_) => return Err(ValkeyError::Str(utils::BAD_INCREMENT)),
                 };
-                let count = v.increment_by(key, value.to_owned());
+                let count = v.increment_by(item, value.to_owned());
                 results.push(ValkeyValue::Integer(count as i64));
             }
             replicate_and_notify_events(ctx, key, Operation::Increment);
@@ -229,7 +229,7 @@ pub fn cms_query(ctx: &Context, args: Vec<ValkeyString>) -> ValkeyResult {
     };
 
     match cms {
-        None => Err(ValkeyError::Str("No CMS Exists")),
+        None => Err(ValkeyError::nonexistent_key()),
         Some(v) => {
             let estimates: Vec<ValkeyValue> = args[2..]
                 .iter()

--- a/src/cms/utils.rs
+++ b/src/cms/utils.rs
@@ -40,7 +40,6 @@ impl CMSError {
 pub struct CMSObject {
     width: u64,
     depth: u64,
-    total: u64,
     cms: CMS,
 }
 
@@ -56,12 +55,7 @@ impl CMSObject {
         }
 
         let cms = CMS::new_by_dimensions(width as usize, depth as usize)?;
-        let obj = CMSObject {
-            width,
-            depth,
-            total: 0,
-            cms,
-        };
+        let obj = CMSObject { width, depth, cms };
 
         Ok(obj)
     }
@@ -83,7 +77,6 @@ impl CMSObject {
         let obj = CMSObject {
             width: cms.sketch.width() as u64,
             depth: cms.sketch.depth() as u64,
-            total: 0,
             cms,
         };
 
@@ -99,15 +92,15 @@ impl CMSObject {
     }
 
     pub fn total(&self) -> u64 {
-        self.total
+        self.cms.sketch.total_count()
     }
 
-    pub fn increment_by(&mut self, item: &String, increment: u64) -> u64 {
+    pub fn increment_by(&mut self, item: &[u8], increment: u64) -> u64 {
         self.cms.increment_item(item, increment);
         self.cms.estimate_item(item)
     }
 
-    pub fn estimate(&self, item: &String) -> u64 {
+    pub fn estimate(&self, item: &[u8]) -> u64 {
         self.cms.estimate_item(item)
     }
 }
@@ -129,11 +122,11 @@ impl CMS {
         Ok(CMS { sketch: cms })
     }
 
-    pub fn increment_item(&mut self, item: &String, increment: u64) {
-        self.sketch.add(item.as_bytes(), increment)
+    pub fn increment_item(&mut self, item: &[u8], increment: u64) {
+        self.sketch.add(item, increment)
     }
 
-    pub fn estimate_item(&self, item: &String) -> u64 {
-        self.sketch.estimate(item.as_bytes())
+    pub fn estimate_item(&self, item: &[u8]) -> u64 {
+        self.sketch.estimate(item)
     }
 }

--- a/src/cms/utils.rs
+++ b/src/cms/utils.rs
@@ -11,6 +11,7 @@ pub const ERROR_RATE_RANGE: &str = "ERR error rate should be between 0 and 1";
 pub const BAD_PROBABILITY: &str = "ERR bad probability";
 pub const PROBABILITY_RANGE: &str = "ERR probability rate should be between 0 and 1";
 pub const KEY_EXISTS: &str = "ERR Target key name already exists.";
+pub const BAD_INCREMENT: &str = "ERR bad increment";
 
 ///Keyspace Notification Events
 pub const INITBYPROB_EVENT: &str = "countminsketch.initbyprob";
@@ -100,6 +101,15 @@ impl CMSObject {
     pub fn total(&self) -> u64 {
         self.total
     }
+
+    pub fn increment_by(&mut self, item: &String, increment: u64) -> u64 {
+        self.cms.increment_item(item, increment);
+        self.cms.estimate_item(item)
+    }
+
+    pub fn estimate(&self, item: &String) -> u64 {
+        self.cms.estimate_item(item)
+    }
 }
 
 struct CMS {
@@ -117,5 +127,13 @@ impl CMS {
     pub fn new_by_dimensions(width: usize, depth: usize) -> Result<CMS, CMSError> {
         let cms = CountMinSketch::with_dimensions(width, depth);
         Ok(CMS { sketch: cms })
+    }
+
+    pub fn increment_item(&mut self, item: &String, increment: u64) {
+        self.sketch.add(item.as_bytes(), increment)
+    }
+
+    pub fn estimate_item(&self, item: &String) -> u64 {
+        self.sketch.estimate(item.as_bytes())
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -104,6 +104,16 @@ fn cms_initbyprob_command(ctx: &Context, args: Vec<ValkeyString>) -> ValkeyResul
     cms_command_handler::cms_initialize_by_probability(ctx, args)
 }
 
+/// Command handler for CMS.INCRBY <key> <item> <increment> [<item> <increment> ...]
+fn cms_incrby_command(ctx: &Context, args: Vec<ValkeyString>) -> ValkeyResult {
+    cms_command_handler::cms_increment_by(ctx, args)
+}
+
+/// Command handler for CMS.QUERY <key> <item> [<item> ...]
+fn cms_query_command(ctx: &Context, args: Vec<ValkeyString>) -> ValkeyResult {
+    cms_command_handler::cms_query(ctx, args)
+}
+
 ///
 /// Module Info
 ///
@@ -140,6 +150,8 @@ valkey_module! {
         ["BF.LOAD", bloom_load_command, "write deny-oom", 1, 1, 1, "write bloom"],
         ["CMS.INITBYDIM", cms_initbydim_command, "write fast deny-oom", 1, 1, 1, "fast write cms"],
         ["CMS.INITBYPROB", cms_initbyprob_command, "write fast deny-oom", 1, 1, 1, "fast write cms"],
+        ["CMS.INCRBY", cms_incrby_command, "write fast deny-oom", 1, 1, 1, "write cms"],
+        ["CMS.QUERY", cms_query_command, "readonly fast", 1, 1, 1, "read cms"],
     ],
     configurations: [
         i64: [

--- a/tests/test_cms_basic.py
+++ b/tests/test_cms_basic.py
@@ -1,0 +1,82 @@
+#!/usr/bin/env python3
+
+import pytest
+from valkey import ResponseError
+from valkey_bloom_test_case import ValkeyBloomTestCaseBase
+from valkeytestframework.conftest import resource_port_tracker
+
+class TestCMSBasic(ValkeyBloomTestCaseBase):
+    """
+    Basic coverage for the ability to create count min sketch data structures, add, and query them.
+    """
+
+    def test_basic_dim(self):
+        client = self.server.get_new_client()
+        module_loaded = False
+        for module in module_list_data:
+            if (module[b'name'] == b'bf'):
+                module_loaded = True
+                break
+        assert(module_loaded)
+        # Validate that all the CMS.* commands are supported on the server.
+        command_cmd_result = client.execute_command('COMMAND')
+        cms_cmds = ["CMS.INITBYDIM, CMS.INITBYPROB, CMS.INCRBY, CMS.QUERY"]
+        assert all(item in command_cmd_result for item in cms_cmds)
+        #Create CMS by Dimensions, add item, estimate the item, increment, estimate
+        assert client.execute_command('CMS.INITBYDIM sketch1 10 5') == b'OK'
+        assert client.execute_command('CMS.QUERY sketch1 item1') == 0
+        assert client.execute_command('CMS.INCRBY sketch1 item1 1 item2 1') == 1
+
+        #CMS guarantees that we have the frequency at LEAST the size of the increment for the item
+        assert client.execute_command('CMS.QUERY sketch1 item1') >= 1
+
+
+
+    def test_basic_prob(self):
+        client = self.server.get_new_client()
+        module_loaded = False
+        for module in module_list_data:
+            if (module[b'name'] == b'bf'):
+                module_loaded = True
+                break
+        assert(module_loaded)
+        # Validate that all the CMS.* commands are supported on the server.
+        command_cmd_result = client.execute_command('COMMAND')
+        cms_cmds = ["CMS.INITBYDIM, CMS.INITBYPROB, CMS.INCRBY, CMS.QUERY"]
+        assert all(item in command_cmd_result for item in cms_cmds)
+        #Create CMS by Dimensions, add item, estimate the item, increment, estimate
+        assert client.execute_command('CMS.INITBYPROB sketch1 0.001 0.01') == b'OK'
+        assert client.execute_command('CMS.QUERY sketch1 item1') == 0
+        assert client.execute_command('CMS.INCRBY sketch1 item1 1 item2 1') == 1
+
+        #CMS guarantees that we have the frequency at LEAST the size of the increment for the item
+        assert client.execute_command('CMS.QUERY sketch1 item1') >= 1
+
+    def test_module_data_type(self):
+        # Validate the name of the Module data type.
+        client = self.server.get_new_client()
+        assert client.execute_command('CMS.INITBYDIM sketch 5 3') == b'OK'
+        type_result = client.execute_command('TYPE sketch')
+        assert type_result == b"cntmnskch"
+        # Validate the name of the Module data type.
+        encoding_result = client.execute_command('OBJECT ENCODING sketch')
+        assert encoding_result == b"raw"
+        
+
+    def test_cms_obj_access(self):
+        client = self.server.get_new_client()
+        # check count min sketch with basic valkey command
+        # cmd touch
+        assert client.execute_command('CMS.INITBYDIM sketch1 5 3') == b'OK'
+        assert client.execute_command('CMS.INITBYDIM sketch2 10 4') == b'OK'
+        
+        assert client.execute_command('CMS.INCRBY sketch1 val1 1') == 1
+        assert client.execute_command('CMS.INCRBY sketch2 val2 2') == 2
+        
+        assert client.execute_command('TOUCH sketch1 sketch2') == 2
+        assert client.execute_command('TOUCH sketch3') == 0
+        self.verify_server_key_count(client, 2)
+        assert client.execute_command('DBSIZE') == 2
+        random_key = client.execute_command('RANDOMKEY')
+        assert random_key == b"sketch1" or random_key == b"sketch2"
+

--- a/tests/test_cms_basic.py
+++ b/tests/test_cms_basic.py
@@ -25,11 +25,11 @@ class TestCMSBasic(ValkeyBloomTestCaseBase):
         assert all(item in command_cmd_result for item in cms_cmds)
         #Create CMS by Dimensions, add item, estimate the item, increment, estimate
         assert client.execute_command('CMS.INITBYDIM sketch1 10 5') == b'OK'
-        assert client.execute_command('CMS.QUERY sketch1 item1') == 0
-        assert client.execute_command('CMS.INCRBY sketch1 item1 1 item2 1') == [1]
+        assert client.execute_command('CMS.QUERY sketch1 item1') == [0]
+        assert client.execute_command('CMS.INCRBY sketch1 item1 1 item2 1') == [1, 1]
 
         #CMS guarantees that we have the frequency at LEAST the size of the increment for the item
-        assert client.execute_command('CMS.QUERY sketch1 item1') >= 1
+        assert client.execute_command('CMS.QUERY sketch1 item1')[0] >= 1
 
 
 
@@ -48,11 +48,11 @@ class TestCMSBasic(ValkeyBloomTestCaseBase):
         assert all(item in command_cmd_result for item in cms_cmds)
         #Create CMS by Dimensions, add item, estimate the item, increment, estimate
         assert client.execute_command('CMS.INITBYPROB sketch1 0.001 0.01') == b'OK'
-        assert client.execute_command('CMS.QUERY sketch1 item1') == 0
-        assert client.execute_command('CMS.INCRBY sketch1 item1 1 item2 1') == [1]
+        assert client.execute_command('CMS.QUERY sketch1 item1') == [0]
+        assert client.execute_command('CMS.INCRBY sketch1 item1 1 item2 1') == [1, 1]
 
         #CMS guarantees that we have the frequency at LEAST the size of the increment for the item
-        assert client.execute_command('CMS.QUERY sketch1 item1') >= 1
+        assert client.execute_command('CMS.QUERY sketch1 item1')[0] >= 1
 
     def test_module_data_type(self):
         # Validate the name of the Module data type.

--- a/tests/test_cms_basic.py
+++ b/tests/test_cms_basic.py
@@ -21,7 +21,7 @@ class TestCMSBasic(ValkeyBloomTestCaseBase):
         assert(module_loaded)
         # Validate that all the CMS.* commands are supported on the server.
         command_cmd_result = client.execute_command('COMMAND')
-        cms_cmds = ["CMS.INITBYDIM, CMS.INITBYPROB, CMS.INCRBY, CMS.QUERY"]
+        cms_cmds = ["CMS.INITBYDIM", "CMS.INITBYPROB", "CMS.INCRBY", "CMS.QUERY"]
         assert all(item in command_cmd_result for item in cms_cmds)
         #Create CMS by Dimensions, add item, estimate the item, increment, estimate
         assert client.execute_command('CMS.INITBYDIM sketch1 10 5') == b'OK'
@@ -44,7 +44,7 @@ class TestCMSBasic(ValkeyBloomTestCaseBase):
         assert(module_loaded)
         # Validate that all the CMS.* commands are supported on the server.
         command_cmd_result = client.execute_command('COMMAND')
-        cms_cmds = ["CMS.INITBYDIM, CMS.INITBYPROB, CMS.INCRBY, CMS.QUERY"]
+        cms_cmds = ["CMS.INITBYDIM", "CMS.INITBYPROB", "CMS.INCRBY", "CMS.QUERY"]
         assert all(item in command_cmd_result for item in cms_cmds)
         #Create CMS by Dimensions, add item, estimate the item, increment, estimate
         assert client.execute_command('CMS.INITBYPROB sketch1 0.001 0.01') == b'OK'

--- a/tests/test_cms_basic.py
+++ b/tests/test_cms_basic.py
@@ -13,6 +13,7 @@ class TestCMSBasic(ValkeyBloomTestCaseBase):
     def test_basic_dim(self):
         client = self.server.get_new_client()
         module_loaded = False
+        module_list_data = client.execute_command('MODULE LIST')      
         for module in module_list_data:
             if (module[b'name'] == b'bf'):
                 module_loaded = True
@@ -25,7 +26,7 @@ class TestCMSBasic(ValkeyBloomTestCaseBase):
         #Create CMS by Dimensions, add item, estimate the item, increment, estimate
         assert client.execute_command('CMS.INITBYDIM sketch1 10 5') == b'OK'
         assert client.execute_command('CMS.QUERY sketch1 item1') == 0
-        assert client.execute_command('CMS.INCRBY sketch1 item1 1 item2 1') == 1
+        assert client.execute_command('CMS.INCRBY sketch1 item1 1 item2 1') == [1]
 
         #CMS guarantees that we have the frequency at LEAST the size of the increment for the item
         assert client.execute_command('CMS.QUERY sketch1 item1') >= 1
@@ -35,6 +36,7 @@ class TestCMSBasic(ValkeyBloomTestCaseBase):
     def test_basic_prob(self):
         client = self.server.get_new_client()
         module_loaded = False
+        module_list_data = client.execute_command('MODULE LIST')      
         for module in module_list_data:
             if (module[b'name'] == b'bf'):
                 module_loaded = True
@@ -47,7 +49,7 @@ class TestCMSBasic(ValkeyBloomTestCaseBase):
         #Create CMS by Dimensions, add item, estimate the item, increment, estimate
         assert client.execute_command('CMS.INITBYPROB sketch1 0.001 0.01') == b'OK'
         assert client.execute_command('CMS.QUERY sketch1 item1') == 0
-        assert client.execute_command('CMS.INCRBY sketch1 item1 1 item2 1') == 1
+        assert client.execute_command('CMS.INCRBY sketch1 item1 1 item2 1') == [1]
 
         #CMS guarantees that we have the frequency at LEAST the size of the increment for the item
         assert client.execute_command('CMS.QUERY sketch1 item1') >= 1
@@ -70,8 +72,8 @@ class TestCMSBasic(ValkeyBloomTestCaseBase):
         assert client.execute_command('CMS.INITBYDIM sketch1 5 3') == b'OK'
         assert client.execute_command('CMS.INITBYDIM sketch2 10 4') == b'OK'
         
-        assert client.execute_command('CMS.INCRBY sketch1 val1 1') == 1
-        assert client.execute_command('CMS.INCRBY sketch2 val2 2') == 2
+        assert client.execute_command('CMS.INCRBY sketch1 val1 1') == [1]
+        assert client.execute_command('CMS.INCRBY sketch2 val2 2') == [2]
         
         assert client.execute_command('TOUCH sketch1 sketch2') == 2
         assert client.execute_command('TOUCH sketch3') == 0

--- a/tests/test_cms_command.py
+++ b/tests/test_cms_command.py
@@ -29,6 +29,8 @@ class TestCMSCommand(ValkeyBloomTestCaseBase):
             ('CMS.INITBYPROB newsketch 0.01 0', 'probability rate should be between 0 and 1'),
             ('CMS.INITBYPROB newsketch 0.01 1', 'probability rate should be between 0 and 1'),
 
+            ('CMS.INCRBY sketch item abc', 'bad increment'),
+            ('CMS.INCRBY sketch item -1', 'bad increment'),
 
             # wrong number of arguments
             ('CMS.INITBYDIM', 'wrong number of arguments for \'CMS.INITBYDIM\' command'),

--- a/tests/test_cms_command.py
+++ b/tests/test_cms_command.py
@@ -33,23 +33,23 @@ class TestCMSCommand(ValkeyBloomTestCaseBase):
             ('CMS.INCRBY sketch item -1', 'bad increment'),
 
             # wrong number of arguments
-            ('CMS.INITBYDIM', 'wrong number of arguments for \'CMS.INITBYDIM\' command'),
-            ('CMS.INITBYDIM key', 'wrong number of arguments for \'CMS.INITBYDIM\' command'),
-            ('CMS.INITBYDIM key 1000', 'wrong number of arguments for \'CMS.INITBYDIM\' command'),
-            ('CMS.INITBYDIM key 1000 5 extra', 'wrong number of arguments for \'CMS.INITBYDIM\' command'),
+            ('CMS.INITBYDIM', "wrong number of arguments for 'CMS.INITBYDIM' command"),
+            ('CMS.INITBYDIM key', "wrong number of arguments for 'CMS.INITBYDIM' command"),
+            ('CMS.INITBYDIM key 1000', "wrong number of arguments for 'CMS.INITBYDIM' command"),
+            ('CMS.INITBYDIM key 1000 5 extra', "wrong number of arguments for 'CMS.INITBYDIM' command"),
 
-            ('CMS.INITBYPROB', 'wrong number of arguments for \'CMS.INITBYPROB\' command'),
-            ('CMS.INITBYPROB key', 'wrong number of arguments for \'CMS.INITBYPROB\' command'),
-            ('CMS.INITBYPROB key 0.01', 'wrong number of arguments for \'CMS.INITBYPROB\' command'),
-            ('CMS.INITBYPROB key 0.01 0.01 extra', 'wrong number of arguments for \'CMS.INITBYPROB\' command'),
+            ('CMS.INITBYPROB', "wrong number of arguments for 'CMS.INITBYPROB' command"),
+            ('CMS.INITBYPROB key', "wrong number of arguments for 'CMS.INITBYPROB' command"),
+            ('CMS.INITBYPROB key 0.01', "wrong number of arguments for 'CMS.INITBYPROB' command"),
+            ('CMS.INITBYPROB key 0.01 0.01 extra', "wrong number of arguments for 'CMS.INITBYPROB' command"),
 
-            ('CMS.INCRBY', 'wrong number of arguments for \'CMS.INCRBY\' command'),
-            ('CMS.INCRBY key', 'wrong number of arguments for \'CMS.INCRBY\' command'),
-            ('CMS.INCRBY key item', 'wrong number of arguments for \'CMS.INCRBY\' command'),
-            ('CMS.INCRBY key item 1 item2', 'wrong number of arguments for \'CMS.INCRBY\' command'),
+            ('CMS.INCRBY', "wrong number of arguments for 'CMS.INCRBY' command"),
+            ('CMS.INCRBY key', "wrong number of arguments for 'CMS.INCRBY' command"),
+            ('CMS.INCRBY key item', "wrong number of arguments for 'CMS.INCRBY' command"),
+            ('CMS.INCRBY key item 1 item2', "wrong number of arguments for 'CMS.INCRBY' command"),
 
-            ('CMS.QUERY', 'wrong number of arguments for \'CMS.QUERY\' command'),
-            ('CMS.QUERY key', 'wrong number of arguments for \'CMS.QUERY\' command'),
+            ('CMS.QUERY', "wrong number of arguments for 'CMS.QUERY' command"),
+            ('CMS.QUERY key', "wrong number of arguments for 'CMS.QUERY' command"),
          
         ]
 

--- a/tests/test_cms_command.py
+++ b/tests/test_cms_command.py
@@ -41,6 +41,13 @@ class TestCMSCommand(ValkeyBloomTestCaseBase):
             ('CMS.INITBYPROB key 0.01', 'wrong number of arguments for \'CMS.INITBYPROB\' command'),
             ('CMS.INITBYPROB key 0.01 0.01 extra', 'wrong number of arguments for \'CMS.INITBYPROB\' command'),
 
+            ('CMS.INCRBY', 'wrong number of arguments for \'CMS.INCRBY\' command'),
+            ('CMS.INCRBY key', 'wrong number of arguments for \'CMS.INCRBY\' command'),
+            ('CMS.INCRBY key item', 'wrong number of arguments for \'CMS.INCRBY\' command'),
+            ('CMS.INCRBY key item 1 item2', 'wrong number of arguments for \'CMS.INCRBY\' command'),
+
+            ('CMS.QUERY', 'wrong number of arguments for \'CMS.QUERY\' command'),
+            ('CMS.QUERY key', 'wrong number of arguments for \'CMS.QUERY\' command'),
          
         ]
 


### PR DESCRIPTION
 This implements the increment by and query methods for the count min sketch and allows us to write the integration tests which test the creation of the CMS along with incrementing and querying.  

Please let me know what may need to change.  Thank you! 