### PR TITLE
Add TopK valkey-py compatibility test

### DIFF
--- a/src/topk/command_handler.rs
+++ b/src/topk/command_handler.rs
@@ -339,17 +339,17 @@ pub fn topk_info(ctx: &Context, input_args: &[ValkeyString]) -> ValkeyResult {
     }
 
     let result = vec![
-        ValkeyValue::SimpleStringStatic("K"),
+        ValkeyValue::SimpleStringStatic("k"),
         ValkeyValue::Integer(topk.k() as i64),
-        ValkeyValue::SimpleStringStatic("Width"),
+        ValkeyValue::SimpleStringStatic("width"),
         ValkeyValue::Integer(topk.width() as i64),
-        ValkeyValue::SimpleStringStatic("Depth"),
+        ValkeyValue::SimpleStringStatic("depth"),
         ValkeyValue::Integer(topk.depth() as i64),
-        ValkeyValue::SimpleStringStatic("Decay"),
+        ValkeyValue::SimpleStringStatic("decay"),
         ValkeyValue::Float(topk.decay()),
-        ValkeyValue::SimpleStringStatic("Size"),
+        ValkeyValue::SimpleStringStatic("size"),
         ValkeyValue::Integer(topk.memory_usage() as i64),
-        ValkeyValue::SimpleStringStatic("Total items added"),
+        ValkeyValue::SimpleStringStatic("total items added"),
         ValkeyValue::Integer(topk.num_items() as i64),
     ];
     Ok(ValkeyValue::Array(result))

--- a/tests/test_topk_basic.py
+++ b/tests/test_topk_basic.py
@@ -213,7 +213,7 @@ class TestTopkBasic(SkipSeedParameterizationMixin, ValkeyBloomTestCaseBase):
         assert self.client.execute_command('TOPK.RESERVE tk 5 50 4 0.9 SEED 42') == b'OK'
         self.client.execute_command('TOPK.ADD tk apple banana cherry')
         info = self.client.execute_command('TOPK.INFO tk')
-        info_size = dict(zip(info[::2], info[1::2]))[b'Size']
+        info_size = dict(zip(info[::2], info[1::2]))[b'size']
         assert self.client.execute_command('MEMORY USAGE tk') >= info_size and info_size > 0
 
     def test_too_large_topk_obj(self):

--- a/tests/test_topk_command.py
+++ b/tests/test_topk_command.py
@@ -175,31 +175,31 @@ class TestTopkCommand(SkipSeedParameterizationMixin, ValkeyBloomTestCaseBase):
             it = iter(raw)
             return dict(zip(it, it))
         info = info_dict('tk1')
-        assert info[b'K'] == 5
-        assert info[b'Width'] == 8
-        assert info[b'Depth'] == 7
-        assert info[b'Decay'] == b'0.9'
-        assert info[b'Size'] > 0
+        assert info[b'k'] == 5
+        assert info[b'width'] == 8
+        assert info[b'depth'] == 7
+        assert info[b'decay'] == b'0.9'
+        assert info[b'size'] > 0
         # tk1 was re-reserved with no items, so nothing has been added yet.
-        assert info[b'Total items added'] == 0
+        assert info[b'total items added'] == 0
 
         info = info_dict('tk5')
-        assert info[b'K'] == 10
-        assert info[b'Width'] == 200
-        assert info[b'Depth'] == 5
-        assert info[b'Decay'] == b'0.5'
-        assert info[b'Size'] > 0
-        assert info[b'Total items added'] == 0
+        assert info[b'k'] == 10
+        assert info[b'width'] == 200
+        assert info[b'depth'] == 5
+        assert info[b'decay'] == b'0.5'
+        assert info[b'size'] > 0
+        assert info[b'total items added'] == 0
 
         info = info_dict('tk_incr')
-        assert info[b'Total items added'] == tk_incr_total
+        assert info[b'total items added'] == tk_incr_total
 
         # TOPK.INFO key <field> returns just that single value.
         assert self.client.execute_command('TOPK.INFO tk5 K') == 10
         assert self.client.execute_command('TOPK.INFO tk5 WIDTH') == 200
         assert self.client.execute_command('TOPK.INFO tk5 depth') == 5
         assert self.client.execute_command('TOPK.INFO tk5 DECAY') == b'0.5'
-        assert self.client.execute_command('TOPK.INFO tk5 SIZE') == info_dict('tk5')[b'Size']
+        assert self.client.execute_command('TOPK.INFO tk5 SIZE') == info_dict('tk5')[b'size']
         assert self.client.execute_command('TOPK.INFO tk_incr TOTALITEMSADDED') == tk_incr_total
 
         # TOPK.LIST returns tracked items by descending count, at most k.

--- a/tests/test_topk_valkeypy_compatibility.py
+++ b/tests/test_topk_valkeypy_compatibility.py
@@ -1,0 +1,71 @@
+import pytest
+from valkey_bloom_test_case import SkipSeedParameterizationMixin, ValkeyBloomTestCaseBase
+from valkeytestframework.conftest import resource_port_tracker  # noqa: F401
+
+class TestValkeyTopKCompatibility(SkipSeedParameterizationMixin, ValkeyBloomTestCaseBase):
+    """
+        Tests TopK compatibility with valkey-py's high-level client API.
+        Adapted from https://github.com/valkey-io/valkey-py/blob/main/tests/test_bloom.py
+    """
+
+    def test_topk(self):
+        decoded_r = self.server.get_new_client()
+
+        assert decoded_r.topk().reserve("topk", 3, 50, 4, 0.9)
+        add_return = decoded_r.topk().add(
+            "topk",
+            "A", "B", "C", "D", "E", "A", "A", "B", "C", "G",
+            "D", "B", "D", "A", "E", "E", 1,
+        )
+        assert 17 == len(add_return)
+        for entry in add_return:
+            assert entry is None or isinstance(entry, str)
+
+        query_return = decoded_r.topk().query("topk", "A", "B", "C", "D", "E", "F", "G")
+        assert 7 == len(query_return)
+        for entry in query_return:
+            assert entry in [0, 1]
+        assert 0 == query_return[5]  # F never added
+        assert 0 == query_return[6]  # G never added
+
+        with pytest.deprecated_call():
+            count_return = decoded_r.topk().count("topk", "A", "B", "C", "D", "E", "F", "G")
+        assert 7 == len(count_return)
+        assert 0 == count_return[5]  # F never added
+
+        # test full list
+        assert decoded_r.topk().reserve("topklist", 3, 50, 3, 0.9)
+        decoded_r.topk().add(
+            "topklist",
+            "A", "B", "C", "D", "E", "A", "A", "B", "C", "G",
+            "D", "B", "D", "A", "E", "E",
+        )
+        listed = decoded_r.topk().list("topklist")
+        assert len(listed) <= 3
+        assert "A" in listed
+
+        listed_wc = decoded_r.topk().list("topklist", withcount=True)
+        assert len(listed_wc) == 2 * len(listed)
+
+        info = decoded_r.topk().info("topklist")
+        assert 3 == info["k"]
+        assert 50 == info["width"]
+        assert 3 == info["depth"]
+        assert 0.9 == round(float(info["decay"]), 1)
+
+    def test_topk_incrby(self):
+        decoded_r = self.server.get_new_client()
+        assert decoded_r.topk().reserve("topk", 3, 10, 3, 0.9)
+        incr_return = decoded_r.topk().incrby("topk", ["bar", "baz", "42"], [3, 6, 2])
+        assert 3 == len(incr_return)
+        for entry in incr_return:
+            assert entry is None or isinstance(entry, str)
+
+        incr_return = decoded_r.topk().incrby("topk", ["42", "xyzzy"], [8, 4])
+        assert 2 == len(incr_return)
+
+        with pytest.deprecated_call():
+            count_return = decoded_r.topk().count("topk", "bar", "baz", "42", "xyzzy", 4)
+        assert 5 == len(count_return)
+        assert 0 == count_return[4]   # "4" never added
+        assert 10 == count_return[2]  # "42" incremented by 2+8=10


### PR DESCRIPTION
## Summary

Fixes TOPK.INFO field-name casing to match the valkey-py client contract, and adds a valkey-py compatibility test for the TopK data type.

## Changes

### INFO field-name fix
- Lowercase the `TOPK.INFO` response labels from `K`/`Width`/`Depth`/`Decay`/`Size`/`Total items added` to `k`/`width`/`depth`/`decay`/`size`/`total items added`.
- The single-field selector tokens (`TOPK.INFO key K`) remain case-insensitive, so existing callers are unaffected.
- Update assertions in `test_topk_command.py` and `test_topk_basic.py`.

### Compatibility test
- Add `test_topk_valkeypy_compatibility.py` adapted from [valkey-py](https://github.com/valkey-io/valkey-py/blob/main/tests/test_bloom.py) (`test_topk` and `test_topk_incrby`), exercising all commands(`reserve`/`add`/`incrby`/`query`/`count`/`list`/`info`) through valkey-py's high-level client API.
- Assertions verify protocol-level compatibility (return types, lengths, field-name parsing).