### PR TITLE
CMS Feature: Add the INFO command 

### DIFF
--- a/src/cms/cms_command_handler.rs
+++ b/src/cms/cms_command_handler.rs
@@ -256,11 +256,11 @@ pub fn cms_info(ctx: &Context, args: Vec<ValkeyString>) -> ValkeyResult {
     match cms {
         Some(cms) => {
             let result = vec![
-                ValkeyValue::SimpleStringStatic("Width"),
+                ValkeyValue::SimpleStringStatic("width"),
                 ValkeyValue::Integer(cms.width as i64),
-                ValkeyValue::SimpleStringStatic("Depth"),
+                ValkeyValue::SimpleStringStatic("depth"),
                 ValkeyValue::Integer(cms.depth as i64),
-                ValkeyValue::SimpleStringStatic("Count"),
+                ValkeyValue::SimpleStringStatic("count"),
                 ValkeyValue::Integer(cms.total() as i64),
             ];
             Ok(ValkeyValue::Array(result))

--- a/src/cms/cms_command_handler.rs
+++ b/src/cms/cms_command_handler.rs
@@ -242,7 +242,8 @@ pub fn cms_query(ctx: &Context, args: Vec<ValkeyString>) -> ValkeyResult {
 //Function that implements logic to handle the CMS.INFO command.
 pub fn cms_info(ctx: &Context, args: Vec<ValkeyString>) -> ValkeyResult {
     let args_count = args.len();
-    if args_count != 2 {
+
+    if !(2..=3).contains(&args_count) {
         return Err(valkey_module::ValkeyError::WrongArity);
     }
 
@@ -254,7 +255,7 @@ pub fn cms_info(ctx: &Context, args: Vec<ValkeyString>) -> ValkeyResult {
     };
 
     match cms {
-        Some(cms) => {
+        Some(cms) if args_count == 2 => {
             let result = vec![
                 ValkeyValue::SimpleStringStatic("width"),
                 ValkeyValue::Integer(cms.width as i64),
@@ -265,6 +266,13 @@ pub fn cms_info(ctx: &Context, args: Vec<ValkeyString>) -> ValkeyResult {
             ];
             Ok(ValkeyValue::Array(result))
         }
-        None => Err(ValkeyError::Str(utils::NOT_FOUND)),
+
+        Some(cms) if args_count == 3 => match args[2].to_string_lossy().to_uppercase().as_str() {
+            "WIDTH" => Ok(ValkeyValue::Integer(cms.width as i64)),
+            "DEPTH" => Ok(ValkeyValue::Integer(cms.depth as i64)),
+            "COUNT" => Ok(ValkeyValue::Integer(cms.total() as i64)),
+            _ => Err(ValkeyError::Str(utils::INVALID_INFO_VALUE)),
+        },
+        _ => Err(ValkeyError::Str(utils::NOT_FOUND)),
     }
 }

--- a/src/cms/cms_command_handler.rs
+++ b/src/cms/cms_command_handler.rs
@@ -238,3 +238,33 @@ pub fn cms_query(ctx: &Context, args: Vec<ValkeyString>) -> ValkeyResult {
         }
     }
 }
+
+//Function that implements logic to handle the CMS.INFO command.
+pub fn cms_info(ctx: &Context, args: Vec<ValkeyString>) -> ValkeyResult {
+    let args_count = args.len();
+    if args_count != 2 {
+        return Err(valkey_module::ValkeyError::WrongArity);
+    }
+
+    let key = &args[1];
+    let key_existing = ctx.open_key(key);
+    let cms = match key_existing.get_value::<CMSObject>(&CMS_TYPE) {
+        Ok(v) => v,
+        Err(_) => return Err(ValkeyError::WrongType),
+    };
+
+    match cms {
+        Some(cms) => {
+            let result = vec![
+                ValkeyValue::SimpleStringStatic("Width"),
+                ValkeyValue::Integer(cms.width as i64),
+                ValkeyValue::SimpleStringStatic("Depth"),
+                ValkeyValue::Integer(cms.depth as i64),
+                ValkeyValue::SimpleStringStatic("Count"),
+                ValkeyValue::Integer(cms.total() as i64),
+            ];
+            Ok(ValkeyValue::Array(result))
+        }
+        None => Err(ValkeyError::Str(utils::NOT_FOUND)),
+    }
+}

--- a/src/cms/utils.rs
+++ b/src/cms/utils.rs
@@ -38,8 +38,8 @@ impl CMSError {
 }
 
 pub struct CMSObject {
-    width: u64,
-    depth: u64,
+    pub width: u64,
+    pub depth: u64,
     cms: CMS,
 }
 
@@ -81,14 +81,6 @@ impl CMSObject {
         };
 
         Ok(obj)
-    }
-
-    pub fn width(&self) -> u64 {
-        self.width
-    }
-
-    pub fn depth(&self) -> u64 {
-        self.depth
     }
 
     pub fn total(&self) -> u64 {

--- a/src/cms/utils.rs
+++ b/src/cms/utils.rs
@@ -12,6 +12,7 @@ pub const BAD_PROBABILITY: &str = "ERR bad probability";
 pub const PROBABILITY_RANGE: &str = "ERR probability rate should be between 0 and 1";
 pub const KEY_EXISTS: &str = "ERR Target key name already exists.";
 pub const BAD_INCREMENT: &str = "ERR bad increment";
+pub const INVALID_INFO_VALUE: &str = "ERR invalid information value";
 
 ///Keyspace Notification Events
 pub const INITBYPROB_EVENT: &str = "countminsketch.initbyprob";

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -114,6 +114,11 @@ fn cms_query_command(ctx: &Context, args: Vec<ValkeyString>) -> ValkeyResult {
     cms_command_handler::cms_query(ctx, args)
 }
 
+/// Command handler for CMS.INFO <key>
+fn cms_info_command(ctx: &Context, args: Vec<ValkeyString>) -> ValkeyResult {
+    cms_command_handler::cms_info(ctx, args)
+}
+
 ///
 /// Module Info
 ///
@@ -152,6 +157,7 @@ valkey_module! {
         ["CMS.INITBYPROB", cms_initbyprob_command, "write fast deny-oom", 1, 1, 1, "fast write cms"],
         ["CMS.INCRBY", cms_incrby_command, "write fast deny-oom", 1, 1, 1, "write cms"],
         ["CMS.QUERY", cms_query_command, "readonly fast", 1, 1, 1, "read cms"],
+        ["CMS.INFO", cms_info_command, "readonly fast", 1, 1, 1, "fast read cms"],
     ],
     configurations: [
         i64: [

--- a/tests/test_cms_basic.py
+++ b/tests/test_cms_basic.py
@@ -21,7 +21,7 @@ class TestCMSBasic(ValkeyBloomTestCaseBase):
         assert(module_loaded)
         # Validate that all the CMS.* commands are supported on the server.
         command_cmd_result = client.execute_command('COMMAND')
-        cms_cmds = ["CMS.INITBYDIM", "CMS.INITBYPROB", "CMS.INCRBY", "CMS.QUERY"]
+        cms_cmds = ["CMS.INITBYDIM", "CMS.INITBYPROB", "CMS.INCRBY", "CMS.QUERY", "CMS.INFO"]
         assert all(item in command_cmd_result for item in cms_cmds)
         #Create CMS by Dimensions, add item, estimate the item, increment, estimate
         assert client.execute_command('CMS.INITBYDIM sketch1 10 5') == b'OK'
@@ -30,6 +30,10 @@ class TestCMSBasic(ValkeyBloomTestCaseBase):
 
         #CMS guarantees that we have the frequency at LEAST the size of the increment for the item
         assert client.execute_command('CMS.QUERY sketch1 item1')[0] >= 1
+
+        #Check Info piece setup
+        assert client.execute_command('CMS.INFO sketch1') == [b'width', 10, b'depth', 5, b'count', 2]
+        
 
 
 
@@ -44,7 +48,7 @@ class TestCMSBasic(ValkeyBloomTestCaseBase):
         assert(module_loaded)
         # Validate that all the CMS.* commands are supported on the server.
         command_cmd_result = client.execute_command('COMMAND')
-        cms_cmds = ["CMS.INITBYDIM", "CMS.INITBYPROB", "CMS.INCRBY", "CMS.QUERY"]
+        cms_cmds = ["CMS.INITBYDIM", "CMS.INITBYPROB", "CMS.INCRBY", "CMS.QUERY", "CMS.INFO"]
         assert all(item in command_cmd_result for item in cms_cmds)
         #Create CMS by Dimensions, add item, estimate the item, increment, estimate
         assert client.execute_command('CMS.INITBYPROB sketch1 0.001 0.01') == b'OK'

--- a/tests/test_cms_basic.py
+++ b/tests/test_cms_basic.py
@@ -33,7 +33,9 @@ class TestCMSBasic(ValkeyBloomTestCaseBase):
 
         #Check Info piece setup
         assert client.execute_command('CMS.INFO sketch1') == [b'width', 10, b'depth', 5, b'count', 2]
-        
+        assert client.execute_command('CMS.INFO sketch1 WIDTH') == [10]
+        assert client.execute_command('CMS.INFO sketch1 DEPTH') == [5]
+        assert client.execute_command('CMS.INFO sketch1 COUNT') == [2]
 
 
 

--- a/tests/test_cms_basic.py
+++ b/tests/test_cms_basic.py
@@ -33,11 +33,9 @@ class TestCMSBasic(ValkeyBloomTestCaseBase):
 
         #Check Info piece setup
         assert client.execute_command('CMS.INFO sketch1') == [b'width', 10, b'depth', 5, b'count', 2]
-        assert client.execute_command('CMS.INFO sketch1 WIDTH') == [10]
-        assert client.execute_command('CMS.INFO sketch1 DEPTH') == [5]
-        assert client.execute_command('CMS.INFO sketch1 COUNT') == [2]
-
-
+        assert client.execute_command('CMS.INFO sketch1 WIDTH') == 10
+        assert client.execute_command('CMS.INFO sketch1 DEPTH') == 5
+        assert client.execute_command('CMS.INFO sketch1 COUNT') == 2
 
     def test_basic_prob(self):
         client = self.server.get_new_client()

--- a/tests/test_cms_command.py
+++ b/tests/test_cms_command.py
@@ -51,8 +51,10 @@ class TestCMSCommand(ValkeyBloomTestCaseBase):
             ('CMS.QUERY', "wrong number of arguments for 'CMS.QUERY' command"),
             ('CMS.QUERY key', "wrong number of arguments for 'CMS.QUERY' command"),
             ('CMS.INFO', "wrong number of arguments for 'CMS.INFO' command"),
-            ('CMS.INFO key WIDTH WIDTH', "wrong number of arguments for 'CMS.INFO' command"),
-            ('CMS.INFO key NOTAPARAM', "invalid information value for 'CMS.INFO' command"),
+            ('CMS.INFO sketch WIDTH WIDTH', "wrong number of arguments for 'CMS.INFO' command"),
+
+            # Invalid parameter name (WIDTH, DEPTH, COUNT)
+            ('CMS.INFO sketch NOTAPARAM', "invalid information value for 'CMS.INFO' command"),
 
 
 

--- a/tests/test_cms_command.py
+++ b/tests/test_cms_command.py
@@ -50,6 +50,12 @@ class TestCMSCommand(ValkeyBloomTestCaseBase):
 
             ('CMS.QUERY', "wrong number of arguments for 'CMS.QUERY' command"),
             ('CMS.QUERY key', "wrong number of arguments for 'CMS.QUERY' command"),
+            ('CMS.INFO', "wrong number of arguments for 'CMS.INFO' command"),
+            ('CMS.INFO key WIDTH WIDTH', "wrong number of arguments for 'CMS.INFO' command"),
+            ('CMS.INFO key NOTAPARAM', "invalid information value for 'CMS.INFO' command"),
+
+
+
          
         ]
 

--- a/tests/test_cms_command.py
+++ b/tests/test_cms_command.py
@@ -54,7 +54,7 @@ class TestCMSCommand(ValkeyBloomTestCaseBase):
             ('CMS.INFO sketch WIDTH WIDTH', "wrong number of arguments for 'CMS.INFO' command"),
 
             # Invalid parameter name (WIDTH, DEPTH, COUNT)
-            ('CMS.INFO sketch NOTAPARAM', "invalid information value for 'CMS.INFO' command"),
+            ('CMS.INFO sketch NOTAPARAM', "invalid information value"),
 
 
 


### PR DESCRIPTION
Branched from: https://github.com/valkey-io/valkey-bloom/pull/111 

This adds the INFO command to the list of supported commands for CMS.  