### PR TITLE
Unit tests using Context::test and ValkeyString::test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,13 +24,13 @@ jobs:
     - name: Run cargo and clippy format check
       run: |
         cargo fmt --check
-        cargo clippy --profile release --all-targets
+        cargo clippy --all-targets
     - name: Release Build
       run: |
         if [ "${{ matrix.server_version }}" = "8.0" ]; then
-          cargo build --all --all-targets --release --features valkey_8_0
+          cargo build --release --features valkey_8_0
         else
-          cargo build --all --all-targets --release
+          cargo build --release
         fi
     - name: Run unit tests
       run: cargo test --features enable-system-alloc
@@ -70,9 +70,9 @@ jobs:
     - name: Run cargo and clippy format check
       run: |
         cargo fmt --check
-        cargo clippy --profile release --all-targets
+        cargo clippy --all-targets
     - name: Release Build
-      run: cargo build --all --all-targets --release
+      run: cargo build --release
     - name: Run unit tests
       run: cargo test --features enable-system-alloc
 
@@ -89,13 +89,13 @@ jobs:
     - name: Run cargo and clippy format check
       run: |
         cargo fmt --check
-        cargo clippy --profile release --all-targets
+        cargo clippy --all-targets
     - name: Release Build
       run: |
         if [ "${{ matrix.server_version }}" = "8.0" ]; then
-          cargo build --all --all-targets --release --features valkey_8_0
+          cargo build --release --features valkey_8_0
         else
-          cargo build --all --all-targets --release
+          cargo build --release
         fi
     - name: Run unit tests
       run: cargo test --features enable-system-alloc

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ __pycache__
 test-data
 .attach_pid*
 src/commands/commands
+docs/*

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ homepage = "https://github.com/valkey-io/valkey-bloom"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-valkey-module = { version = "0.1.5", features = ["min-valkey-compatibility-version-8-0", "min-redis-compatibility-version-7-2"]}
+valkey-module = { version = "0.1.12", features = ["min-valkey-compatibility-version-8-0", "min-redis-compatibility-version-7-2"]}
 valkey-module-macros = "0"
 linkme = "0"
 bloomfilter = { version = "3.0.1", features = ["serde"] }
@@ -24,6 +24,7 @@ bincode = "1.3"
 [dev-dependencies]
 rand = "0.8"
 rstest = "0.23.0"
+valkey-module = { version = "0.1.12", features = ["min-valkey-compatibility-version-8-0", "min-redis-compatibility-version-7-2", "test-shims"]}
 
 [lib]
 crate-type = ["cdylib"]

--- a/build.sh
+++ b/build.sh
@@ -19,7 +19,7 @@ fi
 
 echo "Running cargo and clippy format checks..."
 cargo fmt --check
-cargo clippy --profile release --all-targets -- -D clippy::all
+cargo clippy --all-targets -- -D clippy::all
 
 
 echo "Running unit tests..."
@@ -38,9 +38,9 @@ fi
 
 echo "Running cargo build release..."
 if [ "$SERVER_VERSION" == "8.0" ] ; then
-    RUSTFLAGS="-D warnings" cargo build --all --all-targets  --release --features valkey_8_0
+    RUSTFLAGS="-D warnings" cargo build --release --features valkey_8_0
 else
-    RUSTFLAGS="-D warnings" cargo build --all --all-targets  --release
+    RUSTFLAGS="-D warnings" cargo build --release
 fi
 
 

--- a/src/bloom/command_handler.rs
+++ b/src/bloom/command_handler.rs
@@ -881,3 +881,175 @@ pub fn bloom_filter_load(ctx: &Context, input_args: &[ValkeyString]) -> ValkeyRe
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rstest::rstest;
+
+    #[test]
+    fn bloom_add_rejects_missing_item() {
+        let context = Context::test();
+
+        assert_error(
+            bloom_filter_add_value(&context, &test_args(&["BF.ADD", "filter"]), false),
+            "Wrong Arity",
+        );
+    }
+
+    #[test]
+    fn bloom_exists_rejects_missing_item() {
+        let context = Context::test();
+
+        assert_error(
+            bloom_filter_exists(&context, &test_args(&["BF.EXISTS", "filter"]), false),
+            "Wrong Arity",
+        );
+    }
+
+    #[test]
+    fn bloom_card_rejects_invalid_arity() {
+        let context = Context::test();
+
+        assert_error(
+            bloom_filter_card(&context, &test_args(&["BF.CARD"])),
+            "Wrong Arity",
+        );
+    }
+
+    #[rstest]
+    #[case::missing_item(&["BF.MADD", "filter"])]
+    #[case::too_many_arguments(&["BF.ADD", "filter", "item", "extra"])]
+    fn bloom_add_rejects_invalid_arity(#[case] args: &[&str]) {
+        let context = Context::test();
+
+        assert_error(
+            bloom_filter_add_value(&context, &test_args(args), args[0] == "BF.MADD"),
+            "Wrong Arity",
+        );
+    }
+
+    #[rstest]
+    #[case::missing_item(&["BF.MEXISTS", "filter"])]
+    #[case::too_many_arguments(&["BF.EXISTS", "filter", "item", "extra"])]
+    fn bloom_exists_rejects_invalid_arity(#[case] args: &[&str]) {
+        let context = Context::test();
+
+        assert_error(
+            bloom_filter_exists(&context, &test_args(args), args[0] == "BF.MEXISTS"),
+            "Wrong Arity",
+        );
+    }
+
+    #[rstest]
+    #[case::zero_error_rate(
+        &["BF.RESERVE", "filter", "0", "100"],
+        utils::ERROR_RATE_RANGE
+    )]
+    #[case::zero_capacity(
+        &["BF.RESERVE", "filter", "0.01", "0"],
+        utils::CAPACITY_LARGER_THAN_0
+    )]
+    #[case::invalid_expansion(
+        &["BF.RESERVE", "filter", "0.01", "100", "EXPANSION", "0"],
+        utils::BAD_EXPANSION
+    )]
+    #[case::invalid_option(
+        &["BF.RESERVE", "filter", "0.01", "100", "UNKNOWN"],
+        utils::ERROR
+    )]
+    #[case::non_numeric_error_rate(
+        &["BF.RESERVE", "filter", "invalid", "100"],
+        utils::BAD_ERROR_RATE
+    )]
+    #[case::negative_capacity(
+        &["BF.RESERVE", "filter", "0.01", "-1"],
+        utils::BAD_CAPACITY
+    )]
+    fn bloom_reserve_rejects_invalid_arguments(
+        #[case] args: &[&str],
+        #[case] expected_error: &str,
+    ) {
+        let context = Context::test();
+
+        assert_error(
+            bloom_filter_reserve(&context, &test_args(args)),
+            expected_error,
+        );
+    }
+
+    #[test]
+    fn bloom_insert_rejects_missing_key() {
+        let context = Context::test();
+
+        assert_error(
+            bloom_filter_insert(&context, &test_args(&["BF.INSERT"])),
+            "Wrong Arity",
+        );
+    }
+
+    #[rstest]
+    #[case::missing_key(&["BF.INFO"])]
+    #[case::too_many_arguments(&["BF.INFO", "filter", "CAPACITY", "extra"])]
+    fn bloom_info_rejects_invalid_arity(#[case] args: &[&str]) {
+        let context = Context::test();
+
+        assert_error(bloom_filter_info(&context, &test_args(args)), "Wrong Arity");
+    }
+
+    #[rstest]
+    #[case::missing_payload(&["BF.LOAD", "filter"])]
+    #[case::too_many_arguments(&["BF.LOAD", "filter", "payload", "extra"])]
+    fn bloom_load_rejects_invalid_arity(#[case] args: &[&str]) {
+        let context = Context::test();
+
+        assert_error(bloom_filter_load(&context, &test_args(args)), "Wrong Arity");
+    }
+
+    #[rstest]
+    #[case::missing_option_value(&["BF.INSERT", "filter", "ERROR"], "Wrong Arity")]
+    #[case::invalid_seed_length(
+        &["BF.INSERT", "filter", "SEED", "too-short"],
+        utils::INVALID_SEED
+    )]
+    #[case::unknown_argument(
+        &["BF.INSERT", "filter", "UNKNOWN"],
+        utils::UNKNOWN_ARGUMENT
+    )]
+    #[case::items_without_item(&["BF.INSERT", "filter", "ITEMS"], "Wrong Arity")]
+    #[case::zero_error_rate(
+        &["BF.INSERT", "filter", "ERROR", "0"],
+        utils::ERROR_RATE_RANGE
+    )]
+    #[case::zero_capacity(
+        &["BF.INSERT", "filter", "CAPACITY", "0"],
+        utils::CAPACITY_LARGER_THAN_0
+    )]
+    #[case::invalid_expansion(
+        &["BF.INSERT", "filter", "EXPANSION", "0"],
+        utils::BAD_EXPANSION
+    )]
+    #[case::zero_validate_scale_to(
+        &["BF.INSERT", "filter", "VALIDATESCALETO", "0"],
+        utils::CAPACITY_LARGER_THAN_0
+    )]
+    fn bloom_insert_rejects_invalid_arguments(#[case] args: &[&str], #[case] expected_error: &str) {
+        let context = Context::test();
+
+        assert_error(
+            bloom_filter_insert(&context, &test_args(args)),
+            expected_error,
+        );
+    }
+
+    fn test_args(args: &[&str]) -> Vec<ValkeyString> {
+        args.iter().map(|arg| ValkeyString::test(*arg)).collect()
+    }
+
+    fn assert_error(result: ValkeyResult, expected: &str) {
+        match result {
+            Err(error) => assert_eq!(error.to_string(), expected),
+            Ok(value) => panic!("expected error {expected:?}, got {value:?}"),
+        }
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -143,3 +143,24 @@ valkey_module! {
         module_args_as_configuration: true,
     ]
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rstest::rstest;
+
+    #[rstest]
+    #[case::minimum_supported(8, 0, 0)]
+    #[case::newer_major(8, 1, 0)]
+    #[case::future_version(9, 0, 0)]
+    fn initialize_accepts_supported_server_versions(
+        #[case] major: u8,
+        #[case] minor: u8,
+        #[case] patch: u8,
+    ) {
+        let mut context = Context::test();
+        context.expect_get_server_version(major, minor, patch);
+
+        assert!(matches!(initialize(&context, &[]), Status::Ok));
+    }
+}


### PR DESCRIPTION
  - Upgrades `valkey-module` and enables its `test-shims` feature only for dev dependencies.
  - Adds table-driven validation/error-path tests for `BF.ADD`, `BF.MADD`, `BF.EXISTS`, `BF.MEXISTS`,  `BF.CARD`, `BF.RESERVE`, `BF.INSERT`, `BF.INFO`, and `BF.LOAD`.
  - Adds `initialize()` coverage for the minimum supported Valkey version and newer/future supported versions using `Context::test().expect_get_server_version(...)`.

I know there are already integ tests in the repo.  Recently we added ability to the valkeymodule-rs to create Contest::test and ValkeyString::test.  This allows to test code more granularly. 