### PR TITLE
Add TopK AOF rewrite support (TOPK.LOAD)

### DIFF
--- a/src/bloom/utils.rs
+++ b/src/bloom/utils.rs
@@ -1233,7 +1233,7 @@ mod tests {
     }
 
     #[test]
-    fn test_bf_decode_when_unsupported_version_should_failed() {
+    fn test_bf_decode_when_unsupported_version_should_fail() {
         // arrange: prepare bloom filter
         let mut bf =
             BloomObject::new_reserved(0.5_f64, 0.5_f64, 1000_i64, 2, (None, true), true).unwrap();
@@ -1256,7 +1256,7 @@ mod tests {
     }
 
     #[test]
-    fn test_bf_decode_when_bytes_is_empty_should_failed() {
+    fn test_bf_decode_when_bytes_is_empty_should_fail() {
         // arrange: prepare bloom filter
         let mut bf =
             BloomObject::new_reserved(0.5_f64, 0.5_f64, 1000_i64, 2, (None, true), true).unwrap();
@@ -1277,7 +1277,7 @@ mod tests {
     }
 
     #[test]
-    fn test_bf_decode_when_bytes_is_exceed_limit_should_failed() {
+    fn test_bf_decode_when_bytes_is_exceed_limit_should_fail() {
         // arrange: prepare bloom filter
         let mut bf =
             BloomObject::new_reserved(0.5_f64, 0.5_f64, 1000_i64, 2, (None, true), true).unwrap();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -128,6 +128,11 @@ fn topk_query_command(ctx: &Context, args: Vec<ValkeyString>) -> ValkeyResult {
     topk_command_handler::topk_query(ctx, &args)
 }
 
+/// Command handler for TOPK.LOAD <key> data
+fn topk_load_command(ctx: &Context, args: Vec<ValkeyString>) -> ValkeyResult {
+    topk_command_handler::topk_load(ctx, &args)
+}
+
 ///
 /// Module Info
 ///
@@ -171,6 +176,7 @@ valkey_module! {
         ["TOPK.LIST", topk_list_command, "readonly", 1, 1, 1, "read topk"],
         ["TOPK.COUNT", topk_count_command, "readonly fast", 1, 1, 1, "fast read topk"],
         ["TOPK.QUERY", topk_query_command, "readonly fast", 1, 1, 1, "fast read topk"],
+        ["TOPK.LOAD", topk_load_command, "write deny-oom", 1, 1, 1, "write topk"],
     ],
     configurations: [
         i64: [

--- a/src/topk/command_handler.rs
+++ b/src/topk/command_handler.rs
@@ -14,53 +14,60 @@ struct ReplicateArgs {
     seed: u64,
 }
 
+/// The write operation being propagated to replicas and published as a keyspace event.
+/// Each variant controls which command is propagated and which event is emitted.
+enum ReplicationOp {
+    /// TOPK.RESERVE: replayed as a deterministic TOPK.RESERVE on replicas.
+    Reserve(ReplicateArgs),
+    /// TOPK.ADD / TOPK.INCRBY: replicated verbatim and publishes `topk.add`,
+    /// safe because they are deterministic once the replica is seeded
+    /// identically via the replicated TOPK.RESERVE.
+    Add,
+    /// TOPK.LOAD (generated during AOF rewrite): replicated verbatim since the
+    /// serialized blob already carries the full sketch, and publishes the
+    /// `topk.reserve` event because it creates the object on the replica.
+    Load,
+}
+
 /// Helper function to replicate mutative commands to the replica nodes and publish keyspace events.
-/// There are three cases for replication:
-/// - RESERVE operation: replays a deterministic TOPK.RESERVE on replicas.
-/// - ADD operation: covers TOPK.ADD and TOPK.INCRBY; both replicate verbatim and publish
-///   the same `topk.add` event, safe because they are deterministic once the
-///   replica is seeded identically via the replicated TOPK.RESERVE.
-/// - LOAD operation: TOPK.LOAD (generated during AOF rewrite). Replicates verbatim
-///   since the serialized blob already carries the full sketch, and publishes the
-///   `topk.reserve` event because it creates the object on the replica.
-fn replicate_and_notify_events(
-    ctx: &Context,
-    key_name: &ValkeyString,
-    reserve_operation: bool,
-    add_operation: bool,
-    load_operation: bool,
-    args: Option<ReplicateArgs>,
-) {
-    if reserve_operation {
-        let args = args.expect("reserve replication requires ReplicateArgs");
-        let k_val =
-            ValkeyString::create_from_slice(std::ptr::null_mut(), args.k.to_string().as_bytes());
-        let width_val = ValkeyString::create_from_slice(
-            std::ptr::null_mut(),
-            args.width.to_string().as_bytes(),
-        );
-        let depth_val = ValkeyString::create_from_slice(
-            std::ptr::null_mut(),
-            args.depth.to_string().as_bytes(),
-        );
-        let decay_val = ValkeyString::create_from_slice(
-            std::ptr::null_mut(),
-            args.decay.to_string().as_bytes(),
-        );
-        let seed_str = ValkeyString::create_from_slice(std::ptr::null_mut(), "SEED".as_bytes());
-        let seed_val =
-            ValkeyString::create_from_slice(std::ptr::null_mut(), args.seed.to_string().as_bytes());
-        let cmd = vec![
-            key_name, &k_val, &width_val, &depth_val, &decay_val, &seed_str, &seed_val,
-        ];
-        ctx.replicate("TOPK.RESERVE", cmd.as_slice());
-        ctx.notify_keyspace_event(NotifyEvent::GENERIC, utils::RESERVE_EVENT, key_name);
-    } else if add_operation {
-        ctx.replicate_verbatim();
-        ctx.notify_keyspace_event(NotifyEvent::GENERIC, utils::ADD_EVENT, key_name);
-    } else if load_operation {
-        ctx.replicate_verbatim();
-        ctx.notify_keyspace_event(NotifyEvent::GENERIC, utils::RESERVE_EVENT, key_name);
+fn replicate_and_notify_events(ctx: &Context, key_name: &ValkeyString, op: ReplicationOp) {
+    match op {
+        ReplicationOp::Reserve(args) => {
+            let k_val = ValkeyString::create_from_slice(
+                std::ptr::null_mut(),
+                args.k.to_string().as_bytes(),
+            );
+            let width_val = ValkeyString::create_from_slice(
+                std::ptr::null_mut(),
+                args.width.to_string().as_bytes(),
+            );
+            let depth_val = ValkeyString::create_from_slice(
+                std::ptr::null_mut(),
+                args.depth.to_string().as_bytes(),
+            );
+            let decay_val = ValkeyString::create_from_slice(
+                std::ptr::null_mut(),
+                args.decay.to_string().as_bytes(),
+            );
+            let seed_str = ValkeyString::create_from_slice(std::ptr::null_mut(), "SEED".as_bytes());
+            let seed_val = ValkeyString::create_from_slice(
+                std::ptr::null_mut(),
+                args.seed.to_string().as_bytes(),
+            );
+            let cmd = vec![
+                key_name, &k_val, &width_val, &depth_val, &decay_val, &seed_str, &seed_val,
+            ];
+            ctx.replicate("TOPK.RESERVE", cmd.as_slice());
+            ctx.notify_keyspace_event(NotifyEvent::GENERIC, utils::RESERVE_EVENT, key_name);
+        }
+        ReplicationOp::Add => {
+            ctx.replicate_verbatim();
+            ctx.notify_keyspace_event(NotifyEvent::GENERIC, utils::ADD_EVENT, key_name);
+        }
+        ReplicationOp::Load => {
+            ctx.replicate_verbatim();
+            ctx.notify_keyspace_event(NotifyEvent::GENERIC, utils::RESERVE_EVENT, key_name);
+        }
     }
 }
 
@@ -167,7 +174,7 @@ pub fn topk_reserve(ctx: &Context, input_args: &[ValkeyString]) -> ValkeyResult 
                 decay,
                 seed,
             };
-            replicate_and_notify_events(ctx, key_name, true, false, false, Some(replicate_args));
+            replicate_and_notify_events(ctx, key_name, ReplicationOp::Reserve(replicate_args));
             VALKEY_OK
         }
         Err(_) => Err(ValkeyError::Str(utils::ERROR)),
@@ -196,7 +203,7 @@ pub fn topk_load(ctx: &Context, input_args: &[ValkeyString]) -> ValkeyResult {
 
     match key.set_value(&TOPK_TYPE, topk) {
         Ok(()) => {
-            replicate_and_notify_events(ctx, key_name, false, false, true, None);
+            replicate_and_notify_events(ctx, key_name, ReplicationOp::Load);
             VALKEY_OK
         }
         Err(_) => Err(ValkeyError::Str(utils::ERROR)),
@@ -242,7 +249,7 @@ pub fn topk_add(ctx: &Context, input_args: &[ValkeyString]) -> ValkeyResult {
     let items = &input_args[2..];
     let result = add_with_increments(topk, items.iter().map(|item| (item.as_slice(), 1)));
 
-    replicate_and_notify_events(ctx, key_name, false, true, false, None);
+    replicate_and_notify_events(ctx, key_name, ReplicationOp::Add);
     Ok(ValkeyValue::Array(result))
 }
 
@@ -289,7 +296,7 @@ pub fn topk_incrby(ctx: &Context, input_args: &[ValkeyString]) -> ValkeyResult {
             .map(|(item, increment)| (item.as_slice(), *increment)),
     );
 
-    replicate_and_notify_events(ctx, key_name, false, true, false, None);
+    replicate_and_notify_events(ctx, key_name, ReplicationOp::Add);
     Ok(ValkeyValue::Array(result))
 }
 

--- a/src/topk/command_handler.rs
+++ b/src/topk/command_handler.rs
@@ -1,6 +1,7 @@
 use crate::topk::data_type::TOPK_TYPE;
 use crate::topk::utils;
 use crate::topk::utils::TopKObject;
+use crate::wrapper::must_obey_client;
 use valkey_module::NotifyEvent;
 use valkey_module::{Context, ValkeyError, ValkeyResult, ValkeyString, ValkeyValue, VALKEY_OK};
 
@@ -14,16 +15,20 @@ struct ReplicateArgs {
 }
 
 /// Helper function to replicate mutative commands to the replica nodes and publish keyspace events.
-/// There are two main cases for replication:
+/// There are three cases for replication:
 /// - RESERVE operation: replays a deterministic TOPK.RESERVE on replicas.
 /// - ADD operation: covers TOPK.ADD and TOPK.INCRBY; both replicate verbatim and publish
 ///   the same `topk.add` event, safe because they are deterministic once the
 ///   replica is seeded identically via the replicated TOPK.RESERVE.
+/// - LOAD operation: TOPK.LOAD (generated during AOF rewrite). Replicates verbatim
+///   since the serialized blob already carries the full sketch, and publishes the
+///   `topk.reserve` event because it creates the object on the replica.
 fn replicate_and_notify_events(
     ctx: &Context,
     key_name: &ValkeyString,
     reserve_operation: bool,
     add_operation: bool,
+    load_operation: bool,
     args: Option<ReplicateArgs>,
 ) {
     if reserve_operation {
@@ -53,6 +58,9 @@ fn replicate_and_notify_events(
     } else if add_operation {
         ctx.replicate_verbatim();
         ctx.notify_keyspace_event(NotifyEvent::GENERIC, utils::ADD_EVENT, key_name);
+    } else if load_operation {
+        ctx.replicate_verbatim();
+        ctx.notify_keyspace_event(NotifyEvent::GENERIC, utils::RESERVE_EVENT, key_name);
     }
 }
 
@@ -159,7 +167,36 @@ pub fn topk_reserve(ctx: &Context, input_args: &[ValkeyString]) -> ValkeyResult 
                 decay,
                 seed,
             };
-            replicate_and_notify_events(ctx, key_name, true, false, Some(replicate_args));
+            replicate_and_notify_events(ctx, key_name, true, false, false, Some(replicate_args));
+            VALKEY_OK
+        }
+        Err(_) => Err(ValkeyError::Str(utils::ERROR)),
+    }
+}
+
+/// Function that implements logic to handle the TOPK.LOAD command.
+pub fn topk_load(ctx: &Context, input_args: &[ValkeyString]) -> ValkeyResult {
+    let argc = input_args.len();
+    if argc != 3 {
+        return Err(ValkeyError::WrongArity);
+    }
+
+    let key_name = &input_args[1];
+    let blob = input_args[2].as_slice();
+
+    let key = ctx.open_key_writable(key_name);
+    match key.get_value::<TopKObject>(&TOPK_TYPE) {
+        Ok(Some(_)) => return Err(ValkeyError::Str(utils::KEY_EXISTS)),
+        Ok(None) => {}
+        Err(_) => return Err(ValkeyError::WrongType),
+    };
+
+    let validate_size_limit = !must_obey_client(ctx);
+    let topk = TopKObject::decode_object(blob, validate_size_limit).map_err(ValkeyError::Str)?;
+
+    match key.set_value(&TOPK_TYPE, topk) {
+        Ok(()) => {
+            replicate_and_notify_events(ctx, key_name, false, false, true, None);
             VALKEY_OK
         }
         Err(_) => Err(ValkeyError::Str(utils::ERROR)),
@@ -205,7 +242,7 @@ pub fn topk_add(ctx: &Context, input_args: &[ValkeyString]) -> ValkeyResult {
     let items = &input_args[2..];
     let result = add_with_increments(topk, items.iter().map(|item| (item.as_slice(), 1)));
 
-    replicate_and_notify_events(ctx, key_name, false, true, None);
+    replicate_and_notify_events(ctx, key_name, false, true, false, None);
     Ok(ValkeyValue::Array(result))
 }
 
@@ -252,7 +289,7 @@ pub fn topk_incrby(ctx: &Context, input_args: &[ValkeyString]) -> ValkeyResult {
             .map(|(item, increment)| (item.as_slice(), *increment)),
     );
 
-    replicate_and_notify_events(ctx, key_name, false, true, None);
+    replicate_and_notify_events(ctx, key_name, false, true, false, None);
     Ok(ValkeyValue::Array(result))
 }
 

--- a/src/topk/data_type.rs
+++ b/src/topk/data_type.rs
@@ -1,13 +1,14 @@
-use crate::topk::utils::{
-    TopKObject, TOPK_DEPTH_MAX, TOPK_DEPTH_MIN, TOPK_K_MAX, TOPK_K_MIN, TOPK_WIDTH_MAX,
-    TOPK_WIDTH_MIN,
-};
+use crate::topk::utils::TopKObject;
 use crate::wrapper::topk_callback;
 use crate::MODULE_NAME;
 use heavykeeper::CuckooTopK;
 use valkey_module::digest::Digest;
 use valkey_module::native_types::ValkeyType;
 use valkey_module::{logging, raw};
+
+/// Used for decoding and encoding `TopKObject`. Currently used in AOF Rewrite.
+/// Bump this when the serialized object layout changes.
+pub const TOPK_OBJECT_VERSION: u8 = 1;
 
 /// Module data type encoding version for TopK. Bump this whenever the
 /// on-disk layout changes.
@@ -71,36 +72,13 @@ impl ValkeyDataType for TopKObject {
                 return None;
             }
         };
-        let k = sketch.top_items() as u64;
-        let width = sketch.width() as u64;
-        let depth = sketch.depth() as u64;
-        if !(TOPK_K_MIN as u64..=TOPK_K_MAX as u64).contains(&k) {
-            logging::log_warning("Failed to restore topk object: k out of range");
-            return None;
+        match TopKObject::from_serialized_bytes(seed, num_items, sketch, false) {
+            Ok(item) => Some(item),
+            Err(err) => {
+                logging::log_warning(format!("Failed to restore topk object: {}", err).as_str());
+                None
+            }
         }
-        if !(TOPK_WIDTH_MIN as u64..=TOPK_WIDTH_MAX as u64).contains(&width) {
-            logging::log_warning("Failed to restore topk object: width out of range");
-            return None;
-        }
-        if !(TOPK_DEPTH_MIN as u64..=TOPK_DEPTH_MAX as u64).contains(&depth) {
-            logging::log_warning("Failed to restore topk object: depth out of range");
-            return None;
-        }
-        let decay = sketch.decay();
-        if !(decay > 0.0 && decay < 1.0) {
-            logging::log_warning("Failed to restore topk object: decay out of range");
-            return None;
-        }
-        let item = TopKObject::from_existing(
-            k as u32,
-            width as u32,
-            depth as u32,
-            decay,
-            seed,
-            sketch,
-            num_items,
-        );
-        Some(item)
     }
 
     /// Function that is used to generate a digest on the Topk Object.

--- a/src/topk/data_type.rs
+++ b/src/topk/data_type.rs
@@ -21,7 +21,7 @@ pub static TOPK_TYPE: ValkeyType = ValkeyType::new(
         version: raw::REDISMODULE_TYPE_METHOD_VERSION as u64,
         rdb_load: Some(topk_callback::topk_rdb_load),
         rdb_save: Some(topk_callback::topk_rdb_save),
-        aof_rewrite: None,
+        aof_rewrite: Some(topk_callback::topk_aof_rewrite),
         digest: Some(topk_callback::topk_digest),
 
         mem_usage: Some(topk_callback::topk_mem_usage),

--- a/src/topk/utils.rs
+++ b/src/topk/utils.rs
@@ -235,14 +235,34 @@ impl TopKObject {
         let sketch_blob = &blob[17..];
 
         // Pre-validate: peek width/depth/top_items from the sketch header.
+        // Offsets derived from CuckooTopK::to_bytes / serialization::read_header
+        // and read_params in the heavykeeper crate (src/cuckoo.rs, src/serialization.rs).
         if validate_size_limit {
-            const SKETCH_PARAMS_END: usize = 4 + 1 + 1 + 8 + 8 + 8 + 8 + 8; // 46
+            // Each of width/depth/decay/top_items is serialized as a little-endian u64.
+            const FIELD: usize = std::mem::size_of::<u64>();
+            // magic(4) + variant(1) + version(1) + hasher_probe(8) = 14
+            const WIDTH_OFFSET: usize = 14;
+            const DEPTH_OFFSET: usize = WIDTH_OFFSET + FIELD;
+            const TOP_ITEMS_OFFSET: usize = DEPTH_OFFSET + FIELD + FIELD;
+            const SKETCH_PARAMS_END: usize = TOP_ITEMS_OFFSET + FIELD;
             if sketch_blob.len() < SKETCH_PARAMS_END {
                 return Err(DECODE_TOPK_OBJECT_FAILED);
             }
-            let width = u64::from_le_bytes(sketch_blob[14..22].try_into().expect("8 bytes"));
-            let depth = u64::from_le_bytes(sketch_blob[22..30].try_into().expect("8 bytes"));
-            let k = u64::from_le_bytes(sketch_blob[38..46].try_into().expect("8 bytes"));
+            let width = u64::from_le_bytes(
+                sketch_blob[WIDTH_OFFSET..WIDTH_OFFSET + FIELD]
+                    .try_into()
+                    .expect("8 bytes"),
+            );
+            let depth = u64::from_le_bytes(
+                sketch_blob[DEPTH_OFFSET..DEPTH_OFFSET + FIELD]
+                    .try_into()
+                    .expect("8 bytes"),
+            );
+            let k = u64::from_le_bytes(
+                sketch_blob[TOP_ITEMS_OFFSET..TOP_ITEMS_OFFSET + FIELD]
+                    .try_into()
+                    .expect("8 bytes"),
+            );
             let width_u32 = u32::try_from(width).unwrap_or(u32::MAX);
             let depth_u32 = u32::try_from(depth).unwrap_or(u32::MAX);
             let k_u32 = u32::try_from(k).unwrap_or(u32::MAX);

--- a/src/topk/utils.rs
+++ b/src/topk/utils.rs
@@ -544,7 +544,7 @@ mod tests {
     }
 
     #[test]
-    fn test_topk_decode_when_bytes_is_truncated_should_failed() {
+    fn test_topk_decode_when_bytes_is_truncated_should_fail() {
         // A blob shorter than the 17-byte header is rejected.
         assert_eq!(
             TopKObject::decode_object(&[], false).err(),
@@ -557,7 +557,7 @@ mod tests {
     }
 
     #[test]
-    fn test_topk_decode_when_unsupported_version_should_failed() {
+    fn test_topk_decode_when_unsupported_version_should_fail() {
         // A valid blob with a bumped version byte is rejected.
         let topk = TopKObject::new_reserved(3, 16, 4, 0.9, 42);
         let mut blob = topk.encode_object();
@@ -569,7 +569,7 @@ mod tests {
     }
 
     #[test]
-    fn test_topk_decode_when_wrong_seed_should_failed() {
+    fn test_topk_decode_when_wrong_seed_should_fail() {
         // The sketch header carries a hasher probe keyed by the seed, so decoding
         // with a seed that does not match the one baked into the blob fails.
         let topk = TopKObject::new_reserved(3, 16, 4, 0.9, 42);

--- a/src/topk/utils.rs
+++ b/src/topk/utils.rs
@@ -218,21 +218,42 @@ impl TopKObject {
         ))
     }
 
-    /// Deserialize a byte array to TopK object
+    /// Deserialize a byte array to TopK object. When `validate_size_limit` is
+    /// true, peeks at the sketch header to reject oversized params before
+    /// `from_bytes` allocates (the priority-queue capacity is unbounded otherwise).
     pub fn decode_object(
         blob: &[u8],
         validate_size_limit: bool,
     ) -> Result<TopKObject, &'static str> {
-        // Header: 1 version byte + 8 seed + 8 num_items.
         if blob.len() < 17 {
             return Err(DECODE_TOPK_OBJECT_FAILED);
         }
         if blob[0] != TOPK_OBJECT_VERSION {
             return Err(DECODE_UNSUPPORTED_VERSION);
         }
+
+        let sketch_blob = &blob[17..];
+
+        // Pre-validate: peek width/depth/top_items from the sketch header.
+        if validate_size_limit {
+            const SKETCH_PARAMS_END: usize = 4 + 1 + 1 + 8 + 8 + 8 + 8 + 8; // 46
+            if sketch_blob.len() < SKETCH_PARAMS_END {
+                return Err(DECODE_TOPK_OBJECT_FAILED);
+            }
+            let width = u64::from_le_bytes(sketch_blob[14..22].try_into().expect("8 bytes"));
+            let depth = u64::from_le_bytes(sketch_blob[22..30].try_into().expect("8 bytes"));
+            let k = u64::from_le_bytes(sketch_blob[38..46].try_into().expect("8 bytes"));
+            let width_u32 = u32::try_from(width).unwrap_or(u32::MAX);
+            let depth_u32 = u32::try_from(depth).unwrap_or(u32::MAX);
+            let k_u32 = u32::try_from(k).unwrap_or(u32::MAX);
+            if !Self::validate_size(k_u32, width_u32, depth_u32) {
+                return Err(EXCEEDS_MAX_TOPK_SIZE);
+            }
+        }
+
         let seed = u64::from_le_bytes(blob[1..9].try_into().expect("8 bytes"));
         let num_items = u64::from_le_bytes(blob[9..17].try_into().expect("8 bytes"));
-        let sketch = CuckooTopK::<Vec<u8>>::from_bytes(&blob[17..], seed)
+        let sketch = CuckooTopK::<Vec<u8>>::from_bytes(sketch_blob, seed)
             .map_err(|_| DECODE_TOPK_OBJECT_FAILED)?;
         Self::from_serialized_bytes(seed, num_items, sketch, validate_size_limit)
     }
@@ -578,6 +599,31 @@ mod tests {
         assert_eq!(
             TopKObject::decode_object(&blob, false).err(),
             Some(DECODE_TOPK_OBJECT_FAILED)
+        );
+    }
+
+    #[test]
+    fn test_topk_decode_when_size_exceeds_limit_should_fail() {
+        // A normally-sized object passes the pre-allocation size check.
+        let topk = TopKObject::new_reserved(5, 50, 4, 0.9, 42);
+        assert!(TopKObject::decode_object(&topk.encode_object(), true).is_ok());
+
+        // Tampered top_items (k) at sketch offset 38..46 (blob 55..63): rejected
+        // before from_bytes reserves the priority-queue capacity.
+        let mut blob = topk.encode_object();
+        blob[55..63].copy_from_slice(&(u32::MAX as u64).to_le_bytes());
+        assert_eq!(
+            TopKObject::decode_object(&blob, true).err(),
+            Some(EXCEEDS_MAX_TOPK_SIZE)
+        );
+
+        // Tampered width and depth: blow past the limit.
+        let mut blob = topk.encode_object();
+        blob[31..39].copy_from_slice(&1_000_000u64.to_le_bytes());
+        blob[39..47].copy_from_slice(&1_000_000u64.to_le_bytes());
+        assert_eq!(
+            TopKObject::decode_object(&blob, true).err(),
+            Some(EXCEEDS_MAX_TOPK_SIZE)
         );
     }
 }

--- a/src/topk/utils.rs
+++ b/src/topk/utils.rs
@@ -504,4 +504,80 @@ mod tests {
         assert_eq!(a.seed(), b.seed());
         assert_eq!(a.list(), b.list());
     }
+
+    #[rstest(seed, case::seed_a(1), case::seed_b(42), case::seed_c(123456789))]
+    fn test_topk_encode_and_decode(seed: u64) {
+        let mut topk = TopKObject::new_reserved(5, 50, 4, 0.9, seed);
+        for (item, incr) in [
+            (b"apple".as_slice(), 10),
+            (b"banana".as_slice(), 7),
+            (b"cherry".as_slice(), 3),
+            (b"date".as_slice(), 12),
+            (b"elderberry".as_slice(), 5),
+            (b"fig".as_slice(), 8),
+        ] {
+            topk.add(item, incr);
+        }
+
+        let blob = topk.encode_object();
+        let decoded = TopKObject::decode_object(&blob, false).expect("round trip should succeed");
+
+        assert_eq!(decoded.k(), topk.k());
+        assert_eq!(decoded.width(), topk.width());
+        assert_eq!(decoded.depth(), topk.depth());
+        assert_eq!(decoded.decay(), topk.decay());
+        assert_eq!(decoded.seed(), topk.seed());
+        assert_eq!(decoded.num_items(), topk.num_items());
+        assert_eq!(decoded.list(), topk.list());
+        // The sketch bytes must match exactly so DEBUG DIGEST-VALUE agrees.
+        assert_eq!(decoded.sketch().to_bytes(), topk.sketch().to_bytes());
+    }
+
+    #[test]
+    fn test_topk_encode_and_decode_empty_object() {
+        // A freshly reserved object with no items round-trips too.
+        let topk = TopKObject::new_reserved(3, 16, 4, 0.9, 42);
+        let blob = topk.encode_object();
+        let decoded = TopKObject::decode_object(&blob, false).expect("round trip should succeed");
+        assert_eq!(decoded.num_items(), 0);
+        assert_eq!(decoded.sketch().to_bytes(), topk.sketch().to_bytes());
+    }
+
+    #[test]
+    fn test_topk_decode_when_bytes_is_truncated_should_failed() {
+        // A blob shorter than the 17-byte header is rejected.
+        assert_eq!(
+            TopKObject::decode_object(&[], false).err(),
+            Some(DECODE_TOPK_OBJECT_FAILED)
+        );
+        assert_eq!(
+            TopKObject::decode_object(&[TOPK_OBJECT_VERSION; 10], false).err(),
+            Some(DECODE_TOPK_OBJECT_FAILED)
+        );
+    }
+
+    #[test]
+    fn test_topk_decode_when_unsupported_version_should_failed() {
+        // A valid blob with a bumped version byte is rejected.
+        let topk = TopKObject::new_reserved(3, 16, 4, 0.9, 42);
+        let mut blob = topk.encode_object();
+        blob[0] = TOPK_OBJECT_VERSION.wrapping_add(1);
+        assert_eq!(
+            TopKObject::decode_object(&blob, false).err(),
+            Some(DECODE_UNSUPPORTED_VERSION)
+        );
+    }
+
+    #[test]
+    fn test_topk_decode_when_wrong_seed_should_failed() {
+        // The sketch header carries a hasher probe keyed by the seed, so decoding
+        // with a seed that does not match the one baked into the blob fails.
+        let topk = TopKObject::new_reserved(3, 16, 4, 0.9, 42);
+        let mut blob = topk.encode_object();
+        blob[1..9].copy_from_slice(&99u64.to_le_bytes());
+        assert_eq!(
+            TopKObject::decode_object(&blob, false).err(),
+            Some(DECODE_TOPK_OBJECT_FAILED)
+        );
+    }
 }

--- a/src/topk/utils.rs
+++ b/src/topk/utils.rs
@@ -1,5 +1,6 @@
 use crate::configs;
 use crate::metrics;
+use crate::topk::data_type::TOPK_OBJECT_VERSION;
 use heavykeeper::CuckooTopK;
 use std::sync::atomic::Ordering;
 
@@ -33,6 +34,8 @@ pub const WIDTH_LARGER_THAN_0: &str = "ERR (width should be larger than 0)";
 pub const DEPTH_LARGER_THAN_0: &str = "ERR (depth should be larger than 0)";
 pub const DECAY_RANGE: &str = "ERR (0 < decay < 1)";
 pub const EXCEEDS_MAX_TOPK_SIZE: &str = "ERR operation exceeds topk object memory limit";
+pub const DECODE_TOPK_OBJECT_FAILED: &str = "ERR topk object decoding failed";
+pub const DECODE_UNSUPPORTED_VERSION: &str = "ERR topk object decoding failed. Unsupported version";
 
 /// TopKObject wraps the underlying CuckooTopK sketch together with the
 /// parameters used to construct it.
@@ -162,6 +165,76 @@ impl TopKObject {
     }
     pub fn sketch_mut(&mut self) -> &mut CuckooTopK<Vec<u8>> {
         &mut self.sketch
+    }
+
+    /// Serialize the object into a byte array.
+    pub fn encode_object(&self) -> Vec<u8> {
+        let sketch_bytes = self.sketch.to_bytes();
+        let mut out = Vec::with_capacity(1 + 8 + 8 + sketch_bytes.len());
+        out.push(TOPK_OBJECT_VERSION);
+        out.extend_from_slice(&self.seed.to_le_bytes());
+        out.extend_from_slice(&self.num_items.to_le_bytes());
+        out.extend_from_slice(&sketch_bytes);
+        out
+    }
+
+    /// Validate the params recovered from a decoded sketch and build the object.
+    /// Shared by the RDB load path and [`decode_object`]. `validate_size_limit`
+    /// gates the memory check; the RDB path passes `false` so a tightened limit
+    /// can't reject already-persisted objects on load.
+    pub fn from_serialized_bytes(
+        seed: u64,
+        num_items: u64,
+        sketch: CuckooTopK<Vec<u8>>,
+        validate_size_limit: bool,
+    ) -> Result<TopKObject, &'static str> {
+        let k = sketch.top_items() as u64;
+        let width = sketch.width() as u64;
+        let depth = sketch.depth() as u64;
+        if !(TOPK_K_MIN as u64..=TOPK_K_MAX as u64).contains(&k) {
+            return Err(BAD_TOPK);
+        }
+        if !(TOPK_WIDTH_MIN as u64..=TOPK_WIDTH_MAX as u64).contains(&width) {
+            return Err(BAD_WIDTH);
+        }
+        if !(TOPK_DEPTH_MIN as u64..=TOPK_DEPTH_MAX as u64).contains(&depth) {
+            return Err(BAD_DEPTH);
+        }
+        let decay = sketch.decay();
+        if !(decay > 0.0 && decay < 1.0) {
+            return Err(DECAY_RANGE);
+        }
+        if validate_size_limit && !Self::validate_size(k as u32, width as u32, depth as u32) {
+            return Err(EXCEEDS_MAX_TOPK_SIZE);
+        }
+        Ok(TopKObject::from_existing(
+            k as u32,
+            width as u32,
+            depth as u32,
+            decay,
+            seed,
+            sketch,
+            num_items,
+        ))
+    }
+
+    /// Deserialize a byte array to TopK object
+    pub fn decode_object(
+        blob: &[u8],
+        validate_size_limit: bool,
+    ) -> Result<TopKObject, &'static str> {
+        // Header: 1 version byte + 8 seed + 8 num_items.
+        if blob.len() < 17 {
+            return Err(DECODE_TOPK_OBJECT_FAILED);
+        }
+        if blob[0] != TOPK_OBJECT_VERSION {
+            return Err(DECODE_UNSUPPORTED_VERSION);
+        }
+        let seed = u64::from_le_bytes(blob[1..9].try_into().expect("8 bytes"));
+        let num_items = u64::from_le_bytes(blob[9..17].try_into().expect("8 bytes"));
+        let sketch = CuckooTopK::<Vec<u8>>::from_bytes(&blob[17..], seed)
+            .map_err(|_| DECODE_TOPK_OBJECT_FAILED)?;
+        Self::from_serialized_bytes(seed, num_items, sketch, validate_size_limit)
     }
 
     /// Add `increment` occurrences of `item` to the sketch and return the

--- a/src/wrapper/topk_callback.rs
+++ b/src/wrapper/topk_callback.rs
@@ -3,7 +3,8 @@ use crate::metrics;
 use crate::topk::data_type::ValkeyDataType;
 use crate::topk::utils::TopKObject;
 use heavykeeper::Reallocator;
-use std::os::raw::{c_int, c_void};
+use std::ffi::CString;
+use std::os::raw::{c_char, c_int, c_void};
 use std::ptr::null_mut;
 use std::sync::atomic::Ordering;
 use valkey_module::defrag::Defrag;
@@ -29,6 +30,26 @@ pub unsafe extern "C" fn topk_rdb_load(rdb: *mut raw::RedisModuleIO, encver: c_i
         logging::log_warning("Failed to restore topk object.");
         null_mut()
     }
+}
+
+/// # Safety
+pub unsafe extern "C" fn topk_aof_rewrite(
+    aof: *mut raw::RedisModuleIO,
+    key: *mut RedisModuleString,
+    value: *mut c_void,
+) {
+    let v = &*value.cast::<TopKObject>();
+    let blob = v.encode_object();
+    let cmd = CString::new("TOPK.LOAD").unwrap();
+    let fmt = CString::new("sb").unwrap();
+    raw::RedisModule_EmitAOF.unwrap()(
+        aof,
+        cmd.as_ptr(),
+        fmt.as_ptr(),
+        key,
+        blob.as_ptr().cast::<c_char>(),
+        blob.len(),
+    );
 }
 
 /// # Safety

--- a/tests/test_bloom_acl_category.py
+++ b/tests/test_bloom_acl_category.py
@@ -1,6 +1,6 @@
 from valkeytestframework.conftest import resource_port_tracker
 from valkey_bloom_test_case import ValkeyBloomTestCaseBase
-from valkeytestframework.util.waiters import *
+from valkeytestframework.util.waiters import wait_for_equal
 
 class TestBloomACLCategory(ValkeyBloomTestCaseBase):
 

--- a/tests/test_bloom_aofrewrite.py
+++ b/tests/test_bloom_aofrewrite.py
@@ -1,4 +1,5 @@
-from valkeytestframework.util.waiters import *
+import time
+from valkeytestframework.util.waiters import wait_for_equal
 from valkeytestframework.valkey_test_case import ValkeyAction
 from valkey_bloom_test_case import ValkeyBloomTestCaseBase
 from valkeytestframework.conftest import resource_port_tracker

--- a/tests/test_bloom_aofrewrite.py
+++ b/tests/test_bloom_aofrewrite.py
@@ -7,6 +7,8 @@ class TestBloomAofRewrite(ValkeyBloomTestCaseBase):
 
     def test_basic_aofrewrite_and_restore(self):
         client = self.server.get_new_client()
+        # Disable the RDB preamble so the rewrite emits BF.LOAD commands.
+        client.config_set('aof-use-rdb-preamble', 'no')
         # Enable AOF before adding data
         client.config_set('appendonly', 'yes')
         # Wait for any initial AOF rewrite to complete
@@ -48,6 +50,8 @@ class TestBloomAofRewrite(ValkeyBloomTestCaseBase):
         client.execute_command('DEL testSave')
 
     def test_aofrewrite_bloomfilter_metrics(self):
+        # Disable the RDB preamble so the rewrite emits BF.LOAD commands.
+        self.client.config_set('aof-use-rdb-preamble', 'no')
         # Enable AOF before adding data
         self.client.config_set('appendonly', 'yes')
         # Wait for any initial AOF rewrite to complete

--- a/tests/test_bloom_basic.py
+++ b/tests/test_bloom_basic.py
@@ -1,5 +1,5 @@
 import time
-from valkeytestframework.util.waiters import *
+from valkeytestframework.util.waiters import wait_for_equal
 from valkey import ResponseError
 from valkey_bloom_test_case import ValkeyBloomTestCaseBase
 from valkeytestframework.conftest import resource_port_tracker

--- a/tests/test_bloom_defrag.py
+++ b/tests/test_bloom_defrag.py
@@ -1,7 +1,7 @@
 import time
 from valkey_bloom_test_case import ValkeyBloomTestCaseBase
 from valkeytestframework.conftest import resource_port_tracker
-from valkeytestframework.util.waiters import *
+from valkeytestframework.util.waiters import wait_for_equal
 import pytest
 
 @pytest.mark.skip_for_asan(reason="These tests are skipped due to not being able to set activedefrag to yes when valkey server is an ASAN build")

--- a/tests/test_bloom_metrics.py
+++ b/tests/test_bloom_metrics.py
@@ -1,7 +1,7 @@
 import time
 from valkey_bloom_test_case import ValkeyBloomTestCaseBase
 from valkeytestframework.conftest import resource_port_tracker
-from valkeytestframework.util.waiters import *
+from valkeytestframework.util.waiters import wait_for_equal
 
 DEFAULT_BLOOM_FILTER_SIZE = 384
 DEFAULT_BLOOM_FILTER_CAPACITY = 100

--- a/tests/test_bloom_save_and_restore.py
+++ b/tests/test_bloom_save_and_restore.py
@@ -3,7 +3,7 @@ from valkey import ResponseError
 from valkey_bloom_test_case import ValkeyBloomTestCaseBase
 from valkey_test_case import ValkeyServerHandle
 from valkeytestframework.conftest import resource_port_tracker
-from valkeytestframework.util.waiters import *
+from valkeytestframework.util.waiters import wait_for_equal
 
 class TestBloomSaveRestore(ValkeyBloomTestCaseBase):
 

--- a/tests/test_topk_acl_category.py
+++ b/tests/test_topk_acl_category.py
@@ -1,6 +1,6 @@
 from valkeytestframework.conftest import resource_port_tracker
 from valkey_bloom_test_case import SkipSeedParameterizationMixin, ValkeyBloomTestCaseBase
-from valkeytestframework.util.waiters import *
+from valkeytestframework.util.waiters import wait_for_equal
 
 class TestTopkACLCategory(SkipSeedParameterizationMixin, ValkeyBloomTestCaseBase):
 

--- a/tests/test_topk_aofrewrite.py
+++ b/tests/test_topk_aofrewrite.py
@@ -1,4 +1,3 @@
-import time
 from valkeytestframework.util.waiters import wait_for_equal
 from valkeytestframework.valkey_test_case import ValkeyAction
 from valkey_bloom_test_case import SkipSeedParameterizationMixin, ValkeyBloomTestCaseBase
@@ -32,8 +31,6 @@ class TestTopkAofRewrite(SkipSeedParameterizationMixin, ValkeyBloomTestCaseBase)
         # save aof, restart server
         client.bgrewriteaof()
         self.server.wait_for_action_done(ValkeyAction.AOF_REWRITE)
-        # Keep the server running for 1 second more to have a larger uptime.
-        time.sleep(1)
         # Add appendonly to server args so it loads AOF on restart
         self.server.args['appendonly'] = 'yes'
         self.server.restart(remove_rdb=False, remove_nodes_conf=False, connect_client=True)

--- a/tests/test_topk_aofrewrite.py
+++ b/tests/test_topk_aofrewrite.py
@@ -1,0 +1,93 @@
+from valkeytestframework.util.waiters import *
+from valkeytestframework.valkey_test_case import ValkeyAction
+from valkey_bloom_test_case import SkipSeedParameterizationMixin, ValkeyBloomTestCaseBase
+from valkeytestframework.conftest import resource_port_tracker  # noqa: F401
+
+class TestTopkAofRewrite(SkipSeedParameterizationMixin, ValkeyBloomTestCaseBase):
+
+    def test_basic_aofrewrite_and_restore(self):
+        client = self.server.get_new_client()
+        # Disable the RDB preamble so the rewrite emits TOPK.LOAD commands.
+        client.config_set('aof-use-rdb-preamble', 'no')
+        # Enable AOF before adding data
+        client.config_set('appendonly', 'yes')
+        # Wait for any initial AOF rewrite to complete
+        wait_for_equal(lambda: client.info('persistence')['aof_rewrite_in_progress'], 0, timeout=30)
+
+        assert client.execute_command('TOPK.RESERVE testSave 5 50 4 0.9 SEED 42') == b'OK'
+        # Fill past k (5) so an item is evicted, exercising the priority queue.
+        client.execute_command('TOPK.ADD testSave apple banana cherry date elderberry fig')
+        client.execute_command('TOPK.INCRBY testSave apple 5 banana 3')
+        info_before = client.execute_command('TOPK.INFO testSave')
+        list_before = client.execute_command('TOPK.LIST testSave WITHCOUNT')
+        assert len(info_before) != 0
+        item_count_before = self.server.num_keys(client=client)
+
+        # cmd debug digest
+        server_digest = client.execute_command('DEBUG', 'DIGEST')
+        assert server_digest != None or 0000000000000000000000000000000000000000
+        object_digest = client.execute_command('DEBUG DIGEST-VALUE testSave')
+
+        # save aof, restart server
+        client.bgrewriteaof()
+        self.server.wait_for_action_done(ValkeyAction.AOF_REWRITE)
+        # Keep the server running for 1 second more to have a larger uptime.
+        time.sleep(1)
+        # Add appendonly to server args so it loads AOF on restart
+        self.server.args['appendonly'] = 'yes'
+        self.server.restart(remove_rdb=False, remove_nodes_conf=False, connect_client=True)
+        assert self.server.is_alive()
+
+        restored_server_digest = client.execute_command('DEBUG', 'DIGEST')
+        restored_object_digest = client.execute_command('DEBUG DIGEST-VALUE testSave')
+        assert restored_server_digest == server_digest
+        assert restored_object_digest == object_digest
+
+        # verify restore results
+        item_count_after = self.server.num_keys(client=client)
+        assert item_count_after == item_count_before
+        assert client.execute_command('TOPK.INFO testSave') == info_before
+        assert client.execute_command('TOPK.LIST testSave WITHCOUNT') == list_before
+        client.execute_command('DEL testSave')
+
+    def test_aofrewrite_topk_metrics(self):
+        # Disable the RDB preamble so the rewrite emits TOPK.LOAD commands.
+        self.client.config_set('aof-use-rdb-preamble', 'no')
+        # Enable AOF before adding data
+        self.client.config_set('appendonly', 'yes')
+        # Wait for any initial AOF rewrite to complete
+        wait_for_equal(lambda: self.client.info('persistence')['aof_rewrite_in_progress'], 0, timeout=30)
+
+        # Create a TopK (k=5) and apply ADD (+3) and INCRBY (+9) -> 12 items.
+        assert self.client.execute_command('TOPK.RESERVE key1 5 50 4 0.9 SEED 42') == b'OK'
+        self.client.execute_command('TOPK.ADD key1 apple banana cherry')
+        self.client.execute_command('TOPK.INCRBY key1 apple 5 banana 4')
+        key_size = self.client.execute_command('TOPK.INFO key1')[9]
+        self.verify_topk_metrics(self.client.execute_command("INFO bf"), key_size, 1, 12, 5)
+
+        # cmd debug digest
+        server_digest = self.client.execute_command('DEBUG', 'DIGEST')
+        assert server_digest != None or 0000000000000000000000000000000000000000
+        object_digest = self.client.execute_command('DEBUG DIGEST-VALUE key1')
+
+        # save aof, restart server
+        self.client.bgrewriteaof()
+        self.server.wait_for_action_done(ValkeyAction.AOF_REWRITE)
+        # Add appendonly to server args so it loads AOF on restart
+        self.server.args['appendonly'] = 'yes'
+        self.server.restart(remove_rdb=False, remove_nodes_conf=False, connect_client=True)
+        assert self.server.is_alive()
+
+        restored_server_digest = self.client.execute_command('DEBUG', 'DIGEST')
+        restored_object_digest = self.client.execute_command('DEBUG DIGEST-VALUE key1')
+        assert restored_server_digest == server_digest
+        assert restored_object_digest == object_digest
+
+        # Metrics for the restored object match what they were before the rewrite.
+        restored_key_size = self.client.execute_command('TOPK.INFO key1')[9]
+        assert restored_key_size == key_size
+        self.verify_topk_metrics(self.client.execute_command("INFO bf"), key_size, 1, 12, 5)
+
+        # Deleting the key returns all gauges to 0.
+        assert self.client.execute_command('DEL key1') == 1
+        self.verify_topk_metrics(self.client.execute_command("INFO bf"), 0, 0, 0, 0)

--- a/tests/test_topk_aofrewrite.py
+++ b/tests/test_topk_aofrewrite.py
@@ -1,4 +1,5 @@
-from valkeytestframework.util.waiters import *
+import time
+from valkeytestframework.util.waiters import wait_for_equal
 from valkeytestframework.valkey_test_case import ValkeyAction
 from valkey_bloom_test_case import SkipSeedParameterizationMixin, ValkeyBloomTestCaseBase
 from valkeytestframework.conftest import resource_port_tracker  # noqa: F401

--- a/tests/test_topk_basic.py
+++ b/tests/test_topk_basic.py
@@ -1,5 +1,5 @@
 import time
-from valkeytestframework.util.waiters import *
+from valkeytestframework.util.waiters import wait_for_equal
 from valkey import ResponseError
 from valkeytestframework.conftest import resource_port_tracker  # noqa: F401
 from valkey_bloom_test_case import SkipSeedParameterizationMixin, ValkeyBloomTestCaseBase

--- a/tests/test_topk_command.py
+++ b/tests/test_topk_command.py
@@ -17,7 +17,6 @@ class TestTopkCommand(SkipSeedParameterizationMixin, ValkeyBloomTestCaseBase):
         assert self.client.execute_command('TOPK.RESERVE dup 5') == b'OK'
         assert self.client.execute_command('SET strkey hello') == b'OK'
         basic_error_test_cases = [
-            # ---- TOPK.RESERVE ----
             # re-reserving an existing key: params are immutable.
             ('TOPK.RESERVE dup 5', 'BUSYKEY Target key name already exists.'),
             # wrong type
@@ -106,6 +105,15 @@ class TestTopkCommand(SkipSeedParameterizationMixin, ValkeyBloomTestCaseBase):
             # wrong number of arguments: needs key plus at least one item.
             ('TOPK.QUERY', "wrong number of arguments for 'TOPK.QUERY' command"),
             ('TOPK.QUERY dup', "wrong number of arguments for 'TOPK.QUERY' command"),
+            # loading over an existing key is rejected before decode.
+            ('TOPK.LOAD dup blob', 'BUSYKEY Target key name already exists.'),
+            ('TOPK.LOAD strkey blob', 'WRONGTYPE Operation against a key holding the wrong kind of value'),
+            # a blob that is not valid TopK serialization is rejected.
+            ('TOPK.LOAD newkey garbage', 'topk object decoding failed'),
+            # wrong number of arguments.
+            ('TOPK.LOAD', "wrong number of arguments for 'TOPK.LOAD' command"),
+            ('TOPK.LOAD key', "wrong number of arguments for 'TOPK.LOAD' command"),
+            ('TOPK.LOAD key blob extra', "wrong number of arguments for 'TOPK.LOAD' command"),
         ]
         for cmd, expected_err_reply in basic_error_test_cases:
             self.verify_error_response(self.client, cmd, expected_err_reply)

--- a/tests/test_topk_defrag.py
+++ b/tests/test_topk_defrag.py
@@ -1,7 +1,7 @@
 import time
 from valkey_bloom_test_case import SkipSeedParameterizationMixin, ValkeyBloomTestCaseBase
 from valkeytestframework.conftest import resource_port_tracker
-from valkeytestframework.util.waiters import *
+from valkeytestframework.util.waiters import wait_for_equal
 import pytest
 
 @pytest.mark.skip_for_asan(reason="These tests are skipped due to not being able to set activedefrag to yes when valkey server is an ASAN build")

--- a/tests/test_topk_metrics.py
+++ b/tests/test_topk_metrics.py
@@ -1,6 +1,6 @@
 from valkey_bloom_test_case import SkipSeedParameterizationMixin, ValkeyBloomTestCaseBase
 from valkeytestframework.conftest import resource_port_tracker  # noqa: F401
-from valkeytestframework.util.waiters import *
+from valkeytestframework.util.waiters import wait_for_equal
 
 class TestTopkMetrics(SkipSeedParameterizationMixin, ValkeyBloomTestCaseBase):
 

--- a/tests/test_topk_save_and_restore.py
+++ b/tests/test_topk_save_and_restore.py
@@ -1,7 +1,7 @@
 from valkey import ResponseError
 from valkey_bloom_test_case import SkipSeedParameterizationMixin, ValkeyBloomTestCaseBase
 from valkeytestframework.conftest import resource_port_tracker  # noqa: F401
-from valkeytestframework.util.waiters import *
+from valkeytestframework.util.waiters import wait_for_equal
 
 class TestTopkSaveRestore(SkipSeedParameterizationMixin, ValkeyBloomTestCaseBase):
 


### PR DESCRIPTION
## Summary

Adds AOF rewrite support for the TopK data type. During an AOF rewrite, each TopK object is serialized into a single `TOPK.LOAD <key> <blob>` command; replaying that command on AOF load reconstructs a byte-identical sketch. 

Because a TopK sketch's `DEBUG DIGEST-VALUE` is computed over the exact serialized bytes (`sketch.to_bytes()`, which includes RNG state and cuckoo layout), replaying `TOPK.RESERVE` + `TOPK.ADD` cannot reproduce it. The rewrite therefore carries the full serialized blob rather than replaying the mutating commands.


## Changes

### Shared encode/decode
- Extract `TopKObject::{encode_object, decode_object, from_serialized_bytes}`, factoring the seed/num_items/sketch (de)serialization and parameter validation out of the RDB load path so both the RDB and the AOF/`TOPK.LOAD` paths share one implementation.
- The object blob is `[TOPK_OBJECT_VERSION | seed | num_items | sketch bytes]`. No on-disk RDB format change.

### AOF rewrite callback
- Wire up the `aof_rewrite` type callback.
- `topk_aof_rewrite` serializes the object via `encode_object` and emits a single `TOPK.LOAD` command.

### TOPK.LOAD command
- Add `TOPK.LOAD <key> <blob>`, which reconstructs a TopK object via `decode_object`. It rejects if the key already exists and skips the per-object memory-limit check for primary/AOF clients, since an already-persisted object must load.
- Replicates verbatim: the blob already carries the full sketch state, so the command cannot be decomposed into `TOPK.RESERVE` replay. Publishes the `topk.reserve` keyspace event on the replica since it creates the object. Registered as a public command with an internal-use intent.

### Tests
- `test_topk_aofrewrite.py`: both tests disable `aof-use-rdb-preamble` so the rewrite actually emits `TOPK.LOAD`. With the default preamble the AOF base file is written in RDB format and persistence goes through `rdb_save`/`rdb_load`, so the new path would not be covered. Adds a basic `bgrewriteaof` + restart digest round-trip, and a metrics test asserting the `INFO bf` gauges survive the rewrite and reset to zero on `DEL`.
- Unit tests for the encode/decode round trip and the truncated, unsupported-version, and wrong-seed rejection paths.
- `test_bloom_aofrewrite.py`: the existing bloom AOF tests ran with the default preamble, so they went through the RDB path and never exercised `bloom_aof_rewrite` / `BF.LOAD`. Disable the preamble there too so they cover the intended command path.